### PR TITLE
Add type hints to request payloads

### DIFF
--- a/explainability-service/README.md
+++ b/explainability-service/README.md
@@ -130,14 +130,23 @@ the corresponding environment variable, e.g.
 Get statistical parity difference at `/metrics/spd`
 
 ```shell
-curl -X POST --location "http://localhost:8080/metrics/spd" \
+curl -X POST --location "http://{{host}}:8080/metrics/spd" \
     -H "Content-Type: application/json" \
     -d "{
           \"protectedAttribute\": \"gender\",
-          \"favorableOutcome\": 1,
+          \"favorableOutcome\": {
+            \"type\": \"INT32\",
+            \"value\": 1
+          },
           \"outcomeName\": \"income\",
-          \"privilegedAttribute\": 1,
-          \"unprivilegedAttribute\": 0
+          \"privilegedAttribute\": {
+            \"type\": \"INT32\",
+            \"value\": 1
+          },
+          \"unprivilegedAttribute\": {
+            \"type\": \"INT32\",
+            \"value\": 0
+          }
         }"
 ```
 
@@ -165,14 +174,23 @@ Content-Type: application/json;charset=UTF-8
 #### Disparate Impact Ratio
 
 ```shell
-curl -X POST --location "http://localhost:8080/metrics/dir" \
+curl -X POST --location "http://{{host}}:8080/metrics/dir" \
     -H "Content-Type: application/json" \
     -d "{
           \"protectedAttribute\": \"gender\",
-          \"favorableOutcome\": 1,
+          \"favorableOutcome\": {
+            \"type\": \"INT32\",
+            \"value\": 1
+          },
           \"outcomeName\": \"income\",
-          \"privilegedAttribute\": 1,
-          \"unprivilegedAttribute\": 0
+          \"privilegedAttribute\": {
+            \"type\": \"INT32\",
+            \"value\": 1
+          },
+          \"unprivilegedAttribute\": {
+            \"type\": \"INT32\",
+            \"value\": 0
+          }
         }"
 ```
 
@@ -197,18 +215,28 @@ Content-Type: application/json;charset=UTF-8
 
 #### Scheduled metrics
 
-In order to generate period measurements for a certain metric, you can send a request to the `/metrics/$METRIC/schedule`.
+In order to generate period measurements for a certain metric, you can send a request to
+the `/metrics/$METRIC/schedule`.
 Looking at the SPD example abov,e if we wanted the metric to be calculated periodically we would request:
 
 ```shell
-curl -X POST --location "http://localhost:8080/metrics/spd/request" \
+curl -X POST --location "http://{{host}}:8080/metrics/spd/request" \
     -H "Content-Type: application/json" \
     -d "{
           \"protectedAttribute\": \"gender\",
-          \"favorableOutcome\": 1,
+          \"favorableOutcome\": {
+            \"type\": \"INT32\",
+            \"value\": 1
+          },
           \"outcomeName\": \"income\",
-          \"privilegedAttribute\": 1,
-          \"unprivilegedAttribute\": 0
+          \"privilegedAttribute\": {
+            \"type\": \"INT32\",
+            \"value\": 1
+          },
+          \"unprivilegedAttribute\": {
+            \"type\": \"INT32\",
+            \"value\": 0
+          }
         }"
 ```
 
