### PR TITLE
FAI-961: Change InferencePartialPayload id from UUID to string

### DIFF
--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/consumer/InferencePartialPayload.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/consumer/InferencePartialPayload.java
@@ -1,7 +1,5 @@
 package org.kie.trustyai.service.payloads.consumer;
 
-import java.util.UUID;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class InferencePartialPayload {
@@ -12,14 +10,13 @@ public class InferencePartialPayload {
 
     private String kind;
 
-    @JsonProperty("uuid")
-    private UUID id;
+    private String id;
 
-    public UUID getId() {
+    public String getId() {
         return id;
     }
 
-    public void setId(UUID id) {
+    public void setId(String id) {
         this.id = id;
     }
 

--- a/explainability-service/src/test/java/org/kie/trustyai/service/PayloadProducer.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/PayloadProducer.java
@@ -1,7 +1,5 @@
 package org.kie.trustyai.service;
 
-import java.util.UUID;
-
 import org.kie.trustyai.service.payloads.consumer.InferencePartialPayload;
 import org.kie.trustyai.service.payloads.consumer.InferencePayload;
 
@@ -58,7 +56,7 @@ public class PayloadProducer {
         return payload;
     }
 
-    public static InferencePartialPayload getInferencePartialPayloadInput(UUID id, int number) {
+    public static InferencePartialPayload getInferencePartialPayloadInput(String id, int number) {
         final InferencePartialPayload payload = new InferencePartialPayload();
         payload.setData(encondedInputPayloadsA[number]);
         payload.setId(id);
@@ -67,7 +65,7 @@ public class PayloadProducer {
         return payload;
     }
 
-    public static InferencePartialPayload getInferencePartialPayloadOutput(UUID id, int number) {
+    public static InferencePartialPayload getInferencePartialPayloadOutput(String id, int number) {
         final InferencePartialPayload payload = new InferencePartialPayload();
         payload.setData(encondedOutputPayloadsA[number]);
         payload.setId(id);

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/consumer/ConsumerEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/consumer/ConsumerEndpointTest.java
@@ -127,7 +127,7 @@ class ConsumerEndpointTest {
 
     @Test
     void consumePartialPostInputsOnly() {
-        final UUID id = UUID.randomUUID();
+        final String id = UUID.randomUUID().toString();
         for (int i = 0; i < 5; i++) {
             final InferencePartialPayload payload = PayloadProducer.getInferencePartialPayloadInput(id, i);
             given()
@@ -147,7 +147,7 @@ class ConsumerEndpointTest {
 
     @Test
     void consumePartialPostOutputsOnly() {
-        final UUID id = UUID.randomUUID();
+        final String id = UUID.randomUUID().toString();
         for (int i = 0; i < 5; i++) {
             final InferencePartialPayload payload = PayloadProducer.getInferencePartialPayloadOutput(id, i);
             given()
@@ -167,7 +167,7 @@ class ConsumerEndpointTest {
 
     @Test
     void consumePartialPostSome() {
-        final List<UUID> ids = IntStream.range(0, 5).mapToObj(i -> UUID.randomUUID()).collect(Collectors.toList());
+        final List<String> ids = IntStream.range(0, 5).mapToObj(i -> UUID.randomUUID().toString()).collect(Collectors.toList());
         for (int i = 0; i < 5; i++) {
             final InferencePartialPayload payload = PayloadProducer.getInferencePartialPayloadInput(ids.get(i), i);
             given()
@@ -196,7 +196,7 @@ class ConsumerEndpointTest {
 
     @Test
     void consumePartialPostAll() {
-        final List<UUID> ids = IntStream.range(0, 5).mapToObj(i -> UUID.randomUUID()).collect(Collectors.toList());
+        final List<String> ids = IntStream.range(0, 5).mapToObj(i -> UUID.randomUUID().toString()).collect(Collectors.toList());
         for (int i = 0; i < 5; i++) {
             final InferencePartialPayload payload = PayloadProducer.getInferencePartialPayloadInput(ids.get(i), i);
             given()


### PR DESCRIPTION
[FAI-961](https://issues.redhat.com/browse/FAI-961):

This PR changes the `InferencePartialPayload` id from UUID to a plain string.
This is due to changes in the ModelMesh's upstream payload format.

> Many thanks for submitting your Pull Request :heart:!
> 
> Please make sure that your PR meets the following requirements:
> 
> - [x] You have read the [contributors guide](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md)
> - [x] Pull Request title is properly formatted: `FAI-XYZ Subject`
> - [x] Pull Request title contains the target branch if not targeting main: `[0.3.x] FAI-XYZ Subject`
> - [x] Pull Request contains link to the JIRA issue
> - [x] Pull Request contains link to any dependent or related Pull Request
> - [x] Pull Request contains description of the issue
> - [x] Pull Request does not include fixes for issues other than the main ticket
> 
> 