### PR TITLE
Make data health readiness check just informative

### DIFF
--- a/explainability-service/src/main/java/org/kie/trustyai/service/checks/DataAvailableHealthCheck.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/checks/DataAvailableHealthCheck.java
@@ -19,12 +19,11 @@ public class DataAvailableHealthCheck implements HealthCheck {
 
     @Override
     public HealthCheckResponse call() {
-        HealthCheckResponseBuilder responseBuilder = HealthCheckResponse.named("Data available");
-
+        HealthCheckResponseBuilder responseBuilder = HealthCheckResponse.named("Data").up();
         if (storage.get().inputExists() && storage.get().outputExists()) {
-            responseBuilder.up();
+            responseBuilder.withData("available", "data available");
         } else {
-            responseBuilder.down();
+            responseBuilder.withData("available", "data not yet available");
         }
         return responseBuilder.build();
 


### PR DESCRIPTION
This PR makes the data available Readiness health check just informative, in order to allow the service to consume data.

Closes #103 