### PR TITLE
FAI-960: Add missing FP32 proto parsers

### DIFF
--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/PayloadParser.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/PayloadParser.java
@@ -25,6 +25,7 @@ public class PayloadParser {
             case INT64:
                 return inputFromContentList(responseInputContents.getInt64ContentsList(), Type.NUMBER, inputNames);
             case FP32:
+                return inputFromContentList(responseInputContents.getFp32ContentsList(), Type.NUMBER, inputNames);
             case FP64:
                 return inputFromContentList(responseInputContents.getFp64ContentsList(), Type.NUMBER, inputNames);
             default:
@@ -48,6 +49,7 @@ public class PayloadParser {
             case INT64:
                 return outputFromContentList(responseOutputContents.getInt64ContentsList(), Type.NUMBER, outputNames);
             case FP32:
+                return outputFromContentList(responseOutputContents.getFp32ContentsList(), Type.NUMBER, outputNames);
             case FP64:
                 return outputFromContentList(responseOutputContents.getFp64ContentsList(), Type.NUMBER, outputNames);
             default:

--- a/explainability-connectors/src/test/java/org/kie/trustyai/connectors/kserve/v2/PayloadParserTest.java
+++ b/explainability-connectors/src/test/java/org/kie/trustyai/connectors/kserve/v2/PayloadParserTest.java
@@ -6,7 +6,9 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 import org.kie.trustyai.connectors.kserve.v2.grpc.InferTensorContents;
+import org.kie.trustyai.connectors.kserve.v2.grpc.ModelInferRequest;
 import org.kie.trustyai.connectors.kserve.v2.grpc.ModelInferResponse;
+import org.kie.trustyai.explainability.model.PredictionInput;
 import org.kie.trustyai.explainability.model.PredictionOutput;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -51,6 +53,94 @@ class PayloadParserTest {
         assertEquals(3, predictionOutput.getOutputs().size());
         for (int i = 0; i < 3; i++) {
             assertEquals(values.get(i), predictionOutput.getOutputs().get(i).getValue().asNumber());
+        }
+    }
+
+    @Test
+    void modelInferResponseToPredictionOutputFp32() {
+
+        final Random random = new Random();
+        final List<Float> values = List.of(random.nextFloat(), random.nextFloat(), random.nextFloat());
+        InferTensorContents.Builder contents = InferTensorContents.newBuilder()
+                .addFp32Contents(values.get(0))
+                .addFp32Contents(values.get(1))
+                .addFp32Contents(values.get(2));
+
+        ModelInferResponse.InferOutputTensor outputTensor = ModelInferResponse.InferOutputTensor.newBuilder()
+                .setDatatype("FP32")
+                .addShape(1).addShape(3).setContents(contents).build();
+
+        PredictionOutput predictionOutput = PayloadParser.outputTensorToPredictionOutput(outputTensor, null);
+
+        assertEquals(3, predictionOutput.getOutputs().size());
+        for (int i = 0; i < 3; i++) {
+            assertEquals(values.get(i), Double.valueOf(predictionOutput.getOutputs().get(i).getValue().asNumber()).floatValue());
+        }
+    }
+
+    @Test
+    void modelInferResponseToPredictionOutputFp64() {
+
+        final Random random = new Random();
+        final List<Double> values = List.of(random.nextDouble(), random.nextDouble(), random.nextDouble());
+        InferTensorContents.Builder contents = InferTensorContents.newBuilder()
+                .addFp64Contents(values.get(0))
+                .addFp64Contents(values.get(1))
+                .addFp64Contents(values.get(2));
+
+        ModelInferResponse.InferOutputTensor outputTensor = ModelInferResponse.InferOutputTensor.newBuilder()
+                .setDatatype("FP64")
+                .addShape(1).addShape(3).setContents(contents).build();
+
+        PredictionOutput predictionOutput = PayloadParser.outputTensorToPredictionOutput(outputTensor, null);
+
+        assertEquals(3, predictionOutput.getOutputs().size());
+        for (int i = 0; i < 3; i++) {
+            assertEquals(values.get(i), predictionOutput.getOutputs().get(i).getValue().asNumber());
+        }
+    }
+
+    @Test
+    void modelInferResponseToPredictionInputFp32() {
+
+        final Random random = new Random();
+        final List<Float> values = List.of(random.nextFloat(), random.nextFloat(), random.nextFloat());
+        InferTensorContents.Builder contents = InferTensorContents.newBuilder()
+                .addFp32Contents(values.get(0))
+                .addFp32Contents(values.get(1))
+                .addFp32Contents(values.get(2));
+
+        ModelInferRequest.InferInputTensor tensor = ModelInferRequest.InferInputTensor.newBuilder()
+                .setDatatype("FP32")
+                .addShape(1).addShape(3).setContents(contents).build();
+
+        PredictionInput predictionInput = PayloadParser.inputTensorToPredictionInput(tensor, null);
+
+        assertEquals(3, predictionInput.getFeatures().size());
+        for (int i = 0; i < 3; i++) {
+            assertEquals(values.get(i), Double.valueOf(predictionInput.getFeatures().get(i).getValue().asNumber()).floatValue());
+        }
+    }
+
+    @Test
+    void modelInferResponseToPredictionInputFp64() {
+
+        final Random random = new Random();
+        final List<Double> values = List.of(random.nextDouble(), random.nextDouble(), random.nextDouble());
+        InferTensorContents.Builder contents = InferTensorContents.newBuilder()
+                .addFp64Contents(values.get(0))
+                .addFp64Contents(values.get(1))
+                .addFp64Contents(values.get(2));
+
+        ModelInferRequest.InferInputTensor tensor = ModelInferRequest.InferInputTensor.newBuilder()
+                .setDatatype("FP64")
+                .addShape(1).addShape(3).setContents(contents).build();
+
+        PredictionInput predictionInput = PayloadParser.inputTensorToPredictionInput(tensor, null);
+
+        assertEquals(3, predictionInput.getFeatures().size());
+        for (int i = 0; i < 3; i++) {
+            assertEquals(values.get(i), predictionInput.getFeatures().get(i).getValue().asNumber());
         }
     }
 }


### PR DESCRIPTION
[FAI-960](https://issues.redhat.com/browse/FAI-960): 

This PR adds missing FP32 parsers for KServe v2 gRPC payloads.

> Many thanks for submitting your Pull Request :heart:!
> 
> Please make sure that your PR meets the following requirements:
> 
> - [x] You have read the [contributors guide](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md)
> - [x] Pull Request title is properly formatted: `FAI-XYZ Subject`
> - [x] Pull Request title contains the target branch if not targeting main: `[0.3.x] FAI-XYZ Subject`
> - [x] Pull Request contains link to the JIRA issue
> - [x] Pull Request contains link to any dependent or related Pull Request
> - [x] Pull Request contains description of the issue
> - [x] Pull Request does not include fixes for issues other than the main ticket

