### PR TITLE
Add support for partial payloads

### DIFF
--- a/explainability-service/demo/compose-generator-memory-multi-model.yaml
+++ b/explainability-service/demo/compose-generator-memory-multi-model.yaml
@@ -33,7 +33,7 @@ services:
       dockerfile: ./generator.Dockerfile
     environment:
       MODEL_NAME: "example-model-1"
-      SERVICE_ENDPOINT: "http://trustyai:8080/consumer/kserve/v2"
+      SERVICE_ENDPOINT: "http://trustyai:8080/consumer/kserve/v2/full"
       PYTHONUNBUFFERED: "1"
   generator-2:
     container_name: generator-2
@@ -43,7 +43,7 @@ services:
       dockerfile: ./generator.Dockerfile
     environment:
       MODEL_NAME: "example-model-2"
-      SERVICE_ENDPOINT: "http://trustyai:8080/consumer/kserve/v2"
+      SERVICE_ENDPOINT: "http://trustyai:8080/consumer/kserve/v2/full"
       PYTHONUNBUFFERED: "1"
   generator-3:
     container_name: generator-3
@@ -53,7 +53,7 @@ services:
       dockerfile: ./generator.Dockerfile
     environment:
       MODEL_NAME: "example-model-3"
-      SERVICE_ENDPOINT: "http://trustyai:8080/consumer/kserve/v2"
+      SERVICE_ENDPOINT: "http://trustyai:8080/consumer/kserve/v2/full"
       INPUT_FILE: "inputs-2.b64"
       OUTPUT_FILE: "outputs-2.b64"
       PYTHONUNBUFFERED: "1"

--- a/explainability-service/demo/compose-generator-pvc-multi-model.yaml
+++ b/explainability-service/demo/compose-generator-pvc-multi-model.yaml
@@ -33,7 +33,7 @@ services:
       dockerfile: ./generator.Dockerfile
     environment:
       MODEL_NAME: "example-model-1"
-      SERVICE_ENDPOINT: "http://trustyai:8080/consumer/kserve/v2"
+      SERVICE_ENDPOINT: "http://trustyai:8080/consumer/kserve/v2/full"
       PYTHONUNBUFFERED: "1"
   generator-2:
     container_name: generator-2
@@ -43,7 +43,7 @@ services:
       dockerfile: ./generator.Dockerfile
     environment:
       MODEL_NAME: "example-model-2"
-      SERVICE_ENDPOINT: "http://trustyai:8080/consumer/kserve/v2"
+      SERVICE_ENDPOINT: "http://trustyai:8080/consumer/kserve/v2/full"
       PYTHONUNBUFFERED: "1"
   generator-3:
     container_name: generator-3
@@ -53,7 +53,7 @@ services:
       dockerfile: ./generator.Dockerfile
     environment:
       MODEL_NAME: "example-model-3"
-      SERVICE_ENDPOINT: "http://trustyai:8080/consumer/kserve/v2"
+      SERVICE_ENDPOINT: "http://trustyai:8080/consumer/kserve/v2/full"
       INPUT_FILE: "inputs-2.b64"
       OUTPUT_FILE: "outputs-2.b64"
       PYTHONUNBUFFERED: "1"

--- a/explainability-service/demo/compose-generator-pvc-single-model.yaml
+++ b/explainability-service/demo/compose-generator-pvc-single-model.yaml
@@ -33,7 +33,7 @@ services:
       dockerfile: ./generator.Dockerfile
     environment:
       MODEL_NAME: "example-model-1"
-      SERVICE_ENDPOINT: "http://trustyai:8080/consumer/kserve/v2"
+      SERVICE_ENDPOINT: "http://trustyai:8080/consumer/kserve/v2/full"
       PYTHONUNBUFFERED: "1"
 
 volumes:

