### PR TITLE
FAI-804+807: Refactored CF.asTable tests to not rely on specific outputs

### DIFF
--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/local/counterfactual/CounterfactualExplainerTest.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/local/counterfactual/CounterfactualExplainerTest.java
@@ -32,7 +32,6 @@ import java.util.stream.Stream;
 
 import org.apache.commons.math3.distribution.NormalDistribution;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -873,7 +872,6 @@ class CounterfactualExplainerTest {
                         Config.INSTANCE.getAsyncTimeUnit());
     }
 
-    @Disabled("https://issues.redhat.com/browse/FAI-804")
     @Test
     void testAsTable()
             throws ExecutionException, InterruptedException, TimeoutException {
@@ -905,24 +903,12 @@ class CounterfactualExplainerTest {
                 new Output("Semi-Categorical*2", Type.NUMBER, new Value(2), 0.0));
         List<Output> originalOutputs = model.predictAsync(List.of(new PredictionInput(features))).get().get(0).getOutputs();
 
-        final CounterfactualResult result = runCounterfactualSearch(0L, goal, features, model, .01, 100_000);
+        final CounterfactualResult result = CounterfactualUtils.runCounterfactualSearch(0L, goal, features, model, .01, 100_000);
         String resultString = result.asTable(originalOutputs, goal);
-        assertEquals("=== Counterfactual Search Results ========================================\n" +
-                "           Features |              Domain |  Original Value  → Found Value\n" +
-                "--------------------------------------------------------------------------\n" +
-                "          Feature 0 | -5.000000->5.000000 |           0.000  →       1.000\n" +
-                "          Feature 1 | -5.000000->5.000000 |           1.000  →       4.000\n" +
-                "          Feature 2 |              [A, B] |               A  →           B\n" +
-                "          Feature 3 | -5.000000->5.000000 |           3.000  →       3.000\n" +
-                "          Feature 4 | -5.000000->5.000000 |           4.000  →       3.000\n" +
-                "--------------------------------------------------------------------------\n" +
-                "            Outputs |                Goal |  Original Value  → Found Value\n" +
-                "--------------------------------------------------------------------------\n" +
-                "   Semi-Categorical |               1.000 |          -2.000  →       1.000\n" +
-                " Semi-Categorical*2 |               2.000 |          -4.000  →       2.000\n" +
-                "==========================================================================\n" +
-                "Meets Validity Criteria? true\n" +
-                "==========================================================================", resultString);
+        assertTrue(resultString.contains("Counterfactual Search Results"));
+        assertTrue(resultString.contains("Meets Validity Criteria?"));
+        assertTrue(resultString.contains("Feature 3"));
+        assertTrue(resultString.contains("[A, B]"));
     }
 
     @ParameterizedTest
@@ -941,7 +927,7 @@ class CounterfactualExplainerTest {
 
         final List<Output> goal = List.of(new Output("linear-sum", Type.NUMBER, new Value(0.), 1d));
 
-        final CounterfactualResult result = runCounterfactualSearch((long) seed, goal, fs, model, .01);
+        final CounterfactualResult result = CounterfactualUtils.runCounterfactualSearch((long) seed, goal, fs, model, .01);
 
         final List<Feature> resultFeatures = result.getEntities().stream().map(CounterfactualEntity::asFeature).collect(Collectors.toList());
 


### PR DESCRIPTION
[FAI-804](https://issues.redhat.com/browse/FAI-804), [FAI-807](https://issues.redhat.com/browse/FAI-807)
(duplicate issues)

Fixed CF.asTable() tests to not rely on specific outputs but instead check for general+universal contents. 