### PR TITLE
[FAI-861][FAI-770] Remove usage of kogito-app-build-parent + replace optaplanner-quarkus with optaplanner-core

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -8,7 +8,7 @@ jobs:
     concurrency:
       group: pull_request-${{ github.event_name }}-${{ github.head_ref }}-${{ matrix.os }}-${{ matrix.java-version }}
       cancel-in-progress: true
-    timeout-minutes: 120
+    timeout-minutes: 45
     strategy:
       matrix:
         # configure with [ 'ubuntu-latest', 'windows-latest' ] to enable Windows builds

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -7,7 +7,7 @@ jobs:
     concurrency:
       group: event-connect-pr-${{ github.head_ref }}
       cancel-in-progress: true
-    timeout-minutes: 45
+    timeout-minutes: 120
     runs-on: ubuntu-latest
     name: Build and Test
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,24 @@
-*.class
-/explainability-core/target/
-/.idea/
+target/
+/local
+
+**/.idea
+
+# Repository wide ignore mac DS_Store files
+.DS_Store
+
+# Eclipse, Netbeans and IntelliJ files
+!.gitignore
+!.github
+/nbproject
+/*.ipr
+/*.iws
+*.iml
+.settings/
+.project
+.classpath
+.factorypath
+.vscode
+.run/
+.checkstyle
+
+*.log

--- a/explainability-core/pom.xml
+++ b/explainability-core/pom.xml
@@ -13,10 +13,6 @@
   <version>2.0.0-SNAPSHOT</version>
   <name>TrustyAI Explainability Core</name>
 
-  <properties>
-    <version.org.apache.commons.math>3.6.1</version.org.apache.commons.math>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -36,7 +32,7 @@
     </dependency>
     <dependency>
       <groupId>org.optaplanner</groupId>
-      <artifactId>optaplanner-quarkus</artifactId>
+      <artifactId>optaplanner-core</artifactId>
       <exclusions>
         <!--
           Removes all dependencies on OptaPlanner Drools, as Trusty does not use it.

--- a/explainability-core/pom.xml
+++ b/explainability-core/pom.xml
@@ -36,7 +36,7 @@
     </dependency>
     <dependency>
       <groupId>org.optaplanner</groupId>
-      <artifactId>optaplanner-core</artifactId>
+      <artifactId>optaplanner-quarkus</artifactId>
       <exclusions>
         <!--
           Removes all dependencies on OptaPlanner Drools, as Trusty does not use it.

--- a/explainability-core/pom.xml
+++ b/explainability-core/pom.xml
@@ -2,13 +2,13 @@
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <parent>
-    <groupId>org.kie.kogito</groupId>
-    <artifactId>kogito-apps-build-parent</artifactId>
-    <version>1.22.1.Final</version>
+    <groupId>org.kie.trustyai</groupId>
+    <artifactId>trustyaiexplainability</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.kie.trustyai</groupId>
   <artifactId>explainability-core</artifactId>
   <version>2.0.0-SNAPSHOT</version>
   <name>TrustyAI Explainability Core</name>
@@ -36,7 +36,7 @@
     </dependency>
     <dependency>
       <groupId>org.optaplanner</groupId>
-      <artifactId>optaplanner-quarkus</artifactId>
+      <artifactId>optaplanner-core</artifactId>
       <exclusions>
         <!--
           Removes all dependencies on OptaPlanner Drools, as Trusty does not use it.
@@ -91,7 +91,6 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
             <configuration>
               <artifactSet>

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/local/counterfactual/CounterfactualExplainerTest.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/local/counterfactual/CounterfactualExplainerTest.java
@@ -96,7 +96,7 @@ class CounterfactualExplainerTest {
 
     @BeforeEach
     @SuppressWarnings({ "unused", "unchecked" })
-    private void setup() {
+    protected void setup() {
         this.solverManagerFactory = mock(Function.class);
         this.solverManager = mock(SolverManager.class);
     }

--- a/explainability-integrationtests/explainability-integrationtests-opennlp/pom.xml
+++ b/explainability-integrationtests/explainability-integrationtests-opennlp/pom.xml
@@ -19,8 +19,8 @@
     </dependency>
 
     <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/explainability-integrationtests/explainability-integrationtests-pmml/pom.xml
+++ b/explainability-integrationtests/explainability-integrationtests-pmml/pom.xml
@@ -37,7 +37,7 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,8 @@
         <version.org.assertj>3.22.0</version.org.assertj>
         <version.org.awaitility>4.2.0</version.org.awaitility>
 
-        <version.org.optaplanner>8.29.0.Final</version.org.optaplanner>
-        <version.org.kie.kogito>1.29.0.Final</version.org.kie.kogito>
+        <version.org.optaplanner>8.22.1.Final</version.org.optaplanner>
+        <version.org.kie.kogito>1.22.1.Final</version.org.kie.kogito>
 
         <version.surefire.plugin>2.22.2</version.surefire.plugin> <!-- minimum required by JUnit 5 -->
         <version.shade.plugin>3.4.0</version.shade.plugin> <!-- minimum required by JUnit 5 -->

--- a/pom.xml
+++ b/pom.xml
@@ -17,13 +17,14 @@
         <version.com.fasterxml.jackson.databind>2.13.4.2</version.com.fasterxml.jackson.databind>
         <version.org.apache.commons.commons-lang3>3.12.0</version.org.apache.commons.commons-lang3>
         <version.org.apache.commons.commons-csv>1.9.0</version.org.apache.commons.commons-csv>
-        <version.org.optaplanner>8.29.0.Final</version.org.optaplanner>
-        <version.org.kie.kogito>1.29.0.Final</version.org.kie.kogito>
         <version.org.apache.opennlp>1.9.2</version.org.apache.opennlp>
         <version.org.junit.jupiter>5.9.1</version.org.junit.jupiter>
         <version.org.mockito>4.8.0</version.org.mockito>
         <version.org.assertj>3.22.0</version.org.assertj>
         <version.org.awaitility>4.2.0</version.org.awaitility>
+
+        <version.org.optaplanner>8.29.0.Final</version.org.optaplanner>
+        <version.org.kie.kogito>1.29.0.Final</version.org.kie.kogito>
 
         <version.surefire.plugin>2.22.2</version.surefire.plugin> <!-- minimum required by JUnit 5 -->
         <version.shade.plugin>3.4.0</version.shade.plugin> <!-- minimum required by JUnit 5 -->

--- a/pom.xml
+++ b/pom.xml
@@ -129,12 +129,6 @@
                     <version>${version.surefire.plugin}</version>
                     <configuration>
                         <argLine>-Xmx1024m -Dfile.encoding=UTF-8</argLine>
-                        <systemPropertyVariables>
-                            <apple.awt.UIElement>true</apple.awt.UIElement>
-                            <org.uberfire.nio.git.daemon.enabled>false</org.uberfire.nio.git.daemon.enabled>
-                            <org.uberfire.nio.git.ssh.enabled>false</org.uberfire.nio.git.ssh.enabled>
-                            <org.uberfire.sys.repo.monitor.disabled>true</org.uberfire.sys.repo.monitor.disabled>
-                        </systemPropertyVariables>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,8 @@
     <packaging>pom</packaging>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
@@ -28,6 +30,15 @@
 
         <version.surefire.plugin>2.22.2</version.surefire.plugin> <!-- minimum required by JUnit 5 -->
         <version.shade.plugin>3.4.0</version.shade.plugin> <!-- minimum required by JUnit 5 -->
+
+        <kogito.formatter.version>${version.org.kie.kogito}</kogito.formatter.version>
+        <formatter.plugin.version>2.13.0</formatter.plugin.version>
+        <impsort.plugin.version>1.5.0</impsort.plugin.version>
+
+        <formatter.skip>false</formatter.skip>
+        <formatter.goal>format</formatter.goal>
+        <impsort.goal>sort</impsort.goal>
+
     </properties>
 
     <dependencyManagement>
@@ -126,6 +137,52 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>net.revelc.code.formatter</groupId>
+                    <artifactId>formatter-maven-plugin</artifactId>
+                    <version>${formatter.plugin.version}</version>
+                    <dependencies>
+                        <dependency>
+                            <artifactId>kogito-ide-config</artifactId>
+                            <groupId>org.kie.kogito</groupId>
+                            <version>${kogito.formatter.version}</version>
+                        </dependency>
+                    </dependencies>
+                    <configuration>
+                        <configFile>eclipse-format.xml</configFile>
+                        <lineEnding>LF</lineEnding>
+                        <skip>${formatter.skip}</skip>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>${formatter.goal}</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>net.revelc.code</groupId>
+                    <artifactId>impsort-maven-plugin</artifactId>
+                    <version>${impsort.plugin.version}</version>
+                    <configuration>
+                        <!-- keep in sync with kogito-ide-config/src/main/resources/eclipse.importorder -->
+                        <groups>java.,javax.,org.,com.,io.</groups>
+                        <staticGroups>*</staticGroups>
+                        <staticAfter>true</staticAfter>
+                        <!-- keep in sync with the formatter-maven-plugin -->
+                        <skip>${formatter.skip}</skip>
+                        <removeUnused>true</removeUnused>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>${impsort.goal}</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${version.surefire.plugin}</version>
                     <configuration>
@@ -142,11 +199,53 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>net.revelc.code.formatter</groupId>
+                <artifactId>formatter-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>net.revelc.code</groupId>
+                <artifactId>impsort-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
     </build>
 
     <modules>
         <module>explainability-core</module>
         <module>explainability-integrationtests</module>
     </modules>
+
+
+    <profiles>
+        <profile>
+            <!-- Fail the build if code does not follow the standards. -->
+            <id>validate-formatting</id>
+            <activation>
+                <property>
+                    <name>validate-formatting</name>
+                </property>
+            </activation>
+            <properties>
+                <formatter.skip>false</formatter.skip>
+                <formatter.goal>validate</formatter.goal>
+                <impsort.goal>check</impsort.goal>
+            </properties>
+        </profile>
+        <profile>
+            <id>quickly</id>
+            <activation>
+                <property>
+                    <name>quickly</name>
+                </property>
+            </activation>
+            <properties>
+                <formatter.skip>true</formatter.skip>
+                <skipITs>true</skipITs>
+                <skipTests>true</skipTests>
+            </properties>
+        </profile>
+    </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2,21 +2,156 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <parent>
-    <groupId>org.kie.kogito</groupId>
-    <artifactId>kogito-apps-build-parent</artifactId>
-    <version>1.22.1.Final</version>
-  </parent>
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>org.kie.trustyai</groupId>
-  <artifactId>trustyaiexplainability</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
-  <name>TrustyAI Explainability</name>
-  <packaging>pom</packaging>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.kie.trustyai</groupId>
+    <artifactId>trustyaiexplainability</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+    <name>TrustyAI Explainability</name>
+    <packaging>pom</packaging>
 
-  <modules>
-    <module>explainability-core</module>
-    <module>explainability-integrationtests</module>
-  </modules>
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+
+        <version.org.slf4j>1.7.30</version.org.slf4j>
+        <version.com.fasterxml.jackson.databind>2.13.4.2</version.com.fasterxml.jackson.databind>
+        <version.org.apache.commons.commons-lang3>3.12.0</version.org.apache.commons.commons-lang3>
+        <version.org.apache.commons.commons-csv>1.9.0</version.org.apache.commons.commons-csv>
+        <version.org.optaplanner>8.29.0.Final</version.org.optaplanner>
+        <version.org.kie.kogito>1.29.0.Final</version.org.kie.kogito>
+        <version.org.apache.opennlp>1.9.2</version.org.apache.opennlp>
+        <version.org.junit.jupiter>5.9.1</version.org.junit.jupiter>
+        <version.org.mockito>4.8.0</version.org.mockito>
+        <version.org.assertj>3.22.0</version.org.assertj>
+        <version.org.awaitility>4.2.0</version.org.awaitility>
+
+        <version.surefire.plugin>2.22.2</version.surefire.plugin> <!-- minimum required by JUnit 5 -->
+        <version.shade.plugin>3.4.0</version.shade.plugin> <!-- minimum required by JUnit 5 -->
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.optaplanner</groupId>
+                <artifactId>optaplanner-bom</artifactId>
+                <version>${version.org.optaplanner}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${version.org.apache.commons.commons-lang3}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-csv</artifactId>
+                <version>${version.org.apache.commons.commons-csv}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${version.org.slf4j}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${version.com.fasterxml.jackson.databind}</version>
+            </dependency>
+
+            <!-- TEST dependencies -->
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>${version.org.junit.jupiter}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${version.org.assertj}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${version.org.mockito}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.awaitility</groupId>
+                <artifactId>awaitility</artifactId>
+                <version>${version.org.awaitility}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-simple</artifactId>
+                <version>${version.org.slf4j}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.kie.kogito</groupId>
+                <artifactId>kogito-dmn</artifactId>
+                <version>${version.org.kie.kogito}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.kie.kogito</groupId>
+                <artifactId>kogito-pmml</artifactId>
+                <version>${version.org.kie.kogito}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.opennlp</groupId>
+                <artifactId>opennlp-tools</artifactId>
+                <version>${version.org.apache.opennlp}</version>
+                <scope>test</scope>
+            </dependency>
+
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${version.surefire.plugin}</version>
+                    <configuration>
+                        <argLine>-Xmx1024m -Dfile.encoding=UTF-8</argLine>
+                        <systemPropertyVariables>
+                            <apple.awt.UIElement>true</apple.awt.UIElement>
+                            <org.uberfire.nio.git.daemon.enabled>false</org.uberfire.nio.git.daemon.enabled>
+                            <org.uberfire.nio.git.ssh.enabled>false</org.uberfire.nio.git.ssh.enabled>
+                            <org.uberfire.sys.repo.monitor.disabled>true</org.uberfire.sys.repo.monitor.disabled>
+                        </systemPropertyVariables>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>${version.surefire.plugin}</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <version>${version.shade.plugin}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+    <modules>
+        <module>explainability-core</module>
+        <module>explainability-integrationtests</module>
+    </modules>
 
 </project>


### PR DESCRIPTION
- Removed `kogito-app-build-parent`, now the repo is self contained
- Cleanup POM (removed `quarkus-junit` dependency and moved to `optaplanner-core` dependency)
- Minor `.gitignore` improvements