--- a/explainability-service/demo/compose-partial-pvc-single-model.yaml
+++ b/explainability-service/demo/compose-partial-pvc-single-model.yaml
@@ -6,7 +6,7 @@ services:
       - "8080:8080"
     environment:
       SERVICE_KSERVE_TARGET: "localhost"
-      SERVICE_STORAGE_FORMAT: "MEMORY"
+      SERVICE_STORAGE_FORMAT: "PVC"
       SERVICE_DATA_FORMAT: "CSV"
       SERVICE_METRICS_SCHEDULE: "5s"
       SERVICE_BATCH_SIZE: 5000
@@ -27,13 +27,13 @@ services:
       - prom_data:/prometheus
   generator:
     container_name: generator
-    image: trustyai/trustyai-service-generator
+    image: trustyai/trustyai-service-partial
     build:
       context: ./logger
-      dockerfile: ./generator.Dockerfile
+      dockerfile: ./partial.Dockerfile
     environment:
       MODEL_NAME: "example-model-1"
-      SERVICE_ENDPOINT: "http://trustyai:8080/consumer/kserve/v2/full"
+      SERVICE_ENDPOINT: "http://trustyai:8080/consumer/kserve/v2/partial"
       PYTHONUNBUFFERED: "1"
 
 volumes:

--- a/explainability-service/demo/logger/partial.Dockerfile
+++ b/explainability-service/demo/logger/partial.Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.10-slim-buster
+
+WORKDIR /generator
+
+COPY requirements-generator.txt requirements.txt
+
+RUN pip3 install -r requirements.txt
+
+
+COPY inputs.b64 inputs.b64
+COPY inputs-2.b64 inputs-2.b64
+COPY outputs.b64 outputs.b64
+COPY outputs-2.b64 outputs-2.b64
+COPY partial.py app.py
+
+CMD [ "python3", "app.py"]

