### PR TITLE
FAI-839 - perceptron bias update fix, plus enhancements

### DIFF
--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/utils/LinearModel.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/utils/LinearModel.java
@@ -32,7 +32,7 @@ public class LinearModel {
     private static final Logger logger = LoggerFactory.getLogger(LinearModel.class);
     private static final double GOOD_LOSS_THRESHOLD = 1e-2;
     private static final int MAX_NO_EPOCHS = 50;
-    private static final double INITIAL_LEARNING_RATE = 1e-1;
+    private static final double INITIAL_LEARNING_RATE = 1;
     private static final double DECAY_RATE = 1e-5;
 
     private final double[] weights;
@@ -61,10 +61,13 @@ public class LinearModel {
             Arrays.fill(weights, 0);
             return finalLoss;
         }
+        double bestLoss = Double.MAX_VALUE;
+        double[] bestWeights = new double[weights.length];
+        double bestBias = bias;
         double lr = INITIAL_LEARNING_RATE;
         int e = 0;
         while (checkFinalLoss(finalLoss) && e < MAX_NO_EPOCHS) {
-            double loss = 0;
+            double loss = 0; // MAE
             int i = 0;
             for (Pair<double[], Double> sample : trainingSet) {
                 double[] doubles = sample.getLeft();
@@ -80,17 +83,28 @@ public class LinearModel {
                         }
                         v = finiteOrZero(v);
                         weights[j] += v;
-                        bias += lr * diff * sampleWeights[i];
                     }
+                    double biasUpdate = lr * diff;
+                    if (trainingSet.size() == sampleWeights.length) {
+                        biasUpdate *= sampleWeights[i];
+                    }
+                    bias += biasUpdate;
                 }
                 i++;
             }
             lr *= (1d / (1d + DECAY_RATE * e)); // learning rate decay
-
             finalLoss = loss;
+            if (finalLoss < bestLoss) {
+                bestLoss = finalLoss;
+                System.arraycopy(weights, 0, bestWeights, 0, weights.length);
+                bestBias = bias;
+                logger.debug("weights updated, loss: {}", bestLoss);
+            }
             e++;
             logger.debug("epoch {}, loss: {}", e, loss);
         }
+        bias = bestBias;
+        System.arraycopy(bestWeights, 0, weights, 0, weights.length);
         return finalLoss;
     }
 

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/local/lime/DummyModelsLimeExplainerTest.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/local/lime/DummyModelsLimeExplainerTest.java
@@ -74,8 +74,8 @@ class DummyModelsLimeExplainerTest {
             Assertions.assertEquals(1d, ExplainabilityMetrics.impactScore(model, prediction, topFeatures));
         }
         int topK = 1;
-        double minimumPositiveStabilityRate = 0.5;
-        double minimumNegativeStabilityRate = 0.5;
+        double minimumPositiveStabilityRate = 0.8;
+        double minimumNegativeStabilityRate = 0.8;
         TestUtils.assertLimeStability(model, prediction, limeExplainer, topK, minimumPositiveStabilityRate,
                 minimumNegativeStabilityRate);
         List<PredictionInput> inputs = new ArrayList<>();
@@ -126,8 +126,8 @@ class DummyModelsLimeExplainerTest {
             assertEquals(1d, ExplainabilityMetrics.impactScore(model, prediction, topFeatures));
         }
         int topK = 1;
-        double minimumPositiveStabilityRate = 0.5;
-        double minimumNegativeStabilityRate = 0.5;
+        double minimumPositiveStabilityRate = 0.8;
+        double minimumNegativeStabilityRate = 0.8;
         TestUtils.assertLimeStability(model, prediction, limeExplainer, topK, minimumPositiveStabilityRate,
                 minimumNegativeStabilityRate);
         List<PredictionInput> inputs = new ArrayList<>();
@@ -167,7 +167,7 @@ class DummyModelsLimeExplainerTest {
                 .get(Config.INSTANCE.getAsyncTimeout(), Config.INSTANCE.getAsyncTimeUnit());
         Prediction prediction = new SimplePrediction(input, outputs.get(0));
 
-        LimeConfig limeConfig = new LimeConfig().withSamples(100)
+        LimeConfig limeConfig = new LimeConfig()
                 .withPerturbationContext(new PerturbationContext(seed, random, 2));
         LimeExplainer limeExplainer = new LimeExplainer(limeConfig);
         Map<String, Saliency> saliencyMap = limeExplainer.explainAsync(prediction, model)
@@ -179,7 +179,7 @@ class DummyModelsLimeExplainerTest {
             assertEquals(1d, ExplainabilityMetrics.impactScore(model, prediction, topFeatures));
         }
         double minimumPositiveStabilityRate = 0.5;
-        double minimumNegativeStabilityRate = 0.5;
+        double minimumNegativeStabilityRate = 0.9;
         int topK = 1;
         TestUtils.assertLimeStability(model, prediction, limeExplainer, topK, minimumPositiveStabilityRate,
                 minimumNegativeStabilityRate);
@@ -233,8 +233,8 @@ class DummyModelsLimeExplainerTest {
             assertEquals(1d, ExplainabilityMetrics.impactScore(model, prediction, topFeatures));
         }
         int topK = 1;
-        double minimumPositiveStabilityRate = 0.5;
-        double minimumNegativeStabilityRate = 0.2;
+        double minimumPositiveStabilityRate = 0.9;
+        double minimumNegativeStabilityRate = 0.9;
         TestUtils.assertLimeStability(model, prediction, limeExplainer, topK, minimumPositiveStabilityRate,
                 minimumNegativeStabilityRate);
 
@@ -286,7 +286,7 @@ class DummyModelsLimeExplainerTest {
             assertEquals(1d, ExplainabilityMetrics.impactScore(model, prediction, topFeatures));
         }
         int topK = 1;
-        double minimumPositiveStabilityRate = 0.5;
+        double minimumPositiveStabilityRate = 0.6;
         double minimumNegativeStabilityRate = 0.5;
         TestUtils.assertLimeStability(model, prediction, limeExplainer, topK, minimumPositiveStabilityRate,
                 minimumNegativeStabilityRate);
@@ -337,8 +337,8 @@ class DummyModelsLimeExplainerTest {
             assertEquals(0d, ExplainabilityMetrics.impactScore(model, prediction, topFeatures));
         }
         int topK = 1;
-        double minimumPositiveStabilityRate = 0.5;
-        double minimumNegativeStabilityRate = 0.5;
+        double minimumPositiveStabilityRate = 0.9;
+        double minimumNegativeStabilityRate = 0.9;
         TestUtils.assertLimeStability(model, prediction, limeExplainer, topK, minimumPositiveStabilityRate,
                 minimumNegativeStabilityRate);
 


### PR DESCRIPTION
See https://issues.redhat.com/browse/FAI-839

This fixes a problem with the perceptron learning rule updating the bias unit too often (once for every feature for each sample while it should update the bias unit only once per sample).

A couple of enhancements:
- (starting) learning rate for perceptron should be 1 
- a checkpointing mechanism to use the weights having the lowest loss (MAE) across the whole learning process

