### PR TITLE
FAI-890: Add initial Dataframe implementation

### DIFF
--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/model/Dataframe.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/model/Dataframe.java
@@ -13,11 +13,17 @@ import org.kie.trustyai.explainability.model.domain.ObjectFeatureDomain;
 
 public class Dataframe {
 
-    private List<List<Value>> data = new ArrayList<>();
-    private Metadata metadata = new Metadata();
+    private final List<List<Value>> data;
+    private final Metadata metadata;
 
     private Dataframe() {
+        this.data = new ArrayList<>();
+        this.metadata = new Metadata();
+    }
 
+    private Dataframe(List<List<Value>> data, Metadata metadata) {
+        this.data = data;
+        this.metadata = metadata;
     }
 
     /**
@@ -465,11 +471,9 @@ public class Dataframe {
      * @return A {@link Dataframe}
      */
     public Dataframe copy() {
-        final Dataframe dataframe = new Dataframe();
-
-        dataframe.data = this.data.stream().map(ArrayList::new).collect(Collectors.toList());
-        dataframe.metadata = metadata.copy();
-        return dataframe;
+        return new Dataframe(
+                this.data.stream().map(ArrayList::new).collect(Collectors.toList()),
+                metadata.copy());
     }
 
     /**
@@ -512,15 +516,15 @@ public class Dataframe {
      * @return A filtered {@link Dataframe}.
      */
     public Dataframe filterByRowIndex(List<Integer> rows) {
-        final Dataframe dataframe = new Dataframe();
-        dataframe.metadata = metadata.copy();
 
-        dataframe.data = columnIndexStream().mapToObj(col -> {
+        final Metadata metadataCopy = metadata.copy();
+
+        final List<List<Value>> dataCopy = columnIndexStream().mapToObj(col -> {
             final List<Value> column = data.get(col);
             return rows.stream().map(column::get).collect(Collectors.toList());
         }).collect(Collectors.toList());
 
-        return dataframe;
+        return new Dataframe(dataCopy, metadataCopy);
     }
 
     /**
@@ -660,11 +664,23 @@ public class Dataframe {
     }
 
     private class Metadata {
-        private List<String> names = new ArrayList<>();
-        private List<Type> types = new ArrayList<>();
-        private List<Boolean> constrained = new ArrayList<>();
-        private List<FeatureDomain> domains = new ArrayList<>();
-        private List<Boolean> inputs = new ArrayList<>();
+        private final List<String> names;
+        private final List<Type> types;
+        private final List<Boolean> constrained;
+        private final List<FeatureDomain> domains;
+        private final List<Boolean> inputs;
+
+        private Metadata() {
+            this(new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+        }
+
+        private Metadata(List<String> names, List<Type> types, List<Boolean> constrained, List<FeatureDomain> domains, List<Boolean> inputs) {
+            this.names = names;
+            this.types = types;
+            this.constrained = constrained;
+            this.domains = domains;
+            this.inputs = inputs;
+        }
 
         public void remove(int column) {
             names.remove(column);
@@ -675,13 +691,12 @@ public class Dataframe {
         }
 
         public Metadata copy() {
-            final Metadata copy = new Metadata();
-            copy.names = new ArrayList<>(this.names);
-            copy.types = new ArrayList<>(this.types);
-            copy.constrained = new ArrayList<>(this.constrained);
-            copy.domains = new ArrayList<>(this.domains);
-            copy.inputs = new ArrayList<>(this.inputs);
-            return copy;
+            return new Metadata(
+                    new ArrayList<>(this.names),
+                    new ArrayList<>(this.types),
+                    new ArrayList<>(this.constrained),
+                    new ArrayList<>(this.domains),
+                    new ArrayList<>(this.inputs));
         }
 
     }

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/model/Dataframe.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/model/Dataframe.java
@@ -1,0 +1,688 @@
+package org.kie.trustyai.explainability.model;
+
+import org.kie.trustyai.explainability.model.domain.EmptyFeatureDomain;
+import org.kie.trustyai.explainability.model.domain.FeatureDomain;
+import org.kie.trustyai.explainability.model.domain.NumericalFeatureDomain;
+import org.kie.trustyai.explainability.model.domain.ObjectFeatureDomain;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class Dataframe {
+
+    private List<List<Value>> data = new ArrayList<>();
+    private Metadata metadata = new Metadata();
+
+    private Dataframe() {
+
+    }
+
+    /**
+     * Create a dataframe from a single @link{Prediction}
+     *
+     * @param prediction The original @link{Prediction}
+     * @return A @link{Dataframe}
+     */
+    public static Dataframe createFrom(Prediction prediction) {
+        final Dataframe df = new Dataframe();
+
+        // Process inputs metadata
+        for (Feature feature : prediction.getInput().getFeatures()) {
+            df.metadata.names.add(feature.getName());
+            df.metadata.types.add(feature.getType());
+            df.metadata.constrained.add(feature.isConstrained());
+            df.metadata.domains.add(feature.getDomain());
+            df.metadata.inputs.add(true);
+            df.data.add(new ArrayList<>());
+        }
+        // Process outputs metadata
+        for (Output output : prediction.getOutput().getOutputs()) {
+            df.metadata.names.add(output.getName());
+            df.metadata.types.add(output.getType());
+            df.metadata.constrained.add(true);
+            df.metadata.domains.add(EmptyFeatureDomain.create());
+            df.metadata.inputs.add(false);
+            df.data.add(new ArrayList<>());
+        }
+
+        // Copy data
+        df.addPrediction(prediction);
+
+        return df;
+    }
+
+    /**
+     * Create a dataframe from a @link{Dataset}
+     *
+     * @param dataset The original @link{Dataset}
+     * @return A @link{Dataframe}
+     */
+    public static Dataframe createFrom(Dataset dataset) {
+        return createFrom(dataset.getData());
+    }
+
+    /**
+     * Create a dataframe from a list of @link{Prediction}
+     *
+     * @param predictions The original @link{Prediction} list
+     * @return A @link{Dataframe}
+     */
+    public static Dataframe createFrom(List<Prediction> predictions) {
+        final Prediction prediction = predictions.get(0);
+        final Dataframe df = Dataframe.createFrom(prediction);
+
+        predictions.remove(0);
+        df.addPredictions(predictions);
+
+        return df;
+    }
+
+    /**
+     * Return a copy of the dataframe containing only input columns
+     *
+     * @return A @link{Dataframe}
+     */
+    public Dataframe getInputDataframe() {
+        final Dataframe df = this.copy();
+        df.dropColumns(getOutputsIndices());
+        return df;
+    }
+
+    /**
+     * Add a single prediction (as a row) to the @link{Dataframe}
+     *
+     * @param prediction The @link{Prediction} to add.
+     */
+    public void addPrediction(Prediction prediction) {
+        addPredictions(List.of(prediction));
+    }
+
+    /**
+     * Add a {@link List} of predictions to the {@link Dataframe}
+     *
+     * @param predictions The {@link List} of {@link Prediction} to add.
+     */
+    public void addPredictions(List<Prediction> predictions) {
+        final Prediction prediction = predictions.get(0);
+        final List<Feature> inputs = prediction.getInput().getFeatures();
+        final List<Output> outputs = prediction.getOutput().getOutputs();
+
+        // Validate schema
+        if (!getInputNames().equals(inputs.stream().map(Feature::getName).collect(Collectors.toList()))) {
+            throw new IllegalArgumentException("Prediction inputs do not match dataframe inputs");
+        }
+        if (!getInputNames().equals(inputs.stream().map(Feature::getName).collect(Collectors.toList()))) {
+            throw new IllegalArgumentException("Prediction inputs do not match dataframe inputs");
+        }
+
+        final int inputsSize = getInputsCount();
+
+        IntStream.range(0, predictions.size()).forEach(i -> {
+            final List<Feature> currentInputs = predictions.get(i).getInput().getFeatures();
+            final List<Output> currentOutputs = predictions.get(i).getOutput().getOutputs();
+            // Copy data
+            for (int col = 0; col < inputsSize; col++) {
+                data.get(col).add(currentInputs.get(col).getValue());
+            }
+            final int nFeatures = getColumnDimension();
+            for (int col = inputsSize; col < nFeatures; col++) {
+                data.get(col).add(currentOutputs.get(col - inputsSize).getValue());
+            }
+        });
+    }
+
+    /**
+     * Get a {@link List} of column names marked as inputs.
+     *
+     * @return A {@link List} of input column names.
+     */
+    public List<String> getInputNames() {
+        return getColumnNames(getInputsIndices());
+    }
+
+    /**
+     * Get a {@link List} of column names marked as outputs.
+     *
+     * @return A {@link List} of output column names.
+     */
+    public List<String> getOutputNames() {
+        return getColumnNames(getOutputsIndices());
+    }
+
+    /**
+     * Sets a column's {@link FeatureDomain}.
+     * Setting it to non-empy domain will also mark the column as {@link #isConstrained(int) non-constrained}.
+     *
+     * @param column Column to add the domain to.
+     * @param domain A {@link FeatureDomain} (can be {@link EmptyFeatureDomain}).
+     */
+    public void setColumnDomain(int column, FeatureDomain domain) {
+        validateColumnIndex(column);
+
+        metadata.domains.set(column, domain);
+        if (!domain.isEmpty()) {
+            metadata.constrained.set(column, false);
+        }
+    }
+
+    private void validateColumnIndex(int i) {
+        if (i < 0 || i >= data.size()) {
+            throw new IllegalArgumentException("Column " + i + " outside dataframe bounds.");
+        }
+    }
+
+    private void validateRowIndex(int row) {
+        if (row < 0 || row >= getRowDimension()) {
+            throw new IllegalArgumentException("Row " + row + " outside dataframe bounds.");
+        }
+    }
+
+    /**
+     * Returns whether a column is constrained or not.
+     *
+     * @param column The column index
+     * @return Boolean for constraints.
+     */
+    public boolean isConstrained(int column) {
+        validateColumnIndex(column);
+        return metadata.constrained.get(column);
+    }
+
+    /**
+     * Get the column's {@link Type}.
+     *
+     * @param column Column index
+     * @return The column's {@link Type}.
+     */
+    public Type getType(int column) {
+        validateColumnIndex(column);
+        return metadata.types.get(column);
+    }
+
+    /**
+     * Set the column's type.
+     *
+     * @param column The column index
+     * @param type   The column's {@link Type}
+     */
+    public void setType(int column, Type type) {
+        validateColumnIndex(column);
+        metadata.types.set(column, type);
+    }
+
+    /**
+     * Get a column's {@link FeatureDomain}.
+     *
+     * @param column The column's index.
+     * @return The column's {@link FeatureDomain}.
+     */
+    public FeatureDomain getDomain(int column) {
+        validateColumnIndex(column);
+        return metadata.domains.get(column);
+    }
+
+    /**
+     * Calculate a {@link FeatureDomain} based on a column's data.
+     *
+     * @param column The column to calculate the domain for.
+     * @return A {@link FeatureDomain}.
+     */
+    public FeatureDomain calculateColumnDomain(int column) {
+        validateColumnIndex(column);
+
+        final Type type = metadata.types.get(column);
+
+        if (type.equals(Type.NUMBER)) {
+            final double max = getColumn(column).stream().mapToDouble(Value::asNumber).max().getAsDouble();
+            final double min = getColumn(column).stream().mapToDouble(Value::asNumber).min().getAsDouble();
+            return NumericalFeatureDomain.create(min, max);
+        } else if (type.equals(Type.BOOLEAN)) {
+            final Set<Boolean> categories = getColumn(column).stream().map(value -> (Boolean) value.getUnderlyingObject()).collect(Collectors.toSet());
+            return ObjectFeatureDomain.create(categories);
+        } else {
+            return EmptyFeatureDomain.create();
+        }
+    }
+
+    /**
+     * Returns indices of constrained columns.
+     *
+     * @return A {@link List} of indices.
+     */
+    public List<Integer> getConstrained() {
+        return columnIndexStream().filter(c -> metadata.constrained.get(c)).boxed().collect(Collectors.toList());
+    }
+
+    /**
+     * Returns the number of rows in this dataframe.
+     *
+     * @return Number of rows.
+     */
+    public int getRowDimension() {
+        if (data.isEmpty()) {
+            return 0;
+        } else {
+            return this.data.get(0).size();
+        }
+
+    }
+
+    /**
+     * Sets the number of rows in this dataframe.
+     * If the number is smaller than the current number of rows, the rows are truncated.
+     * If the number is higher, empty rows are add up to the desired size.
+     *
+     * @param i New number of rows.
+     */
+    public void setRowDimension(int i) {
+        final int rows = getRowDimension();
+        final int cols = getColumnDimension();
+        if (i > rows) {
+            columnIndexStream().forEach(c -> {
+                List<Value> pad = IntStream.range(0, i - rows).mapToObj(n -> new Value(null)).collect(Collectors.toList());
+                List<Value> values = data.get(c);
+                values.addAll(pad);
+                data.set(c, values);
+            });
+        } else if (i < rows) {
+            columnIndexStream().forEach(c -> {
+                final List<Value> values = data.get(c);
+                data.set(c, values.subList(0, i));
+            });
+        }
+    }
+
+    /**
+     * Get the number of columns in the {@link Dataframe}.
+     *
+     * @return Number of columns.
+     */
+    public int getColumnDimension() {
+        return this.data.size();
+    }
+
+    public int getInputsCount() {
+        return getInputsIndices().size();
+    }
+
+    /**
+     * Return a column as a {@link List} of {@link Value}.
+     *
+     * @param column The column to return.
+     * @return A {@link List} of {@link Value}.
+     */
+    public List<Value> getColumn(int column) {
+        validateColumnIndex(column);
+        return data.get(column);
+    }
+
+    /**
+     * Return a row as a {@link List} of {@link Value}.
+     *
+     * @param row The row to return.
+     * @return A {@link List} of {@link Value}.
+     */
+    public List<Value> getRow(int row) {
+        validateRowIndex(row);
+        return columnIndexStream().mapToObj(column -> data.get(column).get(row)).collect(Collectors.toList());
+    }
+
+    public List<Integer> getInputsIndices() {
+        return columnIndexStream().filter(i -> metadata.inputs.get(i)).boxed().collect(Collectors.toList());
+    }
+
+    /**
+     * Return a stream with all column indices
+     *
+     * @return A {@link IntStream} of column indices
+     */
+    public IntStream columnIndexStream() {
+        return IntStream.range(0, getColumnDimension());
+    }
+
+    /**
+     * Return a stream with all row indices
+     *
+     * @return A {@link IntStream} of row indices
+     */
+    public IntStream rowIndexStream() {
+        return IntStream.range(0, getRowDimension());
+    }
+
+    public List<Integer> getOutputsIndices() {
+        return columnIndexStream().filter(i -> !metadata.inputs.get(i)).boxed().collect(Collectors.toList());
+    }
+
+    /**
+     * Set a column's values.
+     * If the row is non-existing or the row's dimensions do not match, it will throw an {@link IllegalArgumentException}.
+     *
+     * @param column The column to set.
+     * @param values The {@link List} of {@link Value} to set.
+     */
+    public void setColumn(int column, List<Value> values) {
+        validateColumnIndex(column);
+
+        if (this.getRowDimension() != values.size()) {
+            throw new IllegalArgumentException("Invalid data size. Got " + values.size() + " elements for " + this.getRowDimension() + " rows.");
+        }
+        this.data.set(column, values);
+    }
+
+    /**
+     * Set the {@link Value} at row and column.
+     *
+     * @param row    Row to set the value.
+     * @param column Column to set the value.
+     * @param value  The {@link Value} to set.
+     */
+    public void setValue(int row, int column, Value value) {
+        validateColumnIndex(column);
+        validateRowIndex(row);
+        data.get(column).set(row, value);
+    }
+
+    /**
+     * Get the {@link Value} at row and column.
+     *
+     * @param row    Row to get the value.
+     * @param column Column to get the value.
+     * @return value  The {@link Value}.
+     */
+    public Value getValue(int row, int column) {
+        validateColumnIndex(column);
+        validateRowIndex(row);
+        return data.get(column).get(row);
+    }
+
+    /**
+     * Drop a column from the dataframe.
+     * As when deleting an element for a {@link List}, the right-most column indices will be changed.
+     *
+     * @param column Index of the column to delete.
+     */
+    public void dropColumn(int column) {
+        validateColumnIndex(column);
+        data.remove(column);
+        metadata.remove(column);
+    }
+
+    /**
+     * Drop several columns from the dataframe
+     *
+     * @param columns Indices of the columns to drop
+     */
+    public void dropColumns(int... columns) {
+        Arrays.stream(columns).boxed().sorted(Comparator.reverseOrder()).forEach(this::dropColumn);
+    }
+
+    /**
+     * Drop several columns from the dataframe
+     *
+     * @param columns Indices of the columns to drop
+     */
+    public void dropColumns(List<Integer> columns) {
+        columns.stream().sorted(Comparator.reverseOrder()).forEach(this::dropColumn);
+    }
+
+    /**
+     * Return name of all columns
+     *
+     * @return A {@link List} with the column names
+     */
+    public List<String> getColumnNames() {
+        return metadata.names;
+    }
+
+    /**
+     * Return name of specified columns
+     *
+     * @return A {@link List} with the column names
+     */
+    public List<String> getColumnNames(List<Integer> indices) {
+        return indices.stream().map(metadata.names::get).collect(Collectors.toList());
+    }
+
+    /**
+     * Return the number of outputs.
+     *
+     * @return The number of outputs.
+     */
+    public int getOutputsCount() {
+        if (data.isEmpty()) {
+            return 0;
+        } else {
+            return (int) columnIndexStream().filter(i -> !metadata.inputs.get(i)).count();
+        }
+    }
+
+    /**
+     * Copy this dataframe as a new one.
+     *
+     * @return A {@link Dataframe}
+     */
+    public Dataframe copy() {
+        final Dataframe dataframe = new Dataframe();
+
+        dataframe.data = this.data.stream().map(ArrayList::new).collect(Collectors.toList());
+        dataframe.metadata = metadata.copy();
+        return dataframe;
+    }
+
+    /**
+     * Return a column as a {@link List} of {@link Feature}.
+     *
+     * @param column The column to get.
+     * @return A {@link List} of {@link Feature}.
+     */
+    public List<Feature> columnAsFeatures(int column) {
+        validateColumnIndex(column);
+
+        final Type type = metadata.types.get(column);
+        if (type.equals(Type.NUMBER)) {
+            return data.get(column).stream().map(v -> FeatureFactory.newNumericalFeature(metadata.names.get(column), (Number) v.getUnderlyingObject(), metadata.domains.get(column))).collect(Collectors.toList());
+        } else if (type.equals(Type.BOOLEAN)) {
+            return data.get(column).stream().map(v -> FeatureFactory.newBooleanFeature(metadata.names.get(column), (Boolean) v.getUnderlyingObject(), metadata.domains.get(column))).collect(Collectors.toList());
+        } else {
+            return new ArrayList<>();
+        }
+    }
+
+    /**
+     * Return a column as a {@link List} of {@link Output}.
+     *
+     * @param column The column to get.
+     * @return A {@link List} of {@link Output}.
+     */
+    public List<Output> columnAsOutputs(int column) {
+        validateColumnIndex(column);
+
+        return data.get(column).stream().map(v -> new Output(metadata.names.get(column), metadata.types.get(column), v, 0.0)).collect(Collectors.toList());
+    }
+
+    /**
+     * Return a {@link Dataframe} with only the selected rows.
+     *
+     * @param rows Rows to include in new {@link Dataframe}.
+     * @return A filtered {@link Dataframe}.
+     */
+    public Dataframe filterByRowIndex(List<Integer> rows) {
+        final Dataframe dataframe = new Dataframe();
+        dataframe.metadata = metadata.copy();
+
+        dataframe.data = columnIndexStream().mapToObj(col -> {
+            final List<Value> column = data.get(col);
+            return rows.stream().map(column::get).collect(Collectors.toList());
+        }).collect(Collectors.toList());
+
+        return dataframe;
+    }
+
+    /**
+     * Return a new {@link Dataframe} for which only the rows where the specified column satisfy the {@link Predicate<Value>}.
+     *
+     * @param column    Column to use for filtering
+     * @param predicate {@link Predicate<Value>} to select rows
+     * @return A new {@link Dataframe}
+     */
+    public Dataframe filterByColumnValue(int column, Predicate<Value> predicate) {
+        validateColumnIndex(column);
+
+        final int rows = getRowDimension();
+        final List<Value> values = data.get(column);
+
+        final List<Integer> rowIndices = IntStream.range(0, rows).filter(i -> predicate.test(values.get(i))).boxed().collect(Collectors.toList());
+
+        return filterByRowIndex(rowIndices);
+    }
+
+    /**
+     * Apply a {@link Function<Value,Value>} to all the values in a column.
+     *
+     * @param column The column to apply the function.
+     * @param fn     {@link Function<Value,Value>} to apply.
+     */
+    public void transformColumn(int column, Function<Value, Value> fn) {
+        validateColumnIndex(column);
+        final List<Value> transformedColumn = data.get(column).stream().map(fn).collect(Collectors.toList());
+        data.set(column, transformedColumn);
+    }
+
+    /**
+     * Sort all rows according to a supplied {@link Comparator} applied to a column.
+     *
+     * @param column     The column to sort by
+     * @param comparator A supplied {@link Comparator}
+     */
+    public void sortRowsByColumn(int column, Comparator<Value> comparator) {
+        validateColumnIndex(column);
+        final List<Value> columnValues = data.get(column);
+        // Calculate sort indices
+        final int[] sortedIndices = rowIndexStream().boxed().sorted((i, j) -> comparator.compare(columnValues.get(i), columnValues.get(j))).mapToInt(n -> n).toArray();
+        // Apply new indices to all columns
+        columnIndexStream().forEach(c -> {
+            final List<Value> columnValuesUnsorted = data.get(c);
+            final List<Value> columnValuesSorted = Arrays.stream(sortedIndices).mapToObj(columnValuesUnsorted::get).collect(Collectors.toList());
+            data.set(c, columnValuesSorted);
+        });
+    }
+
+    /**
+     * Apply a {@link Function<Value,Value>} to all the values in a row.
+     *
+     * @param row Row to apply the function.
+     * @param fn  {@link Function<Value,Value>} to apply.
+     */
+    public void transformRow(int row, Function<Value, Value> fn) {
+        validateRowIndex(row);
+        final List<Value> transformedRow = columnIndexStream().mapToObj(column -> data.get(column).get(row)).map(fn).collect(Collectors.toList());
+        columnIndexStream().forEach(column -> data.get(column).set(row, transformedRow.get(column)));
+    }
+
+    /**
+     * Combine all the {@link Value} in a row into a single one and return it.
+     *
+     * @param row Row to apply the reduce function.
+     * @param fn  Reduce {@link Function<List<Value>,Value>} to apply.
+     * @return Resulting {@link Value}.
+     */
+    public Value reduceRow(int row, Function<List<Value>, Value> fn) {
+        validateRowIndex(row);
+        return fn.apply(getRow(row));
+    }
+
+    /**
+     * Combine all the {@link Value} in all rows into a {@link List} and return it.
+     * Since the result list's dimension is the same as the number of rows, this is equivalent to reducing all columns into a single one.
+     *
+     * @param fn Reduce {@link Function<List<Value>,Value>} to apply.
+     * @return Resulting {@link List} {@link Value}.
+     */
+    public List<Value> reduceRows(Function<List<Value>, Value> fn) {
+        return rowIndexStream().mapToObj(row -> fn.apply(getRow(row))).collect(Collectors.toList());
+    }
+
+    public void addColumn(String name, Type type, List<Value> values) {
+        data.add(new ArrayList<>(values));
+
+        metadata.names.add(name);
+        metadata.types.add(type);
+        metadata.constrained.add(true);
+        metadata.domains.add(EmptyFeatureDomain.create());
+        metadata.inputs.add(false);
+    }
+
+
+    public List<Prediction> asPredictions() {
+        final List<Integer> inputIndices = getInputsIndices();
+        final List<Integer> outputIndices = getOutputsIndices();
+        List<List<Feature>> allInputs = getInputsIndices().stream().map(this::columnAsFeatures).collect(Collectors.toList());
+        List<List<Output>> allOutputs = getOutputsIndices().stream().map(this::columnAsOutputs).collect(Collectors.toList());
+
+        List<Prediction> predictions = new ArrayList<>();
+        for (int row = 0; row < this.getRowDimension(); row++) {
+            List<Feature> features = new ArrayList<>();
+            for (int col = 0; col < inputIndices.size(); col++) {
+                features.add(allInputs.get(col).get(row));
+            }
+            List<Output> outputs = new ArrayList<>();
+            for (int col = 0; col < outputIndices.size(); col++) {
+                outputs.add(allOutputs.get(col).get(row));
+            }
+            PredictionInput input = new PredictionInput(features);
+            PredictionOutput output = new PredictionOutput(outputs);
+            predictions.add(new SimplePrediction(input, output));
+        }
+        return predictions;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder builder = new StringBuilder();
+        builder.append("Dataframe [").append(getRowDimension()).append("x").append(getColumnDimension()).append("]\n");
+        for (int i = 0; i < getColumnDimension(); i++) {
+            builder.append("\tColumn ").append(i).append(" (").append(metadata.names.get(i)).append(")\n");
+            builder.append("\t\tType: ").append(metadata.types.get(i)).append("\n");
+            builder.append("\t\tDomain: ");
+            final FeatureDomain domain = metadata.domains.get(i);
+            if (domain.isEmpty()) {
+                builder.append("(no domain)");
+            } else {
+                builder.append(domain.prettyPrint());
+            }
+            builder.append("\n");
+        }
+        return builder.toString();
+    }
+
+    private class Metadata {
+        private List<String> names = new ArrayList<>();
+        private List<Type> types = new ArrayList<>();
+        private List<Boolean> constrained = new ArrayList<>();
+        private List<FeatureDomain> domains = new ArrayList<>();
+        private List<Boolean> inputs = new ArrayList<>();
+
+        public void remove(int column) {
+            names.remove(column);
+            types.remove(column);
+            constrained.remove(column);
+            domains.remove(column);
+            inputs.remove(column);
+        }
+
+        public Metadata copy() {
+            final Metadata copy = new Metadata();
+            copy.names = new ArrayList<>(this.names);
+            copy.types = new ArrayList<>(this.types);
+            copy.constrained = new ArrayList<>(this.constrained);
+            copy.domains = new ArrayList<>(this.domains);
+            copy.inputs = new ArrayList<>(this.inputs);
+            return copy;
+        }
+
+    }
+}
+

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/model/Dataframe.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/model/Dataframe.java
@@ -175,14 +175,16 @@ public class Dataframe {
     }
 
     private void validateColumnIndex(int i) {
-        if (i < 0 || i >= data.size()) {
-            throw new IllegalArgumentException("Column " + i + " outside dataframe bounds.");
+        final int size = getColumnDimension();
+        if (i < 0 || i >= size) {
+            throw new IllegalArgumentException("Column " + i + " outside dataframe bounds (0, " + size + ").");
         }
     }
 
     private void validateRowIndex(int row) {
-        if (row < 0 || row >= getRowDimension()) {
-            throw new IllegalArgumentException("Row " + row + " outside dataframe bounds.");
+        final int size = getRowDimension();
+        if (row < 0 || row >= size) {
+            throw new IllegalArgumentException("Row " + row + " outside dataframe bounds (0, " + size + ").");
         }
     }
 

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/model/Dataframe.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/model/Dataframe.java
@@ -1,15 +1,15 @@
 package org.kie.trustyai.explainability.model;
 
-import org.kie.trustyai.explainability.model.domain.EmptyFeatureDomain;
-import org.kie.trustyai.explainability.model.domain.FeatureDomain;
-import org.kie.trustyai.explainability.model.domain.NumericalFeatureDomain;
-import org.kie.trustyai.explainability.model.domain.ObjectFeatureDomain;
-
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
+import org.kie.trustyai.explainability.model.domain.EmptyFeatureDomain;
+import org.kie.trustyai.explainability.model.domain.FeatureDomain;
+import org.kie.trustyai.explainability.model.domain.NumericalFeatureDomain;
+import org.kie.trustyai.explainability.model.domain.ObjectFeatureDomain;
 
 public class Dataframe {
 
@@ -206,7 +206,7 @@ public class Dataframe {
      * Set the column's type.
      *
      * @param column The column index
-     * @param type   The column's {@link Type}
+     * @param type The column's {@link Type}
      */
     public void setType(int column, Type type) {
         validateColumnIndex(column);
@@ -375,9 +375,9 @@ public class Dataframe {
     /**
      * Set the {@link Value} at row and column.
      *
-     * @param row    Row to set the value.
+     * @param row Row to set the value.
      * @param column Column to set the value.
-     * @param value  The {@link Value} to set.
+     * @param value The {@link Value} to set.
      */
     public void setValue(int row, int column, Value value) {
         validateColumnIndex(column);
@@ -388,9 +388,9 @@ public class Dataframe {
     /**
      * Get the {@link Value} at row and column.
      *
-     * @param row    Row to get the value.
+     * @param row Row to get the value.
      * @param column Column to get the value.
-     * @return value  The {@link Value}.
+     * @return value The {@link Value}.
      */
     public Value getValue(int row, int column) {
         validateColumnIndex(column);
@@ -483,9 +483,11 @@ public class Dataframe {
 
         final Type type = metadata.types.get(column);
         if (type.equals(Type.NUMBER)) {
-            return data.get(column).stream().map(v -> FeatureFactory.newNumericalFeature(metadata.names.get(column), (Number) v.getUnderlyingObject(), metadata.domains.get(column))).collect(Collectors.toList());
+            return data.get(column).stream().map(v -> FeatureFactory.newNumericalFeature(metadata.names.get(column), (Number) v.getUnderlyingObject(), metadata.domains.get(column)))
+                    .collect(Collectors.toList());
         } else if (type.equals(Type.BOOLEAN)) {
-            return data.get(column).stream().map(v -> FeatureFactory.newBooleanFeature(metadata.names.get(column), (Boolean) v.getUnderlyingObject(), metadata.domains.get(column))).collect(Collectors.toList());
+            return data.get(column).stream().map(v -> FeatureFactory.newBooleanFeature(metadata.names.get(column), (Boolean) v.getUnderlyingObject(), metadata.domains.get(column)))
+                    .collect(Collectors.toList());
         } else {
             return new ArrayList<>();
         }
@@ -524,7 +526,7 @@ public class Dataframe {
     /**
      * Return a new {@link Dataframe} for which only the rows where the specified column satisfy the {@link Predicate<Value>}.
      *
-     * @param column    Column to use for filtering
+     * @param column Column to use for filtering
      * @param predicate {@link Predicate<Value>} to select rows
      * @return A new {@link Dataframe}
      */
@@ -543,7 +545,7 @@ public class Dataframe {
      * Apply a {@link Function<Value,Value>} to all the values in a column.
      *
      * @param column The column to apply the function.
-     * @param fn     {@link Function<Value,Value>} to apply.
+     * @param fn {@link Function<Value,Value>} to apply.
      */
     public void transformColumn(int column, Function<Value, Value> fn) {
         validateColumnIndex(column);
@@ -554,7 +556,7 @@ public class Dataframe {
     /**
      * Sort all rows according to a supplied {@link Comparator} applied to a column.
      *
-     * @param column     The column to sort by
+     * @param column The column to sort by
      * @param comparator A supplied {@link Comparator}
      */
     public void sortRowsByColumn(int column, Comparator<Value> comparator) {
@@ -574,7 +576,7 @@ public class Dataframe {
      * Apply a {@link Function<Value,Value>} to all the values in a row.
      *
      * @param row Row to apply the function.
-     * @param fn  {@link Function<Value,Value>} to apply.
+     * @param fn {@link Function<Value,Value>} to apply.
      */
     public void transformRow(int row, Function<Value, Value> fn) {
         validateRowIndex(row);
@@ -586,7 +588,7 @@ public class Dataframe {
      * Combine all the {@link Value} in a row into a single one and return it.
      *
      * @param row Row to apply the reduce function.
-     * @param fn  Reduce {@link Function<List<Value>,Value>} to apply.
+     * @param fn Reduce {@link Function<List<Value>,Value>} to apply.
      * @return Resulting {@link Value}.
      */
     public Value reduceRow(int row, Function<List<Value>, Value> fn) {
@@ -614,7 +616,6 @@ public class Dataframe {
         metadata.domains.add(EmptyFeatureDomain.create());
         metadata.inputs.add(false);
     }
-
 
     public List<Prediction> asPredictions() {
         final List<Integer> inputIndices = getInputsIndices();
@@ -685,4 +686,3 @@ public class Dataframe {
 
     }
 }
-

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/model/DataframeTest.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/model/DataframeTest.java
@@ -1,0 +1,412 @@
+package org.kie.trustyai.explainability.model;
+
+import org.junit.jupiter.api.Test;
+import org.kie.trustyai.explainability.model.domain.FeatureDomain;
+import org.kie.trustyai.explainability.model.domain.NumericalFeatureDomain;
+import org.kie.trustyai.explainability.model.domain.ObjectFeatureDomain;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DataframeTest {
+
+    private static final int N = 5000;
+
+    public static Dataframe createTestDataframe() {
+
+        final List<Prediction> predictions = new ArrayList<>();
+        for (int i = 0; i < N; i++) {
+            final List<Feature> features = new ArrayList<>();
+            features.add(FeatureFactory.newNumericalFeature("num-1", Math.random() * 100, NumericalFeatureDomain.create(0, 100)));
+            features.add(FeatureFactory.newBooleanFeature("bool-2", new Random().nextBoolean(), ObjectFeatureDomain.create(Set.of(true, false))));
+            features.add(FeatureFactory.newNumericalFeature("num-3", 1000.0 + Math.random() * 20.0));
+            final PredictionInput input = new PredictionInput(features);
+
+            final Output outputA = new Output("pred-1", Type.NUMBER, new Value(Math.random()), 0.0);
+            final PredictionOutput output = new PredictionOutput(List.of(outputA));
+
+            final Prediction prediction = new SimplePrediction(input, output);
+            predictions.add(prediction);
+        }
+        return Dataframe.createFrom(predictions);
+    }
+
+    @Test
+    void createFromPrediction() {
+
+        final Feature featureA = FeatureFactory.newNumericalFeature("A", 10, NumericalFeatureDomain.create(-100, 100));
+        final Feature featureB = FeatureFactory.newBooleanFeature("B", true);
+
+        final PredictionInput input = new PredictionInput(List.of(featureA, featureB));
+
+        final Output outputC = new Output("C", Type.BOOLEAN, new Value(false), 0.0);
+
+        final PredictionOutput output = new PredictionOutput(List.of(outputC));
+
+        final Prediction prediction = new SimplePrediction(input, output);
+
+        final Dataframe df = Dataframe.createFrom(prediction);
+
+        assertEquals(1, df.getRowDimension());
+        assertEquals(3, df.getColumnDimension());
+        assertFalse(df.getDomain(0).isEmpty());
+        assertTrue(df.getDomain(1).isEmpty());
+        assertTrue(df.getDomain(2).isEmpty());
+        assertEquals(Type.NUMBER, df.getType(0));
+        assertEquals(Type.BOOLEAN, df.getType(1));
+        assertEquals(Type.BOOLEAN, df.getType(2));
+
+    }
+
+
+    @Test
+    void getInputDataframe() {
+        final Dataframe df = createTestDataframe();
+
+        assertFalse(df.getOutputsIndices().isEmpty());
+
+        final Dataframe inputDf = df.getInputDataframe();
+
+        assertEquals(3, inputDf.getColumnDimension());
+        assertTrue(inputDf.getOutputsIndices().isEmpty());
+    }
+
+    @Test
+    void setColumnDomain() {
+        final Dataframe df = createTestDataframe();
+        assertTrue(df.getDomain(2).isEmpty());
+        final FeatureDomain domain = NumericalFeatureDomain.create(-100, 1000);
+        df.setColumnDomain(2, domain);
+        assertFalse(df.getDomain(2).isEmpty());
+        assertEquals(df.getDomain(2), domain);
+    }
+
+    @Test
+    void isConstrained() {
+        final Dataframe df = createTestDataframe();
+        assertFalse(df.isConstrained(1));
+        assertTrue(df.isConstrained(2));
+        final FeatureDomain domain = NumericalFeatureDomain.create(-100, 1000);
+        df.setColumnDomain(2, domain);
+        assertFalse(df.isConstrained(2));
+    }
+
+    @Test
+    void getType() {
+        final Dataframe df = createTestDataframe();
+        assertEquals(df.getType(0), Type.NUMBER);
+        assertEquals(df.getType(1), Type.BOOLEAN);
+
+        final List<Value> newValues = IntStream.range(0, N).mapToObj(i -> new Value(Math.random())).collect(Collectors.toList());
+        df.setColumn(1, newValues);
+        df.setType(1, Type.NUMBER);
+
+        assertEquals(df.getType(1), Type.NUMBER);
+    }
+
+    @Test
+    void getDomain() {
+        final Dataframe df = createTestDataframe();
+        assertFalse(df.getDomain(0).isEmpty());
+        assertFalse(df.getDomain(1).isEmpty());
+        assertTrue(df.getDomain(2).isEmpty());
+        final FeatureDomain d1 = NumericalFeatureDomain.create(0, 100);
+        final FeatureDomain d2 = ObjectFeatureDomain.create(Set.of(true, false));
+        assertEquals(df.getDomain(0).getLowerBound(), d1.getLowerBound());
+        assertEquals(df.getDomain(0).getUpperBound(), d1.getUpperBound());
+        assertEquals(df.getDomain(1).getCategories(), d2.getCategories());
+    }
+
+    @Test
+    void recalculateColumnDomain() {
+        final Dataframe df = createTestDataframe();
+
+        final FeatureDomain domain = df.calculateColumnDomain(0);
+
+        assertTrue(df.getColumn(0).stream().allMatch(value -> {
+            double d = value.asNumber();
+            return d >= domain.getLowerBound() && d <= domain.getUpperBound();
+        }));
+
+        df.transformColumn(0, value -> new Value(value.asNumber() * 2.0));
+
+        assertFalse(df.getColumn(0).stream().allMatch(value -> {
+            double d = value.asNumber();
+            return d >= domain.getLowerBound() && d <= domain.getUpperBound();
+        }));
+
+        final FeatureDomain domainNew = df.calculateColumnDomain(0);
+
+        assertTrue(df.getColumn(0).stream().allMatch(value -> {
+            double d = value.asNumber();
+            return d >= domainNew.getLowerBound() && d <= domainNew.getUpperBound();
+        }));
+    }
+
+    @Test
+    void getConstrained() {
+        final Dataframe df = createTestDataframe();
+        assertEquals(List.of(2, 3), df.getConstrained());
+
+        final FeatureDomain domain = NumericalFeatureDomain.create(-100, 1000);
+        df.setColumnDomain(2, domain);
+        assertEquals(List.of(3), df.getConstrained());
+    }
+
+    @Test
+    void getRowDimension() {
+        final Dataframe df = createTestDataframe();
+
+        assertEquals(N, df.getRowDimension());
+    }
+
+    @Test
+    void getColumnDimension() {
+        final Dataframe df = createTestDataframe();
+
+        assertEquals(4, df.getColumnDimension());
+
+        df.dropColumn(0);
+
+        assertEquals(3, df.getColumnDimension());
+
+        df.dropColumns(0, 1, 2);
+
+        assertEquals(0, df.getColumnDimension());
+
+    }
+
+    @Test
+    void getColumn() {
+        final Dataframe df = createTestDataframe();
+
+        final List<Value> column = df.getColumn(0);
+
+        assertEquals(N, column.size());
+        assertTrue(column.stream().allMatch(value -> value.getUnderlyingObject() instanceof Double));
+    }
+
+    @Test
+    void getInputsIndices() {
+        final Dataframe df = createTestDataframe();
+
+        assertEquals(List.of(0, 1, 2), df.getInputsIndices());
+
+        df.dropColumn(1);
+
+        assertEquals(List.of(0, 1), df.getInputsIndices());
+
+        df.dropColumns(2); // output column
+
+        assertEquals(List.of(0, 1), df.getInputsIndices());
+    }
+
+    @Test
+    void getOutputsIndices() {
+        final Dataframe df = createTestDataframe();
+
+        assertEquals(List.of(3), df.getOutputsIndices());
+
+        df.dropColumn(1);
+
+        assertEquals(List.of(2), df.getOutputsIndices());
+
+        df.dropColumns(2); // output column
+
+        assertTrue(df.getOutputsIndices().isEmpty());
+    }
+
+
+    @Test
+    void copy() {
+        final Dataframe original = createTestDataframe();
+        final Dataframe copy = original.copy();
+
+        assertEquals(original.getValue(2500, 0), copy.getValue(2500, 0));
+        assertEquals(original.getDomain(0), copy.getDomain(0));
+
+        copy.setValue(2500, 0, new Value(-999.0));
+        copy.setColumnDomain(0, NumericalFeatureDomain.create(-9999, -999));
+
+        assertNotEquals(original.getValue(2500, 0), copy.getValue(2500, 0));
+        assertNotEquals(original.getDomain(0), copy.getDomain(0));
+
+    }
+
+
+    @Test
+    void filterByRowIndex() {
+        final Dataframe dataframe = createTestDataframe();
+
+        final Dataframe top = dataframe.filterByRowIndex(IntStream.range(0, 100).boxed().collect(Collectors.toList()));
+
+        assertEquals(dataframe.getValue(50, 0), top.getValue(50, 0));
+        assertEquals(100, top.getRowDimension());
+
+        top.setValue(50, 0, new Value(-999));
+        assertNotEquals(dataframe.getValue(50, 0), top.getValue(50, 0));
+    }
+
+    @Test
+    void filterByColumnValue() {
+        final Dataframe dataframe = createTestDataframe();
+
+        assertFalse(dataframe.getColumn(1).stream().map(value -> (Boolean) value.getUnderlyingObject()).allMatch(value -> !value));
+
+        final Dataframe filtered = dataframe.filterByColumnValue(1, value -> value.getUnderlyingObject().equals(false));
+
+        assertTrue(filtered.getRowDimension() < dataframe.getRowDimension());
+
+        assertTrue(filtered.getColumn(1).stream().map(value -> (Boolean) value.getUnderlyingObject()).allMatch(value -> !value));
+
+    }
+
+    @Test
+    void transformColumn() {
+        final Dataframe df = createTestDataframe();
+
+        final double sumBefore = df.getColumn(0).stream().mapToDouble(Value::asNumber).sum();
+
+        df.transformColumn(0, value -> new Value(2.0 * value.asNumber()));
+
+        final double sumAfter = df.getColumn(0).stream().mapToDouble(Value::asNumber).sum();
+
+        assertEquals(sumAfter, 2.0 * sumBefore);
+    }
+
+    @Test
+    void transformRow() {
+
+        final Dataframe df = createTestDataframe();
+
+        List<Value> original = df.getRow(100);
+
+        df.transformRow(100, value -> new Value(value.asNumber() / 2.0));
+
+        assertEquals(original.stream().mapToDouble(Value::asNumber).sum() / 2.0, df.getRow(100).stream().mapToDouble(Value::asNumber).sum());
+    }
+
+
+    @Test
+    void sortRowsByColumn() {
+        final Dataframe original = createTestDataframe();
+        final Dataframe toSort = original.copy();
+        final int column = 0;
+
+        toSort.sortRowsByColumn(column, Comparator.comparingDouble(Value::asNumber));
+
+        assertNotEquals(original.getColumn(column), toSort.getColumn(column));
+        assertEquals(5000, toSort.getRowDimension());
+        assertEquals(4, toSort.getColumnDimension());
+        assertEquals(original.getColumn(column).stream().sorted(Comparator.comparingDouble(Value::asNumber)).collect(Collectors.toList()), toSort.getColumn(column));
+    }
+
+    @Test
+    void dropColumn() {
+        final Dataframe df = createTestDataframe();
+
+        assertEquals(4, df.getColumnDimension());
+
+        df.dropColumn(2);
+
+        assertEquals(3, df.getColumnDimension());
+
+        assertEquals(List.of("num-1", "bool-2", "pred-1"), df.getColumnNames());
+    }
+
+    @Test
+    void reduceRow() {
+        final Dataframe df = createTestDataframe();
+
+        Function<List<Value>, Value> fn = (List<Value> values) -> new Value(values.stream().mapToDouble(Value::asNumber).sum() * 2.0);
+
+        Value value = df.reduceRow(100, fn);
+
+        assertEquals(fn.apply(df.getRow(100)), value);
+    }
+
+    @Test
+    void reduceRows() {
+        final Dataframe df = createTestDataframe();
+
+        Function<List<Value>, Value> fn = (List<Value> values) -> new Value(values.stream().mapToDouble(Value::asNumber).sum() * 2.0);
+
+        List<Value> value = df.reduceRows(fn);
+
+        assertEquals(fn.apply(df.getRow(100)), value.get(100));
+
+    }
+
+    @Test
+    void addColumn() {
+        final Dataframe df = createTestDataframe();
+
+        df.addColumn("new", Type.NUMBER, IntStream.range(0, N).mapToObj(Value::new).collect(Collectors.toList()));
+
+        assertEquals(5, df.getColumnDimension());
+    }
+
+    @Test
+    void dropColumns() {
+        final Dataframe df = createTestDataframe();
+
+        assertEquals(4, df.getColumnDimension());
+
+        df.dropColumns(1, 2);
+
+        assertEquals(2, df.getColumnDimension());
+
+        assertEquals(List.of("num-1", "pred-1"), df.getColumnNames());
+
+    }
+
+    @Test
+    void getColumnNames() {
+        final Dataframe df = createTestDataframe();
+
+        assertEquals(List.of("num-1", "bool-2", "num-3", "pred-1"), df.getColumnNames());
+
+        df.addColumn("pred-2", Type.NUMBER, IntStream.range(0, N).mapToObj(Value::new).collect(Collectors.toList()));
+
+        assertEquals(List.of("num-1", "bool-2", "num-3", "pred-1", "pred-2"), df.getColumnNames());
+
+    }
+
+    @Test
+    void getOutputsCount() {
+        final Dataframe df = createTestDataframe();
+
+        assertEquals(1, df.getOutputsCount());
+
+        df.dropColumn(3);
+
+        assertEquals(0, df.getOutputsCount());
+    }
+
+    @Test
+    void getInputNames() {
+        final Dataframe df = createTestDataframe();
+
+        assertEquals(List.of("num-1", "bool-2", "num-3"), df.getInputNames());
+    }
+
+    @Test
+    void getOutputNames() {
+        final Dataframe df = createTestDataframe();
+
+        assertEquals(List.of("pred-1"), df.getOutputNames());
+    }
+
+    @Test
+    void testGetColumnNames() {
+        final Dataframe df = createTestDataframe();
+
+        assertEquals(List.of("bool-2", "num-3"), df.getColumnNames(List.of(1, 2)));
+
+    }
+
+}

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/model/DataframeTest.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/model/DataframeTest.java
@@ -1,14 +1,14 @@
 package org.kie.trustyai.explainability.model;
 
-import org.junit.jupiter.api.Test;
-import org.kie.trustyai.explainability.model.domain.FeatureDomain;
-import org.kie.trustyai.explainability.model.domain.NumericalFeatureDomain;
-import org.kie.trustyai.explainability.model.domain.ObjectFeatureDomain;
-
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+import org.kie.trustyai.explainability.model.domain.FeatureDomain;
+import org.kie.trustyai.explainability.model.domain.NumericalFeatureDomain;
+import org.kie.trustyai.explainability.model.domain.ObjectFeatureDomain;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -61,7 +61,6 @@ class DataframeTest {
         assertEquals(Type.BOOLEAN, df.getType(2));
 
     }
-
 
     @Test
     void getInputDataframe() {
@@ -220,7 +219,6 @@ class DataframeTest {
         assertTrue(df.getOutputsIndices().isEmpty());
     }
 
-
     @Test
     void copy() {
         final Dataframe original = createTestDataframe();
@@ -236,7 +234,6 @@ class DataframeTest {
         assertNotEquals(original.getDomain(0), copy.getDomain(0));
 
     }
-
 
     @Test
     void filterByRowIndex() {
@@ -289,7 +286,6 @@ class DataframeTest {
 
         assertEquals(original.stream().mapToDouble(Value::asNumber).sum() / 2.0, df.getRow(100).stream().mapToDouble(Value::asNumber).sum());
     }
-
 
     @Test
     void sortRowsByColumn() {


### PR DESCRIPTION
Initial implementation of a tabular data structure to be used in counterfactual (and potentially fairness metrics) work.
This data structure aims at adding utility methods presently too verbose when manipulating lists of `Prediction`.
Presently the data is stored as `Value`s with associated `Feature` metadata.
For operations dependent on the feature type (e.g. recalculating domains), only numeric and boolean are supported at the moment, but can be trivially extended to other feature types in the future.

> Many thanks for submitting your Pull Request :heart:!
> 
> Please make sure that your PR meets the following requirements:
> 
> - [x] You have read the [contributors guide](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md)
> - [x] Pull Request title is properly formatted: `FAI-XYZ Subject`
> - [x] Pull Request title contains the target branch if not targeting main: `[0.3.x] FAI-XYZ Subject`
> - [x] Pull Request contains link to the JIRA issue
> - [x] Pull Request contains link to any dependent or related Pull Request
> - [x] Pull Request contains description of the issue
> - [x] Pull Request does not include fixes for issues other than the main ticket