--- a/explainability-service/demo/logger/partial.py
+++ b/explainability-service/demo/logger/partial.py
@@ -1,0 +1,56 @@
+import os
+import random
+import uuid
+from time import sleep
+
+import requests
+
+SERVICE_ENDPOINT = os.getenv("SERVICE_ENDPOINT")
+MODEL_NAME = os.getenv("MODEL_NAME", "example-model-1")
+INPUT_FILE = os.getenv("INPUT_FILE", 'inputs.b64')
+OUTPUT_FILE = os.getenv("OUTPUT_FILE", 'outputs.b64')
+
+print("Starting the gRPC generator!")
+print(f"Sending requests to {SERVICE_ENDPOINT}")
+
+with open(INPUT_FILE) as f:
+    inputs = f.read().splitlines()
+
+with open(OUTPUT_FILE) as f:
+    outputs = f.read().splitlines()
+
+sleep(10)  # Wait a little for the service
+
+# generate full list of partials
+partial_requests = []
+partial_responses = []
+for i in range(len(inputs)):
+    id = uuid.uuid4()
+    request = {
+        "modelid": MODEL_NAME,
+        "uuid": str(id),
+        "data": inputs[i],
+        "kind": "request"
+    }
+    partial_requests.append(request)
+    response = {
+        "modelid": MODEL_NAME,
+        "uuid": str(id),
+        "data": outputs[i],
+        "kind": "response"
+    }
+    partial_responses.append(response)
+
+request_indices = list(range(len(inputs)))
+random.shuffle(request_indices)
+response_indices = list(range(len(inputs)))
+random.shuffle(response_indices)
+
+for index in range(len(inputs)):
+    print("=" * 80)
+
+    print("Sending data")
+    req = requests.post(SERVICE_ENDPOINT, json=partial_requests[request_indices[index]])
+    sleep(random.randint(1, 3))
+    # use same indices, for now
+    req = requests.post(SERVICE_ENDPOINT, json=partial_responses[request_indices[index]])

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/InferencePayloadReconciler.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/InferencePayloadReconciler.java
@@ -1,0 +1,106 @@
+package org.kie.trustyai.service.data.utils;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.jboss.logging.Logger;
+import org.kie.trustyai.connectors.kserve.v2.PayloadParser;
+import org.kie.trustyai.connectors.kserve.v2.grpc.ModelInferRequest;
+import org.kie.trustyai.connectors.kserve.v2.grpc.ModelInferResponse;
+import org.kie.trustyai.explainability.model.*;
+import org.kie.trustyai.service.data.DataSource;
+import org.kie.trustyai.service.data.exceptions.DataframeCreateException;
+import org.kie.trustyai.service.payloads.consumer.InferencePartialPayload;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+
+@Singleton
+public class InferencePayloadReconciler {
+    private static final Logger LOG = Logger.getLogger(InferencePayloadReconciler.class);
+    private final Map<UUID, InferencePartialPayload> unreconciledInputs = new HashMap<>();
+    private final Map<UUID, InferencePartialPayload> unreconciledOutputs = new HashMap<>();
+
+    @Inject
+    Instance<DataSource> datasource;
+
+    public void addUnreconciledInput(InferencePartialPayload input) {
+        final UUID id = input.getId();
+        unreconciledInputs.put(id, input);
+        if (unreconciledOutputs.containsKey(id)) {
+            save(id, input.getModelId());
+        }
+    }
+
+    public void addUnreconciledOutput(InferencePartialPayload output) {
+        final UUID id = output.getId();
+        unreconciledOutputs.put(id, output);
+        if (unreconciledInputs.containsKey(id)) {
+            save(id, output.getModelId());
+        }
+    }
+
+    private void save(UUID id, String modelId) {
+        final InferencePartialPayload output = unreconciledOutputs.get(id);
+        final InferencePartialPayload input = unreconciledInputs.get(id);
+        LOG.info("Saving: " + output + " and " + input);
+
+        // save
+        final byte[] inputBytes = Base64.getDecoder().decode(input.getData().getBytes());
+        final byte[] outputBytes = Base64.getDecoder().decode(output.getData().getBytes());
+
+        final Prediction prediction = save(inputBytes, outputBytes);
+        final Dataframe dataframe = Dataframe.createFrom(prediction);
+
+        datasource.get().saveDataframe(dataframe, modelId);
+
+        unreconciledInputs.remove(id);
+        unreconciledOutputs.remove(id);
+
+    }
+
+    public Prediction save(byte[] inputs, byte[] outputs) throws DataframeCreateException {
+        final ModelInferRequest input;
+        try {
+            input = ModelInferRequest.parseFrom(inputs);
+        } catch (InvalidProtocolBufferException e) {
+            throw new DataframeCreateException(e.getMessage());
+        }
+        final PredictionInput predictionInput = PayloadParser
+                .inputTensorToPredictionInput(input.getInputs(0), null);
+        LOG.info(predictionInput.getFeatures());
+
+        // Check for dataframe metadata name conflicts
+        if (predictionInput.getFeatures()
+                .stream()
+                .map(Feature::getName)
+                .anyMatch(name -> name.equals(MetadataUtils.ID_FIELD) || name.equals(MetadataUtils.TIMESTAMP_FIELD))) {
+            final String message = "An input feature as a protected name: \"_id\" or \"_timestamp\"";
+            LOG.error(message);
+            throw new DataframeCreateException(message);
+        }
+
+        // enrich with data and id
+        final List<Feature> features = new ArrayList<>();
+        features.add(FeatureFactory.newObjectFeature(MetadataUtils.ID_FIELD, UUID.randomUUID()));
+        features.add(FeatureFactory.newObjectFeature(MetadataUtils.TIMESTAMP_FIELD, LocalDateTime.now()));
+        features.addAll(predictionInput.getFeatures());
+
+        final ModelInferResponse output;
+        try {
+            output = ModelInferResponse.parseFrom(outputs);
+        } catch (InvalidProtocolBufferException e) {
+            throw new DataframeCreateException(e.getMessage());
+        }
+        final PredictionOutput predictionOutput = PayloadParser
+                .outputTensorToPredictionOutput(output.getOutputs(0), null);
+        LOG.info(predictionOutput.getOutputs());
+
+        return new SimplePrediction(new PredictionInput(features), predictionOutput);
+
+    }
+
+}

