### PR TITLE
Surefire heap space OOM fix

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -3,7 +3,7 @@ on: [ push, pull_request ]
 jobs:
   event-connect-build:
     env:
-      MAVEN_OPTS: "-Dhttps.protocols=TLSv1.2 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Dorg.slf4j.simpleLogger.showDateTime=true -Djava.awt.headless=true -Xmx7g"
+      MAVEN_OPTS: "-Dhttps.protocols=TLSv1.2 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Dorg.slf4j.simpleLogger.showDateTime=true -Djava.awt.headless=true"
       MAVEN_ARGS: "-nsu -fae -e"
     concurrency:
       group: pull_request-${{ github.event_name }}-${{ github.head_ref }}-${{ matrix.os }}-${{ matrix.java-version }}

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${version.surefire.plugin}</version>
                     <configuration>
-                        <argLine>-Xmx1024m -Dfile.encoding=UTF-8  --add-opens java.base/java.nio=ALL-UNNAMED</argLine>
+                        <argLine>-Xmx7g -Dfile.encoding=UTF-8 --add-opens java.base/java.nio=ALL-UNNAMED</argLine>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${version.surefire.plugin}</version>
                     <configuration>
-                        <argLine>-Xmx7g -Dfile.encoding=UTF-8 --add-opens java.base/java.nio=ALL-UNNAMED</argLine>
+                        <argLine>-Xmx2048m -Dfile.encoding=UTF-8 --add-opens java.base/java.nio=ALL-UNNAMED</argLine>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Surefire's forked VMs weren't picking up the max heap size argument from `MAVEN_OPTS`.
This PR fixes this by adding the argument to surefire's configuration. Max heap size also lowered from 7Gb to 2Gb.