### PR TITLE
FAI-837 - disable failing PMML ITs

### DIFF
--- a/explainability-integrationtests/explainability-integrationtests-pmml/pom.xml
+++ b/explainability-integrationtests/explainability-integrationtests-pmml/pom.xml
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-kie-bom</artifactId>
-        <version>${project.version}</version>
+        <version>1.22.0.Final</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/explainability-integrationtests/explainability-integrationtests-pmml/src/test/java/org/kie/trustyai/explainability/integrationtests/pmml/PmmlCompoundScorecardLimeExplainerTest.java
+++ b/explainability-integrationtests/explainability-integrationtests-pmml/src/test/java/org/kie/trustyai/explainability/integrationtests/pmml/PmmlCompoundScorecardLimeExplainerTest.java
@@ -56,6 +56,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.kie.pmml.evaluator.assembler.factories.PMMLRuntimeFactoryInternal.getPMMLRuntime;
 
+@Disabled
 class PmmlCompoundScorecardLimeExplainerTest {
 
     private static PMMLRuntime compoundScoreCardRuntime;

--- a/explainability-integrationtests/explainability-integrationtests-pmml/src/test/java/org/kie/trustyai/explainability/integrationtests/pmml/PmmlScorecardCategoricalLimeExplainerTest.java
+++ b/explainability-integrationtests/explainability-integrationtests-pmml/src/test/java/org/kie/trustyai/explainability/integrationtests/pmml/PmmlScorecardCategoricalLimeExplainerTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeoutException;
 
 import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.kie.api.pmml.PMML4Result;
 import org.kie.pmml.api.runtime.PMMLRuntime;
@@ -55,6 +56,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.kie.pmml.evaluator.assembler.factories.PMMLRuntimeFactoryInternal.getPMMLRuntime;
 
+@Disabled
 class PmmlScorecardCategoricalLimeExplainerTest {
 
     private static PMMLRuntime scorecardCategoricalRuntime;


### PR DESCRIPTION
See https://issues.redhat.com/browse/FAI-837

Disable faling PMML ITs.
Some models seem not compatible anymore with the current Drools-PMML version, however with these changes we depend on a fixed version of kie-pmml and we can keep running at least one of the models.