### PR TITLE
FAI-884: Added kPerGoal flag to chained counterfactual generation

### DIFF
--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/shap/background/CounterfactualGenerator.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/shap/background/CounterfactualGenerator.java
@@ -207,13 +207,13 @@ public class CounterfactualGenerator {
      * will be added to the counterfactual seeds.
      */
     public List<PredictionInput> generateRange(
-            List<PredictionInput> seeds, List<PredictionOutput> goals, boolean chain)
+            List<PredictionInput> seeds, List<PredictionOutput> goals, int kPerGoal, boolean chain)
             throws ExecutionException, InterruptedException, TimeoutException {
         List<PredictionInput> rangeSeeds = new ArrayList<>(seeds);
         List<PredictionInput> generatedBackground = new ArrayList<>();
 
         for (int i = 0; i < goals.size(); i++) {
-            List<PredictionInput> generated = generate(rangeSeeds, goals.get(i), 1);
+            List<PredictionInput> generated = generate(rangeSeeds, goals.get(i), kPerGoal);
             if (!generated.isEmpty()) {
                 if (chain) {
                     rangeSeeds.addAll(generated);

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/local/shap/background/CounterfactualGeneratorTest.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/local/shap/background/CounterfactualGeneratorTest.java
@@ -116,7 +116,7 @@ class CounterfactualGeneratorTest {
                 .withKSeeds(5)
                 .withMaxAttemptCount(10)
                 .build()
-                .generateRange(seeds, goals, true);
+                .generateRange(seeds, goals, 1, true);
         assertEquals(1, seeds.size());
         assertEquals(N_COUNTERFACTUALS_TO_GENERATE, background.size());
     }


### PR DESCRIPTION
Now there's an option to generate kPerGoal counterfactuals per specified goal in the SHAP CF background generation.
Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `FAI-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.3.x] FAI-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

