### PR TITLE
FAI-821: Moved model null output into saliencies

### DIFF
--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/shap/ShapResults.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/shap/ShapResults.java
@@ -27,19 +27,13 @@ import org.kie.trustyai.explainability.utils.IOUtils;
 
 public class ShapResults {
     private final Map<String, Saliency> saliencies;
-    private final Map<String, Double> fnull;
 
-    public ShapResults(Map<String, Saliency> saliencies, Map<String, Double> fnull) {
+    public ShapResults(Map<String, Saliency> saliencies) {
         this.saliencies = saliencies;
-        this.fnull = fnull;
     }
 
     public Map<String, Saliency> getSaliencies() {
         return saliencies;
-    }
-
-    public Map<String, Double> getFnull() {
-        return fnull;
     }
 
     @Override
@@ -52,9 +46,6 @@ public class ShapResults {
         }
         ShapResults other = (ShapResults) o;
         if (this.saliencies.size() != other.getSaliencies().size()) {
-            return false;
-        }
-        if (!this.fnull.equals(other.getFnull())) {
             return false;
         }
         for (Map.Entry<String, Saliency> entry : this.saliencies.entrySet()) {
@@ -78,7 +69,7 @@ public class ShapResults {
 
     @Override
     public int hashCode() {
-        return Objects.hash(saliencies.hashCode(), fnull);
+        return Objects.hash(saliencies.hashCode());
     }
 
     /**
@@ -122,11 +113,11 @@ public class ShapResults {
 
             featureNames.add("");
             featureValues.add("FNull");
-            shapValues.add(IOUtils.roundedString(this.fnull.get(entry.getKey()), decimalPlaces));
+            shapValues.add(IOUtils.roundedString(pfis.get(pfis.size() - 1).getScore(), decimalPlaces));
             confidences.add("");
             lineIDX++;
 
-            for (int i = 0; i < pfis.size(); i++) {
+            for (int i = 0; i < pfis.size() - 1; i++) {
                 featureNames.add(pfis.get(i).getFeature().getName() + " = ");
                 featureValues.add(IOUtils.roundedString(pfis.get(i).getFeature(), decimalPlaces));
                 shapValues.add(IOUtils.roundedString(pfis.get(i).getScore(), decimalPlaces));

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/local/shap/ShapResultsTest.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/local/shap/ShapResultsTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.kie.trustyai.explainability.model.Feature;
+import org.kie.trustyai.explainability.model.FeatureFactory;
 import org.kie.trustyai.explainability.model.FeatureImportance;
 import org.kie.trustyai.explainability.model.Output;
 import org.kie.trustyai.explainability.model.Saliency;
@@ -41,12 +42,12 @@ class ShapResultsTest {
             for (int j = 0; j < nFeatures; j++) {
                 fis.add(new FeatureImportance(new Feature("Feature " + String.valueOf(j), Type.NUMBER, new Value(j)), (i + 1) * j * scalar1));
             }
+            fis.add(new FeatureImportance(FeatureFactory.newNumericalFeature("Background", (double) scalar2), scalar2));
             String oname = "Output " + i;
             saliencies.put(oname,
                     new Saliency(new Output(oname, Type.NUMBER, new Value(i + 1), 1.0), fis));
-            fnull.put(oname, (double) scalar2);
         }
-        return new ShapResults(saliencies, fnull);
+        return new ShapResults(saliencies);
     }
 
     // test equals and hashing

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/local/shap/ShapResultsTest.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/local/shap/ShapResultsTest.java
@@ -39,10 +39,11 @@ class ShapResultsTest {
         Map<String, Double> fnull = new HashMap<>();
         for (int i = 0; i < nOutputs; i++) {
             List<FeatureImportance> fis = new ArrayList<>();
+            fis.add(new FeatureImportance(FeatureFactory.newNumericalFeature("Background", (double) scalar2), scalar2));
             for (int j = 0; j < nFeatures; j++) {
                 fis.add(new FeatureImportance(new Feature("Feature " + String.valueOf(j), Type.NUMBER, new Value(j)), (i + 1) * j * scalar1));
             }
-            fis.add(new FeatureImportance(FeatureFactory.newNumericalFeature("Background", (double) scalar2), scalar2));
+
             String oname = "Output " + i;
             saliencies.put(oname,
                     new Saliency(new Output(oname, Type.NUMBER, new Value(i + 1), 1.0), fis));


### PR DESCRIPTION
https://issues.redhat.com/browse/FAI-821

This refactors the Model Null Output field of the ShapResults into the final FeatureImportantance of the Saliencies. This allows for easier union of the various [*Results] classes in the Python bindings, and also aligns with the common treatment of the model null output as a phi-value within SHAP. 

 