### PR TITLE
FAI-799: Refactored ShapResults for internal consistency with LIME

### DIFF
--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/shap/ShapDataCarrier.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/shap/ShapDataCarrier.java
@@ -18,6 +18,7 @@ package org.kie.trustyai.explainability.local.shap;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.commons.math3.linear.RealVector;
@@ -27,6 +28,7 @@ public class ShapDataCarrier {
     private PredictionProvider model;
     private CompletableFuture<RealVector> linkNull;
     private CompletableFuture<RealVector> fnull;
+    private CompletableFuture<Map<String, Double>> nullOutput;
     private int rows;
     private int cols;
     private CompletableFuture<Integer> outputSize;
@@ -87,6 +89,14 @@ public class ShapDataCarrier {
 
     public void setFnull(CompletableFuture<RealVector> fnull) {
         this.fnull = fnull;
+    }
+
+    public CompletableFuture<Map<String, Double>> getNullOutput() {
+        return nullOutput;
+    }
+
+    public void setNullOutput(CompletableFuture<Map<String, Double>> nullOutput) {
+        this.nullOutput = nullOutput;
     }
 
     // shap configuration =========================================================
@@ -158,5 +168,4 @@ public class ShapDataCarrier {
     public ShapDataCarrier() {
         // empty
     }
-
 }

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/local/shap/ShapResultsTest.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/local/shap/ShapResultsTest.java
@@ -17,10 +17,10 @@
 package org.kie.trustyai.explainability.local.shap;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
-import org.apache.commons.math3.linear.MatrixUtils;
-import org.apache.commons.math3.linear.RealVector;
 import org.junit.jupiter.api.Test;
 import org.kie.trustyai.explainability.model.Feature;
 import org.kie.trustyai.explainability.model.FeatureImportance;
@@ -34,16 +34,18 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 class ShapResultsTest {
     ShapResults buildShapResults(int nOutputs, int nFeatures, int scalar1, int scalar2) {
-        Saliency[] saliencies = new Saliency[nOutputs];
+        Map<String, Saliency> saliencies = new HashMap<>();
+        Map<String, Double> fnull = new HashMap<>();
         for (int i = 0; i < nOutputs; i++) {
             List<FeatureImportance> fis = new ArrayList<>();
             for (int j = 0; j < nFeatures; j++) {
                 fis.add(new FeatureImportance(new Feature("Feature " + String.valueOf(j), Type.NUMBER, new Value(j)), (i + 1) * j * scalar1));
             }
-            saliencies[i] = new Saliency(new Output("Output " + String.valueOf(i), Type.NUMBER, new Value(i + 1), 1.0), fis);
+            String oname = "Output " + i;
+            saliencies.put(oname,
+                    new Saliency(new Output(oname, Type.NUMBER, new Value(i + 1), 1.0), fis));
+            fnull.put(oname, (double) scalar2);
         }
-        RealVector fnull = MatrixUtils.createRealVector(new double[nOutputs]);
-        fnull.mapAddToSelf(scalar2);
         return new ShapResults(saliencies, fnull);
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/FAI-799

ShapResults now returns saliencies as a dictionary of saliencies keyed by output name, like LIME.