### PR TITLE
FAI-962: Add memory storage backend concurrent hashmap

### DIFF
--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/storage/MemoryStorage.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/storage/MemoryStorage.java
@@ -19,7 +19,7 @@ import io.quarkus.logging.Log;
 @ApplicationScoped
 public class MemoryStorage extends Storage {
 
-    private final Map<String, String> data = new ConcurrentHashMap<>();
+    protected final Map<String, String> data = new ConcurrentHashMap<>();
     private final String dataFilename;
 
     public MemoryStorage(StorageConfig config) {
@@ -50,14 +50,11 @@ public class MemoryStorage extends Storage {
     }
 
     @Override
-    public synchronized void append(ByteBuffer data, String location) throws StorageWriteException {
-        if (this.data.containsKey(location)) {
-            final String existing = this.data.get(location);
-            this.data.put(location, existing + new String(data.array(), StandardCharsets.UTF_8));
-        } else {
+    public void append(ByteBuffer data, String location) throws StorageWriteException {
+        final String value = this.data.computeIfPresent(location, (key, existing) -> existing + new String(data.array(), StandardCharsets.UTF_8));
+        if (value == null) {
             throw new StorageWriteException("Destination does not exist: " + location);
         }
-
     }
 
     @Override

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/storage/MemoryStorage.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/storage/MemoryStorage.java
@@ -3,8 +3,8 @@ package org.kie.trustyai.service.data.storage;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.enterprise.context.ApplicationScoped;
 
@@ -19,7 +19,7 @@ import io.quarkus.logging.Log;
 @ApplicationScoped
 public class MemoryStorage extends Storage {
 
-    private final Map<String, String> data = new HashMap<>();
+    private final Map<String, String> data = new ConcurrentHashMap<>();
     private final String dataFilename;
 
     public MemoryStorage(StorageConfig config) {
@@ -50,7 +50,7 @@ public class MemoryStorage extends Storage {
     }
 
     @Override
-    public void append(ByteBuffer data, String location) throws StorageWriteException {
+    public synchronized void append(ByteBuffer data, String location) throws StorageWriteException {
         if (this.data.containsKey(location)) {
             final String existing = this.data.get(location);
             this.data.put(location, existing + new String(data.array(), StandardCharsets.UTF_8));

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/consumer/ConsumerEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/consumer/ConsumerEndpointTest.java
@@ -142,7 +142,7 @@ class ConsumerEndpointTest {
         Exception exception = assertThrows(DataframeCreateException.class, () -> {
             final Dataframe dataframe = datasource.get().getDataframe(MODEL_A_ID);
         });
-        assertEquals("Data file not found", exception.getMessage());
+        assertEquals("Data file '" + MODEL_A_ID + "-data.csv' not found", exception.getMessage());
 
     }
 
@@ -162,7 +162,7 @@ class ConsumerEndpointTest {
         Exception exception = assertThrows(DataframeCreateException.class, () -> {
             final Dataframe dataframe = datasource.get().getDataframe(MODEL_A_ID);
         });
-        assertEquals("Data file not found", exception.getMessage());
+        assertEquals("Data file '" + MODEL_A_ID + "-data.csv' not found", exception.getMessage());
 
     }
 

--- a/explainability-service/src/test/java/org/kie/trustyai/service/mocks/MockMemoryStorage.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/mocks/MockMemoryStorage.java
@@ -1,107 +1,24 @@
 package org.kie.trustyai.service.mocks;
 
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.Map;
-
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Alternative;
 
-import org.kie.trustyai.service.data.exceptions.StorageReadException;
-import org.kie.trustyai.service.data.exceptions.StorageWriteException;
-import org.kie.trustyai.service.data.storage.Storage;
+import org.kie.trustyai.service.data.storage.MemoryStorage;
 
-import io.quarkus.logging.Log;
 import io.quarkus.test.Mock;
 
 @Mock
 @Alternative
 @ApplicationScoped
-public class MockMemoryStorage extends Storage {
-
-    private final String dataFilename;
-    private Map<String, String> data = new HashMap<>();
+public class MockMemoryStorage extends MemoryStorage {
 
     public MockMemoryStorage() {
-        this.dataFilename = "data.csv";
-    }
+        super(new MockMemoryStorageConfig());
 
-    @Override
-    public ByteBuffer readData(String modelId) throws StorageReadException {
-        final String key = buildDataPath(modelId).toString();
-        if (data.containsKey(key)) {
-            return ByteBuffer.wrap(data.get(key).getBytes());
-        } else {
-            throw new StorageReadException("Data file not found");
-        }
-
-    }
-
-    @Override
-    public boolean dataExists(String modelId) throws StorageReadException {
-        return data.containsKey(buildDataPath(modelId).toString());
-    }
-
-    @Override
-    public void save(ByteBuffer data, String location) throws StorageWriteException {
-        final String stringData = new String(data.array(), StandardCharsets.UTF_8);
-        Log.info("Saving " + stringData + " to " + location);
-        this.data.put(location, stringData);
-    }
-
-    @Override
-    public void append(ByteBuffer data, String location) throws StorageWriteException {
-        if (this.data.containsKey(location)) {
-            final String existing = this.data.get(location);
-            this.data.put(location, existing + new String(data.array(), StandardCharsets.UTF_8));
-        } else {
-            throw new StorageWriteException("Destination does not exist: " + location);
-        }
-
-    }
-
-    @Override
-    public void appendData(ByteBuffer data, String modelId) throws StorageWriteException {
-        append(data, buildDataPath(modelId).toString());
-    }
-
-    @Override
-    public ByteBuffer read(String location) throws StorageReadException {
-        if (data.containsKey(location)) {
-            return ByteBuffer.wrap(data.get(location).getBytes());
-        } else {
-            throw new StorageReadException("File not found: " + location);
-        }
-
-    }
-
-    @Override
-    public void saveData(ByteBuffer data, String modelId) throws StorageWriteException {
-        save(data, buildDataPath(modelId).toString());
-    }
-
-    @Override
-    public boolean fileExists(String location) throws StorageReadException {
-        return data.containsKey(location);
-    }
-
-    @Override
-    public String getDataFilename(String modelId) {
-        return modelId + "-" + this.dataFilename;
-    }
-
-    @Override
-    public Path buildDataPath(String modelId) {
-        return Path.of(getDataFilename(modelId));
     }
 
     public void emptyStorage() {
-        this.data = new HashMap<>();
+        this.data.clear();
     }
 
-    public void reset() {
-        this.data = new HashMap<>();
-    }
 }

--- a/explainability-service/src/test/java/org/kie/trustyai/service/mocks/MockMemoryStorageConfig.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/mocks/MockMemoryStorageConfig.java
@@ -1,0 +1,15 @@
+package org.kie.trustyai.service.mocks;
+
+import org.kie.trustyai.service.config.storage.StorageConfig;
+
+public class MockMemoryStorageConfig implements StorageConfig {
+    @Override
+    public String dataFilename() {
+        return "data.csv";
+    }
+
+    @Override
+    public String dataFolder() {
+        return "/tmp";
+    }
+}

--- a/explainability-service/src/test/java/org/kie/trustyai/service/scenarios/nodata/StorageTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/scenarios/nodata/StorageTest.java
@@ -1,0 +1,136 @@
+package org.kie.trustyai.service.scenarios.nodata;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.kie.trustyai.service.BaseTestProfile;
+import org.kie.trustyai.service.data.exceptions.StorageReadException;
+import org.kie.trustyai.service.data.exceptions.StorageWriteException;
+import org.kie.trustyai.service.mocks.MockDatasource;
+import org.kie.trustyai.service.mocks.MockMemoryStorage;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+@TestProfile(BaseTestProfile.class)
+class StorageTest {
+
+    private final static String MODEL_ID = "non-existing-model";
+    @Inject
+    Instance<MockMemoryStorage> storage;
+    @Inject
+    Instance<MockDatasource> datasource;
+
+    @BeforeEach
+    void emptyStorage() {
+        datasource.get().empty();
+    }
+
+    @Test
+    void getData() {
+        Exception exception = assertThrows(StorageReadException.class, () -> {
+            storage.get().getData(MODEL_ID);
+        });
+        assertEquals("Data file not found", exception.getMessage());
+
+    }
+
+    @Test
+    void dataExists() {
+        assertFalse(storage.get().dataExists(MODEL_ID));
+        storage.get().saveData(ByteBuffer.wrap("data".getBytes()), MODEL_ID);
+        assertTrue(storage.get().dataExists(MODEL_ID));
+    }
+
+    @Test
+    void save() {
+        final String filename = "foobar";
+        // Check file does not yet exist
+        assertFalse(storage.get().fileExists(filename));
+        final ByteBuffer byteBuffer = ByteBuffer.wrap("data".getBytes());
+        // Save file
+        storage.get().save(byteBuffer, filename);
+        // Check file exists
+        assertTrue(storage.get().fileExists(filename));
+    }
+
+    @Test
+    void append() {
+        final String filename = "foobar";
+        final ByteBuffer byteBuffer = ByteBuffer.wrap("data".getBytes());
+        // Append to yet non-existing file
+        Exception exception = assertThrows(StorageWriteException.class, () -> {
+            storage.get().append(byteBuffer, filename);
+        });
+        assertEquals("Destination does not exist: " + filename, exception.getMessage());
+        // Save file
+        storage.get().save(byteBuffer, filename);
+        // Append
+        storage.get().append(ByteBuffer.wrap(" and more".getBytes()), filename);
+        // Check file exists
+        assertTrue(storage.get().fileExists(filename));
+
+        final ByteBuffer result = storage.get().read(filename);
+        assertEquals("data and more", new String(result.array(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void appendData() {
+        final ByteBuffer byteBuffer = ByteBuffer.wrap("data".getBytes());
+        // Append to yet non-existing data file
+        Exception exception = assertThrows(StorageWriteException.class, () -> {
+            storage.get().appendData(byteBuffer, MODEL_ID);
+        });
+        assertEquals("Destination does not exist: " + MODEL_ID + "-data.csv", exception.getMessage());
+        // Save file
+        storage.get().saveData(byteBuffer, MODEL_ID);
+        // Append
+        storage.get().appendData(ByteBuffer.wrap(" and more".getBytes()), MODEL_ID);
+        // Check file exists
+        assertTrue(storage.get().dataExists(MODEL_ID));
+
+        final ByteBuffer result = storage.get().getData(MODEL_ID);
+        assertEquals("data and more", new String(result.array(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void read() {
+        final String filename = "foobar";
+        // Read from yet non-existing file
+        Exception exception = assertThrows(StorageReadException.class, () -> {
+            storage.get().read(filename);
+        });
+        assertEquals("File not found: " + filename, exception.getMessage());
+        storage.get().save(ByteBuffer.wrap("data".getBytes()), filename);
+        final ByteBuffer result = storage.get().read(filename);
+        assertEquals("data", new String(result.array(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void saveData() {
+        // Check data does not yet exist
+        assertFalse(storage.get().dataExists(MODEL_ID));
+        final ByteBuffer byteBuffer = ByteBuffer.wrap("data".getBytes());
+        // Save data
+        storage.get().saveData(byteBuffer, MODEL_ID);
+        // Check data exists
+        assertTrue(storage.get().dataExists(MODEL_ID));
+    }
+
+    @Test
+    void fileExists() {
+        final String filename = "foobar";
+        assertFalse(storage.get().fileExists(filename));
+        storage.get().save(ByteBuffer.wrap("data".getBytes()), filename);
+        assertTrue(storage.get().fileExists(filename));
+    }
+
+}


### PR DESCRIPTION
[FAI-962](https://issues.redhat.com/browse/FAI-962):

- Add unit test for memory storage
- Replace `HashMap` with `ConcurrentHashMap`

> Many thanks for submitting your Pull Request :heart:!
> 
> Please make sure that your PR meets the following requirements:
> 
> - [x] You have read the [contributors guide](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md)
> - [x] Pull Request title is properly formatted: `FAI-XYZ Subject`
> - [x] Pull Request title contains the target branch if not targeting main: `[0.3.x] FAI-XYZ Subject`
> - [x] Pull Request contains link to the JIRA issue
> - [x] Pull Request contains link to any dependent or related Pull Request
> - [x] Pull Request contains description of the issue
> - [x] Pull Request does not include fixes for issues other than the main ticket

