### PR TITLE
Add custom string representation to TypedValue

### DIFF
--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/values/TypedValue.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/values/TypedValue.java
@@ -3,6 +3,9 @@ package org.kie.trustyai.service.payloads.values;
 import com.fasterxml.jackson.databind.JsonNode;
 
 public class TypedValue {
+    public String type;
+    public JsonNode value;
+
     public String getType() {
         return type;
     }
@@ -10,8 +13,6 @@ public class TypedValue {
     public void setType(String type) {
         this.type = type;
     }
-
-    public String type;
 
     public JsonNode getValue() {
         return value;
@@ -21,5 +22,8 @@ public class TypedValue {
         this.value = value;
     }
 
-    public JsonNode value;
+    @Override
+    public String toString() {
+        return value.toString();
+    }
 }


### PR DESCRIPTION
Prometheus tags were showing `TypedValue` default string representation (`org.kie.trustyai.service.payloads.values.TypedValue@...`.

This PR implements a proper string representation of the value.
Closes #69 