--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/consumer/ConsumerEndpoint.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/consumer/ConsumerEndpoint.java
@@ -23,11 +23,13 @@ import org.kie.trustyai.connectors.kserve.v2.grpc.ModelInferResponse;
 import org.kie.trustyai.explainability.model.*;
 import org.kie.trustyai.service.data.DataSource;
 import org.kie.trustyai.service.data.exceptions.DataframeCreateException;
-import org.kie.trustyai.service.data.metadata.Metadata;
+import org.kie.trustyai.service.data.utils.InferencePayloadReconciler;
 import org.kie.trustyai.service.data.utils.MetadataUtils;
+import org.kie.trustyai.service.payloads.consumer.InferencePartialPayload;
 import org.kie.trustyai.service.payloads.consumer.InferencePayload;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.InvalidProtocolBufferException;
 
 @Path("/consumer/kserve/v2")
@@ -37,9 +39,13 @@ public class ConsumerEndpoint {
     @Inject
     Instance<DataSource> dataSource;
 
+    @Inject
+    InferencePayloadReconciler reconciler;
+
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.TEXT_PLAIN)
+    @Path("/full")
     public Response consume(InferencePayload request) throws DataframeCreateException {
         LOG.info("Got payload on the consumer");
         try {
@@ -79,27 +85,8 @@ public class ConsumerEndpoint {
             // Save data
             dataSource.get().saveDataframe(dataframe, modelId);
 
-            // Save metadata if it doesn't exist
-            final Metadata metadata;
-            if (!dataSource.get().hasMetadata(modelId)) {
-
-                metadata = new Metadata();
-
-                metadata.setInputSchema(MetadataUtils.getInputSchema(dataframe));
-                metadata.setOutputSchema(MetadataUtils.getOutputSchema(dataframe));
-                metadata.setModelId(modelId);
-
-            } else {
-                try {
-                    metadata = dataSource.get().getMetadata(modelId);
-                } catch (JsonProcessingException e) {
-                    throw new DataframeCreateException("Could not parse metadata for model " + modelId + ": " + e.getMessage());
-                }
-            }
-            metadata.incrementObservations(dataframe.getRowDimension());
-
             try {
-                dataSource.get().saveMetadata(metadata, modelId);
+                dataSource.get().updateMetadataObservations(dataframe.getRowDimension(), modelId);
             } catch (JsonProcessingException e) {
                 LOG.error("Error parsing metadata for model " + modelId + ": " + e.getMessage());
                 return Response.serverError().status(RestResponse.StatusCode.INTERNAL_SERVER_ERROR).build();
@@ -113,4 +100,29 @@ public class ConsumerEndpoint {
         return Response.ok().build();
     }
 
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response consumeInput(InferencePartialPayload request) throws DataframeCreateException {
+
+        final ObjectMapper mapper = new ObjectMapper();
+        final String v;
+        try {
+            v = mapper.writeValueAsString(request);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
+        if (request.getKind().equals("request")) {
+            LOG.info("Got partial input payload on the consumer: " + v);
+            reconciler.addUnreconciledInput(request);
+        } else if (request.getKind().equals("response")) {
+            LOG.info("Got partial output payload on the consumer: " + v);
+            reconciler.addUnreconciledOutput(request);
+        } else {
+            return Response.serverError().entity("Unsupported payload kind: " + request.getKind()).status(Response.Status.BAD_REQUEST).build();
+        }
+
+        return Response.ok().build();
+    }
 }

--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/consumer/InferencePartialPayload.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/consumer/InferencePartialPayload.java
@@ -1,0 +1,49 @@
+package org.kie.trustyai.service.payloads.consumer;
+
+import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class InferencePartialPayload {
+
+    @JsonProperty("modelid")
+    private String modelId;
+    private String data;
+
+    private String kind;
+
+    @JsonProperty("uuid")
+    private UUID id;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getData() {
+        return data;
+    }
+
+    public void setData(String data) {
+        this.data = data;
+    }
+
+    public String getModelId() {
+        return modelId;
+    }
+
+    public void setModelId(String modelId) {
+        this.modelId = modelId;
+    }
+
+    public String getKind() {
+        return this.kind;
+    }
+
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+}

--- a/explainability-service/src/test/java/org/kie/trustyai/service/PayloadProducer.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/PayloadProducer.java
@@ -1,5 +1,8 @@
 package org.kie.trustyai.service;
 
+import java.util.UUID;
+
+import org.kie.trustyai.service.payloads.consumer.InferencePartialPayload;
 import org.kie.trustyai.service.payloads.consumer.InferencePayload;
 
 public class PayloadProducer {
@@ -54,4 +57,23 @@ public class PayloadProducer {
         payload.setModelId(MODEL_B_ID);
         return payload;
     }
+
+    public static InferencePartialPayload getInferencePartialPayloadInput(UUID id, int number) {
+        final InferencePartialPayload payload = new InferencePartialPayload();
+        payload.setData(encondedInputPayloadsA[number]);
+        payload.setId(id);
+        payload.setKind("request");
+        payload.setModelId(MODEL_A_ID);
+        return payload;
+    }
+
+    public static InferencePartialPayload getInferencePartialPayloadOutput(UUID id, int number) {
+        final InferencePartialPayload payload = new InferencePartialPayload();
+        payload.setData(encondedOutputPayloadsA[number]);
+        payload.setId(id);
+        payload.setKind("response");
+        payload.setModelId(MODEL_A_ID);
+        return payload;
+    }
+
 }

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/consumer/ConsumerEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/consumer/ConsumerEndpointTest.java
@@ -1,5 +1,10 @@
 package org.kie.trustyai.service.endpoints.consumer;
 
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
@@ -8,8 +13,10 @@ import org.junit.jupiter.api.*;
 import org.kie.trustyai.explainability.model.Dataframe;
 import org.kie.trustyai.service.BaseTestProfile;
 import org.kie.trustyai.service.PayloadProducer;
+import org.kie.trustyai.service.data.exceptions.DataframeCreateException;
 import org.kie.trustyai.service.mocks.MockDatasource;
 import org.kie.trustyai.service.mocks.MockMemoryStorage;
+import org.kie.trustyai.service.payloads.consumer.InferencePartialPayload;
 import org.kie.trustyai.service.payloads.consumer.InferencePayload;
 
 import io.quarkus.test.common.http.TestHTTPEndpoint;
@@ -20,6 +27,8 @@ import io.restassured.http.ContentType;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.kie.trustyai.service.PayloadProducer.MODEL_A_ID;
 
 @QuarkusTest
 @TestProfile(BaseTestProfile.class)
@@ -44,13 +53,13 @@ class ConsumerEndpointTest {
 
     @Order(1)
     @Test
-    void consumePostCorrectModelA() {
+    void consumeFullPostCorrectModelA() {
         final InferencePayload payload = PayloadProducer.getInferencePayloadA(0);
 
         given()
                 .contentType(ContentType.JSON)
                 .body(payload)
-                .when().post()
+                .when().post("/full")
                 .then()
                 .statusCode(RestResponse.StatusCode.OK)
 
@@ -65,14 +74,14 @@ class ConsumerEndpointTest {
 
     @Order(3)
     @Test
-    void consumePostIncorrectModelA() {
+    void consumeFullPostIncorrectModelA() {
         final InferencePayload payload = PayloadProducer.getInferencePayloadA(1);
         // Mangle inputs
         payload.setInput(payload.getInput().substring(0, 10) + "X" + payload.getInput().substring(11));
         given()
                 .contentType(ContentType.JSON)
                 .body(payload)
-                .when().post()
+                .when().post("/full")
                 .then()
                 .statusCode(RestResponse.StatusCode.INTERNAL_SERVER_ERROR)
 
@@ -81,13 +90,13 @@ class ConsumerEndpointTest {
 
     @Order(2)
     @Test
-    void consumePostCorrectModelB() {
+    void consumeFullPostCorrectModelB() {
         final InferencePayload payload = PayloadProducer.getInferencePayloadB(1);
 
         given()
                 .contentType(ContentType.JSON)
                 .body(payload)
-                .when().post()
+                .when().post("/full")
                 .then()
                 .statusCode(RestResponse.StatusCode.OK)
 
@@ -102,18 +111,116 @@ class ConsumerEndpointTest {
 
     @Order(4)
     @Test
-    void consumePostIncorrectModelB() {
+    void consumeFullPostIncorrectModelB() {
         final InferencePayload payload = PayloadProducer.getInferencePayloadA(1);
         // Mangle inputs
         payload.setInput(payload.getInput().substring(0, 10) + "X" + payload.getInput().substring(11));
         given()
                 .contentType(ContentType.JSON)
                 .body(payload)
-                .when().post()
+                .when().post("/full")
                 .then()
                 .statusCode(RestResponse.StatusCode.INTERNAL_SERVER_ERROR)
 
                 .body(is(""));
+    }
+
+    @Test
+    void consumePartialPostInputsOnly() {
+        final UUID id = UUID.randomUUID();
+        for (int i = 0; i < 5; i++) {
+            final InferencePartialPayload payload = PayloadProducer.getInferencePartialPayloadInput(id, i);
+            given()
+                    .contentType(ContentType.JSON)
+                    .body(payload)
+                    .when().post()
+                    .then()
+                    .statusCode(RestResponse.StatusCode.OK)
+                    .body(is(""));
+        }
+        Exception exception = assertThrows(DataframeCreateException.class, () -> {
+            final Dataframe dataframe = datasource.get().getDataframe(MODEL_A_ID);
+        });
+        assertEquals("Data file not found", exception.getMessage());
+
+    }
+
+    @Test
+    void consumePartialPostOutputsOnly() {
+        final UUID id = UUID.randomUUID();
+        for (int i = 0; i < 5; i++) {
+            final InferencePartialPayload payload = PayloadProducer.getInferencePartialPayloadOutput(id, i);
+            given()
+                    .contentType(ContentType.JSON)
+                    .body(payload)
+                    .when().post()
+                    .then()
+                    .statusCode(RestResponse.StatusCode.OK)
+                    .body(is(""));
+        }
+        Exception exception = assertThrows(DataframeCreateException.class, () -> {
+            final Dataframe dataframe = datasource.get().getDataframe(MODEL_A_ID);
+        });
+        assertEquals("Data file not found", exception.getMessage());
+
+    }
+
+    @Test
+    void consumePartialPostSome() {
+        final List<UUID> ids = IntStream.range(0, 5).mapToObj(i -> UUID.randomUUID()).collect(Collectors.toList());
+        for (int i = 0; i < 5; i++) {
+            final InferencePartialPayload payload = PayloadProducer.getInferencePartialPayloadInput(ids.get(i), i);
+            given()
+                    .contentType(ContentType.JSON)
+                    .body(payload)
+                    .when().post()
+                    .then()
+                    .statusCode(RestResponse.StatusCode.OK)
+                    .body(is(""));
+        }
+        for (int i = 0; i < 3; i++) {
+            final InferencePartialPayload payload = PayloadProducer.getInferencePartialPayloadOutput(ids.get(i), i);
+            given()
+                    .contentType(ContentType.JSON)
+                    .body(payload)
+                    .when().post()
+                    .then()
+                    .statusCode(RestResponse.StatusCode.OK)
+                    .body(is(""));
+        }
+
+        final Dataframe dataframe = datasource.get().getDataframe(MODEL_A_ID);
+        assertEquals(3, dataframe.getRowDimension());
+
+    }
+
+    @Test
+    void consumePartialPostAll() {
+        final List<UUID> ids = IntStream.range(0, 5).mapToObj(i -> UUID.randomUUID()).collect(Collectors.toList());
+        for (int i = 0; i < 5; i++) {
+            final InferencePartialPayload payload = PayloadProducer.getInferencePartialPayloadInput(ids.get(i), i);
+            given()
+                    .contentType(ContentType.JSON)
+                    .body(payload)
+                    .when().post()
+                    .then()
+                    .statusCode(RestResponse.StatusCode.OK)
+                    .body(is(""));
+        }
+        for (int i = 0; i < 5; i++) {
+            final InferencePartialPayload payload = PayloadProducer.getInferencePartialPayloadOutput(ids.get(i), i);
+            given()
+                    .contentType(ContentType.JSON)
+                    .body(payload)
+                    .when().post()
+                    .then()
+                    .statusCode(RestResponse.StatusCode.OK)
+                    .body(is(""));
+        }
+
+        final Dataframe dataframe = datasource.get().getDataframe(MODEL_A_ID);
+        assertEquals(5, dataframe.getRowDimension());
+
     }
 
 }

--- a/explainability-service/src/test/java/org/kie/trustyai/service/scenarios/nodata/ConsumerEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/scenarios/nodata/ConsumerEndpointTest.java
@@ -36,14 +36,14 @@ class ConsumerEndpointTest {
     }
 
     @Test
-    void consumePostCorrectModelA() {
+    void consumeFullPostCorrectModelA() {
         datasource.get().empty();
         final InferencePayload payload = PayloadProducer.getInferencePayloadA(0);
 
         given()
                 .contentType(ContentType.JSON)
                 .body(payload)
-                .when().post()
+                .when().post("/full")
                 .then()
                 .statusCode(RestResponse.StatusCode.OK)
 
@@ -57,7 +57,7 @@ class ConsumerEndpointTest {
     }
 
     @Test
-    void consumePostIncorrectModelA() {
+    void consumeFullPostIncorrectModelA() {
         datasource.get().empty();
         final InferencePayload payload = PayloadProducer.getInferencePayloadA(1);
         // Mangle inputs
@@ -65,7 +65,7 @@ class ConsumerEndpointTest {
         given()
                 .contentType(ContentType.JSON)
                 .body(payload)
-                .when().post()
+                .when().post("/full")
                 .then()
                 .statusCode(RestResponse.StatusCode.INTERNAL_SERVER_ERROR)
 
@@ -73,13 +73,13 @@ class ConsumerEndpointTest {
     }
 
     @Test
-    void consumePostCorrectModelB() {
+    void consumeFullPostCorrectModelB() {
         final InferencePayload payload = PayloadProducer.getInferencePayloadB(0);
 
         given()
                 .contentType(ContentType.JSON)
                 .body(payload)
-                .when().post()
+                .when().post("/full")
                 .then()
                 .statusCode(RestResponse.StatusCode.OK)
 
@@ -93,14 +93,14 @@ class ConsumerEndpointTest {
     }
 
     @Test
-    void consumePostIncorrectModelB() {
+    void consumeFullPostIncorrectModelB() {
         final InferencePayload payload = PayloadProducer.getInferencePayloadA(1);
         // Mangle inputs
         payload.setInput(payload.getInput().substring(0, 10) + "X" + payload.getInput().substring(11));
         given()
                 .contentType(ContentType.JSON)
                 .body(payload)
-                .when().post()
+                .when().post("/full")
                 .then()
                 .statusCode(RestResponse.StatusCode.INTERNAL_SERVER_ERROR)
 


### PR DESCRIPTION
This PR adds support for when the model sends the payload as two separate requests (input and output).