### PR TITLE
Replace jib with plain docker

### DIFF
--- a/explainability-service/README.md
+++ b/explainability-service/README.md
@@ -40,7 +40,7 @@ The first step to run the demos locally, is to build the TrustyAI service contai
 This can be done by running (on `$PROJECT/explainability-service`):
 
 ```shell
-mvn clean install
+mvn clean install -Dquarkus.container-image.build=true
 ```
 
 ### Using data in storage only

--- a/explainability-service/pom.xml
+++ b/explainability-service/pom.xml
@@ -84,7 +84,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-container-image-jib</artifactId>
+            <artifactId>quarkus-container-image-docker</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/explainability-service/src/main/resources/application.properties
+++ b/explainability-service/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 quarkus.http.host=0.0.0.0
-quarkus.container-image.build=true
+quarkus.container-image.build=false
 quarkus.container-image.group=trustyai
 quarkus.container-image.name=trustyai-service
 quarkus.minio.devservices.enabled=false


### PR DESCRIPTION
Replace jib with plain docker and remove automatic image build.
Updated README.md

Closes #72 
