### PR TITLE
FAI-756: Optimize test suite for faster builds

### DIFF
--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/score/DefaultCounterfactualScoreCalculator.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/score/DefaultCounterfactualScoreCalculator.java
@@ -157,7 +157,6 @@ public class DefaultCounterfactualScoreCalculator implements CounterfactualScore
     }
 
     private BendableBigDecimalScore calculateInputScore(CounterfactualSolution solution) {
-        StringBuilder builder = new StringBuilder();
         int secondarySoftScore = 0;
         int secondaryHardScore = 0;
 
@@ -167,8 +166,6 @@ public class DefaultCounterfactualScoreCalculator implements CounterfactualScore
         for (CounterfactualEntity entity : solution.getEntities()) {
             final double entitySimilarity = entity.similarity();
             inputSimilarities += entitySimilarity / numberOfEntities;
-            final Feature f = entity.asFeature();
-            builder.append(String.format("%s=%s (d:%f)", f.getName(), f.getValue().getUnderlyingObject(), entitySimilarity));
 
             if (entity.isChanged()) {
                 secondarySoftScore -= 1;
@@ -179,12 +176,8 @@ public class DefaultCounterfactualScoreCalculator implements CounterfactualScore
             }
         }
 
-        logger.debug("Current solution: {}", builder);
-
         // Calculate Gower distance from the similarities
         final double primarySoftScore = -Math.sqrt(Math.abs(1.0 - inputSimilarities));
-        logger.debug("Changed constraints penalty: {}", secondaryHardScore);
-        logger.debug("Feature distance: {}", -Math.abs(primarySoftScore));
 
         return BendableBigDecimalScore.of(new BigDecimal[] {
                 BigDecimal.ZERO,
@@ -223,9 +216,6 @@ public class DefaultCounterfactualScoreCalculator implements CounterfactualScore
                 }
             }
             primaryHardScore -= Math.sqrt(outputDistance);
-            logger.debug("Distance penalty: {}", primaryHardScore);
-
-            logger.debug("Confidence threshold penalty: {}", tertiaryHardScore);
         }
         return BendableBigDecimalScore.of(
                 new BigDecimal[] {

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/model/Value.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/model/Value.java
@@ -60,7 +60,11 @@ public class Value {
     public double asNumber() {
         if (underlyingObject != null) {
             try {
-                if (underlyingObject instanceof Boolean) {
+                if (underlyingObject instanceof Double) {
+                    return (double) underlyingObject;
+                } else if (underlyingObject instanceof Number) {
+                    return ((Number) underlyingObject).doubleValue();
+                } else if (underlyingObject instanceof Boolean) {
                     return (boolean) underlyingObject ? 1d : 0d;
                 } else {
                     return Double.parseDouble(asString());

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/TestUtils.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/TestUtils.java
@@ -17,10 +17,11 @@ package org.kie.trustyai.explainability;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
-import java.util.Random;
+import java.util.SplittableRandom;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.kie.trustyai.explainability.local.lime.LimeExplainer;
@@ -75,14 +76,15 @@ public class TestUtils {
         });
     }
 
-    public static PredictionProvider getNoisySumModel(Random rn, double noiseMagnitude) {
+    public static PredictionProvider getNoisySumModel(SplittableRandom rn, double noiseMagnitude, long noiseSamples) {
         return inputs -> supplyAsync(() -> {
+            Iterator<Double> noiseStream = rn.doubles(noiseSamples).iterator();
             List<PredictionOutput> predictionOutputs = new LinkedList<>();
             for (PredictionInput predictionInput : inputs) {
                 List<Feature> features = predictionInput.getFeatures();
                 double result = 0;
                 for (int i = 0; i < features.size(); i++) {
-                    result += features.get(i).getValue().asNumber() + ((rn.nextDouble() - .5) * noiseMagnitude);
+                    result += features.get(i).getValue().asNumber() + ((noiseStream.next() - .5) * noiseMagnitude);
                 }
                 PredictionOutput predictionOutput = new PredictionOutput(
                         List.of(new Output("noisy-sum", Type.NUMBER, new Value(result), 1d)));

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/local/shap/ShapKernelExplainerTest.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/local/shap/ShapKernelExplainerTest.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
+import java.util.SplittableRandom;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -543,8 +544,9 @@ class ShapKernelExplainerTest {
     void testErrorBounds(double noise) throws InterruptedException, ExecutionException {
         for (double interval : new double[] { .95, .975, .99 }) {
             int[] testResults = new int[600];
+            SplittableRandom rn = new SplittableRandom();
+            PredictionProvider model = TestUtils.getNoisySumModel(rn, noise, 64 * 100);
             for (int test = 0; test < 100; test++) {
-                PredictionProvider model = TestUtils.getNoisySumModel(pc.getRandom(), noise);
                 ShapConfig skConfig = testConfig
                         .withBackground(createPIFromMatrix(backgroundAllZeros))
                         .withConfidence(interval)


### PR DESCRIPTION
https://issues.redhat.com/browse/FAI-756

This refactors a few things within exp-core to speed up our test process by around 25%; on my dev machine, testing used to take ~6m12s, it now takes 4m39s. The specific changes made:
 - Value.asNumber() now explicitly checks if the `underlyingObject` is already a Number, and avoids the String.parseAsDouble() if so
 - The CounterFactualScoreCalculator no longer generates debug log messages
 - The TestUtils.NoisySum model now caches a sequence of random numbers, avoiding expensive random number generation per prediction