@@ -229,7 +257,8 @@ The metrics will now be pushed to Prometheus with the runtime provided `SERVICE_
 e.g. `SERVICE_METRICS_SCHEDULE=10s`)
 which follows the [Quarkus syntax](https://quarkus.io/guides/scheduler-reference).
 
-To stop the periodic calculation you can issue an HTTP `DELETE` request to the `/metrics/$METRIC/request` endpoint, with the id
+To stop the periodic calculation you can issue an HTTP `DELETE` request to the `/metrics/$METRIC/request` endpoint, with
+the id
 of periodic task we want to cancel
 in the payload.
 For instance:

--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/GroupStatisticalParityDifferenceEndpoint.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/GroupStatisticalParityDifferenceEndpoint.java
@@ -3,11 +3,7 @@ package org.kie.trustyai.service.endpoints.metrics;
 import java.util.UUID;
 
 import javax.inject.Inject;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
+import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 

--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/PayloadConverter.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/PayloadConverter.java
@@ -1,23 +1,27 @@
 package org.kie.trustyai.service.payloads;
 
 import org.kie.trustyai.explainability.model.Value;
+import org.kie.trustyai.service.payloads.values.TypedValue;
+import org.kie.trustyai.service.payloads.values.Values;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeType;
+import static org.kie.trustyai.service.payloads.values.Values.*;
 
 public class PayloadConverter {
-    public static Value convertToValue(JsonNode node) {
-        JsonNodeType type = node.getNodeType();
-        if (type == JsonNodeType.BOOLEAN) {
-            return new Value(node.asBoolean());
-        } else if (type == JsonNodeType.NUMBER) {
-            if (node.isInt()) {
-                return new Value(node.asInt());
-            } else {
-                return new Value(node.asDouble());
-            }
-        } else if (type == JsonNodeType.STRING) {
-            return new Value(node.asText());
+    private PayloadConverter() {
+    }
+
+    public static Value convertToValue(TypedValue node) {
+        final Values type = Values.valueOf(node.getType());
+        if (type == BOOL) {
+            return new Value(node.getValue().asBoolean());
+        } else if (type == FLOAT || type == DOUBLE) {
+            return new Value(node.getValue().asDouble());
+        } else if (type == INT32) {
+            return new Value(node.getValue().asInt());
+        } else if (type == INT64) {
+            return new Value(node.getValue().asLong());
+        } else if (type == STRING) {
+            return new Value(node.getValue().asText());
         } else {
             return new Value(null);
         }

--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/spd/GroupStatisticalParityDifferenceRequest.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/spd/GroupStatisticalParityDifferenceRequest.java
@@ -1,17 +1,18 @@
 package org.kie.trustyai.service.payloads.spd;
 
+import org.kie.trustyai.service.payloads.values.TypedValue;
+
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.databind.JsonNode;
 
 @JsonPropertyOrder({ "protected", "favorable" })
 public class GroupStatisticalParityDifferenceRequest {
 
     private String protectedAttribute;
 
-    private JsonNode favorableOutcome;
+    private TypedValue favorableOutcome;
     private String outcomeName;
-    private JsonNode privilegedAttribute;
-    private JsonNode unprivilegedAttribute;
+    private TypedValue privilegedAttribute;
+    private TypedValue unprivilegedAttribute;
 
     public GroupStatisticalParityDifferenceRequest() {
 
@@ -25,11 +26,11 @@ public class GroupStatisticalParityDifferenceRequest {
         this.protectedAttribute = protectedAttribute;
     }
 
-    public JsonNode getFavorableOutcome() {
+    public TypedValue getFavorableOutcome() {
         return favorableOutcome;
     }
 
-    public void setFavorableOutcome(JsonNode favorableOutcome) {
+    public void setFavorableOutcome(TypedValue favorableOutcome) {
         this.favorableOutcome = favorableOutcome;
     }
 
@@ -41,19 +42,19 @@ public class GroupStatisticalParityDifferenceRequest {
         this.outcomeName = outcomeName;
     }
 
-    public JsonNode getPrivilegedAttribute() {
+    public TypedValue getPrivilegedAttribute() {
         return privilegedAttribute;
     }
 
-    public void setPrivilegedAttribute(JsonNode privilegedAttribute) {
+    public void setPrivilegedAttribute(TypedValue privilegedAttribute) {
         this.privilegedAttribute = privilegedAttribute;
     }
 
-    public JsonNode getUnprivilegedAttribute() {
+    public TypedValue getUnprivilegedAttribute() {
         return unprivilegedAttribute;
     }
 
-    public void setUnprivilegedAttribute(JsonNode unprivilegedAttribute) {
+    public void setUnprivilegedAttribute(TypedValue unprivilegedAttribute) {
         this.unprivilegedAttribute = unprivilegedAttribute;
     }
 }

--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/values/TypedValue.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/values/TypedValue.java
@@ -1,0 +1,25 @@
+package org.kie.trustyai.service.payloads.values;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class TypedValue {
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String type;
+
+    public JsonNode getValue() {
+        return value;
+    }
+
+    public void setValue(JsonNode value) {
+        this.value = value;
+    }
+
+    public JsonNode value;
+}

--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/values/Values.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/values/Values.java
@@ -1,0 +1,10 @@
+package org.kie.trustyai.service.payloads.values;
+
+public enum Values {
+    BOOL,
+    FLOAT,
+    DOUBLE,
+    INT32,
+    INT64,
+    STRING
+}

--- a/explainability-service/src/requests/test.http
+++ b/explainability-service/src/requests/test.http
@@ -3,22 +3,19 @@ Content-Type: application/json
 
 {
   "protectedAttribute": "gender",
-  "favorableOutcome": 1,
+  "favorableOutcome": {
+    "type": "INT32",
+    "value": 1
+  },
   "outcomeName": "income",
-  "privilegedAttribute": 1,
-  "unprivilegedAttribute": 0
-}
-
-###
-POST http://{{host}}:8080/metrics/spd/evaluate
-Content-Type: application/json
-
-{
-  "protectedAttribute": "gender",
-  "favorableOutcome": 1,
-  "outcomeName": "income",
-  "privilegedAttribute": 1,
-  "unprivilegedAttribute": 0
+  "privilegedAttribute": {
+    "type": "INT32",
+    "value": 1
+  },
+  "unprivilegedAttribute": {
+    "type": "INT32",
+    "value": 0
+  }
 }
 
 ###
@@ -27,10 +24,19 @@ Content-Type: application/json
 
 {
   "protectedAttribute": "gender",
-  "favorableOutcome": 1,
+  "favorableOutcome": {
+    "type": "INT32",
+    "value": 1
+  },
   "outcomeName": "income",
-  "privilegedAttribute": 1,
-  "unprivilegedAttribute": 0
+  "privilegedAttribute": {
+    "type": "INT32",
+    "value": 1
+  },
+  "unprivilegedAttribute": {
+    "type": "INT32",
+    "value": 0
+  }
 }
 
 ###
@@ -47,10 +53,19 @@ Content-Type: application/json
 
 {
   "protectedAttribute": "gender",
-  "favorableOutcome": 1,
+  "favorableOutcome": {
+    "type": "INT32",
+    "value": 1
+  },
   "outcomeName": "income",
-  "privilegedAttribute": 1,
-  "unprivilegedAttribute": 0
+  "privilegedAttribute": {
+    "type": "INT32",
+    "value": 1
+  },
+  "unprivilegedAttribute": {
+    "type": "INT32",
+    "value": 0
+  }
 }
 
 ###
@@ -59,10 +74,19 @@ Content-Type: application/json
 
 {
   "protectedAttribute": "gender",
-  "favorableOutcome": 1,
+  "favorableOutcome": {
+    "type": "INT32",
+    "value": 1
+  },
   "outcomeName": "income",
-  "privilegedAttribute": 1,
-  "unprivilegedAttribute": 0
+  "privilegedAttribute": {
+    "type": "INT32",
+    "value": 1
+  },
+  "unprivilegedAttribute": {
+    "type": "INT32",
+    "value": 0
+  }
 }
 
 ###
@@ -79,10 +103,19 @@ Content-Type: application/json
 
 {
   "protectedAttribute": "gender",
-  "favorableOutcome": 1,
+  "favorableOutcome": {
+    "type": "INT32",
+    "value": 1
+  },
   "outcomeName": "income",
-  "privilegedAttribute": 1,
-  "unprivilegedAttribute": 0
+  "privilegedAttribute": {
+    "type": "INT32",
+    "value": 1
+  },
+  "unprivilegedAttribute": {
+    "type": "INT32",
+    "value": 0
+  }
 }
 
 ###


### PR DESCRIPTION
This PR adds mandatory type hints to the request payloads to avoid ambigious parsing (eg. `Long` vs `int`).

Closes #62 .
