### PR TITLE
FAI-964: Add schema validation for partial payload consumer

### DIFF
--- a/explainability-service/demo/compose-partial-memory-multi-model.yaml
+++ b/explainability-service/demo/compose-partial-memory-multi-model.yaml
@@ -5,7 +5,6 @@ services:
     ports:
       - "8080:8080"
     environment:
-      SERVICE_KSERVE_TARGET: "localhost"
       SERVICE_STORAGE_FORMAT: "MEMORY"
       SERVICE_DATA_FORMAT: "CSV"
       SERVICE_METRICS_SCHEDULE: "5s"
@@ -28,37 +27,24 @@ services:
       - prom_data:/prometheus
   generator-1:
     container_name: generator-1
-    image: trustyai/trustyai-service-generator
+    image: trustyai/trustyai-service-partial
     build:
       context: ./logger
-      dockerfile: ./generator.Dockerfile
+      dockerfile: ./partial.Dockerfile
     environment:
       MODEL_NAME: "example-model-1"
-      SERVICE_ENDPOINT: "http://trustyai:8080/consumer/kserve/v2/full"
+      SERVICE_ENDPOINT: "http://trustyai:8080/consumer/kserve/v2"
       PYTHONUNBUFFERED: "1"
   generator-2:
     container_name: generator-2
-    image: trustyai/trustyai-service-generator
+    image: trustyai/trustyai-service-partial
     build:
       context: ./logger
-      dockerfile: ./generator.Dockerfile
+      dockerfile: ./partial.Dockerfile
     environment:
       MODEL_NAME: "example-model-2"
-      SERVICE_ENDPOINT: "http://trustyai:8080/consumer/kserve/v2/full"
+      SERVICE_ENDPOINT: "http://trustyai:8080/consumer/kserve/v2"
       PYTHONUNBUFFERED: "1"
-  generator-3:
-    container_name: generator-3
-    image: trustyai/trustyai-service-generator
-    build:
-      context: ./logger
-      dockerfile: ./generator.Dockerfile
-    environment:
-      MODEL_NAME: "example-model-3"
-      SERVICE_ENDPOINT: "http://trustyai:8080/consumer/kserve/v2/full"
-      INPUT_FILE: "inputs-2.b64"
-      OUTPUT_FILE: "outputs-2.b64"
-      PYTHONUNBUFFERED: "1"
-
 
 volumes:
   prom_data:

--- a/explainability-service/demo/logger/partial.py
+++ b/explainability-service/demo/logger/partial.py
@@ -1,9 +1,8 @@
 import os
 import random
+import requests
 import uuid
 from time import sleep
-
-import requests
 
 SERVICE_ENDPOINT = os.getenv("SERVICE_ENDPOINT")
 MODEL_NAME = os.getenv("MODEL_NAME", "example-model-1")
@@ -28,14 +27,14 @@ for i in range(len(inputs)):
     id = uuid.uuid4()
     request = {
         "modelid": MODEL_NAME,
-        "uuid": str(id),
+        "id": str(id),
         "data": inputs[i],
         "kind": "request"
     }
     partial_requests.append(request)
     response = {
         "modelid": MODEL_NAME,
-        "uuid": str(id),
+        "id": str(id),
         "data": outputs[i],
         "kind": "response"
     }
@@ -47,10 +46,9 @@ response_indices = list(range(len(inputs)))
 random.shuffle(response_indices)
 
 for index in range(len(inputs)):
-    print("=" * 80)
-
-    print("Sending data")
+    print(f"🚀 Sending partial request to {SERVICE_ENDPOINT}")
     req = requests.post(SERVICE_ENDPOINT, json=partial_requests[request_indices[index]])
     sleep(random.randint(1, 3))
     # use same indices, for now
+    print(f"🎲 Sending partial response to {SERVICE_ENDPOINT}")
     req = requests.post(SERVICE_ENDPOINT, json=partial_responses[request_indices[index]])

--- a/explainability-service/dev.sh
+++ b/explainability-service/dev.sh
@@ -8,5 +8,6 @@ export SERVICE_METRICS_SCHEDULE="5s"
 export SERVICE_BATCH_SIZE=5000
 export STORAGE_DATA_FILENAME="income-biased-inputs.csv"
 export STORAGE_DATA_FOLDER="/inputs"
+export LOG_LEVEL="DEBUG"
 
 quarkus dev

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/DataSource.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/DataSource.java
@@ -13,7 +13,9 @@ import org.jboss.logging.Logger;
 import org.kie.trustyai.explainability.model.Dataframe;
 import org.kie.trustyai.service.config.ServiceConfig;
 import org.kie.trustyai.service.data.exceptions.DataframeCreateException;
+import org.kie.trustyai.service.data.exceptions.InvalidSchemaException;
 import org.kie.trustyai.service.data.exceptions.StorageReadException;
+import org.kie.trustyai.service.data.exceptions.StorageWriteException;
 import org.kie.trustyai.service.data.metadata.Metadata;
 import org.kie.trustyai.service.data.parsers.DataParser;
 import org.kie.trustyai.service.data.storage.Storage;
@@ -51,7 +53,7 @@ public class DataSource {
         final Metadata metadata;
         try {
             metadata = getMetadata(modelId);
-        } catch (JsonProcessingException e) {
+        } catch (StorageReadException e) {
             throw new DataframeCreateException("Could not parse metadata: " + e.getMessage());
         }
 
@@ -67,46 +69,76 @@ public class DataSource {
         }
     }
 
-    public void saveDataframe(Dataframe dataframe, String modelId) {
+    public void saveDataframe(final Dataframe dataframe, final String modelId) throws InvalidSchemaException {
 
         // Add to known models
         this.knownModels.add(modelId);
 
-        if (!storage.get().dataExists(modelId)) {
-            if (!hasMetadata(modelId)) {
-                final Metadata metadata = new Metadata();
-                metadata.setInputSchema(MetadataUtils.getInputSchema(dataframe));
-                metadata.setOutputSchema(MetadataUtils.getOutputSchema(dataframe));
-                metadata.setModelId(modelId);
+        if (!hasMetadata(modelId)) {
+            // If metadata is not present, create it
+            final Metadata metadata = new Metadata();
+            metadata.setInputSchema(MetadataUtils.getInputSchema(dataframe));
+            metadata.setOutputSchema(MetadataUtils.getOutputSchema(dataframe));
+            metadata.setModelId(modelId);
+            metadata.setObservations(dataframe.getRowDimension());
+            try {
+                saveMetadata(metadata, modelId);
+            } catch (StorageWriteException e) {
+                throw new DataframeCreateException(e.getMessage());
+            }
+        } else {
+            // If metadata is present, just increment number of observations
+            final Metadata metadata = getMetadata(modelId);
+
+            // validate metadata
+            if (metadata.getInputSchema().equals(MetadataUtils.getInputSchema(dataframe)) && metadata.getOutputSchema().equals(MetadataUtils.getOutputSchema(dataframe))) {
+                metadata.incrementObservations(dataframe.getRowDimension());
                 try {
                     saveMetadata(metadata, modelId);
-                } catch (JsonProcessingException e) {
+                } catch (StorageWriteException e) {
                     throw new DataframeCreateException(e.getMessage());
                 }
+            } else {
+                final String message = "Payload schema and stored schema are not the same";
+                LOG.error(message);
+                throw new InvalidSchemaException(message);
             }
+        }
 
+        if (!storage.get().dataExists(modelId)) {
             storage.get().saveData(parser.toByteBuffer(dataframe, false), modelId);
         } else {
             storage.get().appendData(parser.toByteBuffer(dataframe, false), modelId);
         }
+
     }
 
-    public void updateMetadataObservations(int number, String modelId) throws JsonProcessingException {
+    public void updateMetadataObservations(int number, String modelId) {
         final Metadata metadata = getMetadata(modelId);
         metadata.incrementObservations(number);
         saveMetadata(metadata, modelId);
     }
 
-    public void saveMetadata(Metadata metadata, String modelId) throws JsonProcessingException {
+    public void saveMetadata(Metadata metadata, String modelId) throws StorageWriteException {
         final ObjectMapper mapper = new ObjectMapper();
-        final ByteBuffer byteBuffer = ByteBuffer.wrap(mapper.writeValueAsString(metadata).getBytes());
+        final ByteBuffer byteBuffer;
+        try {
+            byteBuffer = ByteBuffer.wrap(mapper.writeValueAsString(metadata).getBytes());
+        } catch (JsonProcessingException e) {
+            throw new StorageWriteException("Could not save metadata: " + e.getMessage());
+        }
         storage.get().save(byteBuffer, modelId + "-" + METADATA_FILENAME);
     }
 
-    public Metadata getMetadata(String modelId) throws StorageReadException, JsonProcessingException {
+    public Metadata getMetadata(String modelId) throws StorageReadException {
         final ObjectMapper mapper = new ObjectMapper();
         final ByteBuffer metadataBytes = storage.get().read(modelId + "-" + METADATA_FILENAME);
-        return mapper.readValue(new String(metadataBytes.array(), StandardCharsets.UTF_8), Metadata.class);
+        try {
+            return mapper.readValue(new String(metadataBytes.array(), StandardCharsets.UTF_8), Metadata.class);
+        } catch (JsonProcessingException e) {
+            LOG.error("Could not parse metadata: " + e.getMessage());
+            throw new StorageReadException(e.getMessage());
+        }
 
     }
 

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/exceptions/InvalidSchemaException.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/exceptions/InvalidSchemaException.java
@@ -1,0 +1,7 @@
+package org.kie.trustyai.service.data.exceptions;
+
+public class InvalidSchemaException extends RuntimeException {
+    public InvalidSchemaException(String errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/metadata/Metadata.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/metadata/Metadata.java
@@ -1,14 +1,11 @@
 package org.kie.trustyai.service.data.metadata;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.kie.trustyai.service.payloads.service.SchemaItem;
+import org.kie.trustyai.service.payloads.service.Schema;
 
 public class Metadata {
 
-    private List<SchemaItem> inputSchema = new ArrayList<>();
-    private List<SchemaItem> outputSchema = new ArrayList<>();
+    private Schema inputSchema = new Schema();
+    private Schema outputSchema = new Schema();
 
     private int observations = 0;
 
@@ -18,19 +15,19 @@ public class Metadata {
 
     }
 
-    public List<SchemaItem> getOutputSchema() {
+    public Schema getOutputSchema() {
         return outputSchema;
     }
 
-    public void setOutputSchema(List<SchemaItem> outputSchema) {
+    public void setOutputSchema(Schema outputSchema) {
         this.outputSchema = outputSchema;
     }
 
-    public List<SchemaItem> getInputSchema() {
+    public Schema getInputSchema() {
         return inputSchema;
     }
 
-    public void setInputSchema(List<SchemaItem> inputSchema) {
+    public void setInputSchema(Schema inputSchema) {
         this.inputSchema = inputSchema;
     }
 

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/CSVUtils.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/CSVUtils.java
@@ -23,11 +23,11 @@ public class CSVUtils {
     public static List<Prediction> parse(String in, Metadata metadata) throws IOException {
         CSVParser parser = CSVFormat.DEFAULT.parse(new StringReader(in));
 
-        final List<Integer> inputIndices = metadata.getInputSchema()
+        final List<Integer> inputIndices = metadata.getInputSchema().getItems()
                 .stream()
                 .map(SchemaItem::getIndex)
                 .collect(Collectors.toList());
-        final List<Integer> outputIndices = metadata.getOutputSchema()
+        final List<Integer> outputIndices = metadata.getOutputSchema().getItems()
                 .stream()
                 .map(SchemaItem::getIndex)
                 .collect(Collectors.toList());
@@ -35,7 +35,7 @@ public class CSVUtils {
         return parser.stream().map(entry -> {
 
             final List<Feature> inputFeatures = IntStream.range(0, inputIndices.size()).mapToObj(index -> {
-                final SchemaItem schemaItem = metadata.getInputSchema().get(index);
+                final SchemaItem schemaItem = metadata.getInputSchema().getItems().get(index);
                 final int inputIndex = schemaItem.getIndex();
                 final String name = schemaItem.getName();
                 final String valueString = entry.get(inputIndex);
@@ -54,7 +54,7 @@ public class CSVUtils {
             }).collect(Collectors.toList());
 
             final List<Output> outputs = IntStream.range(0, outputIndices.size()).mapToObj(index -> {
-                final SchemaItem schemaItem = metadata.getOutputSchema().get(index);
+                final SchemaItem schemaItem = metadata.getOutputSchema().getItems().get(index);
                 final int inputIndex = schemaItem.getIndex();
                 final String name = schemaItem.getName();
                 final DataType vtypes = schemaItem.getType();

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/MetadataUtils.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/MetadataUtils.java
@@ -1,10 +1,10 @@
 package org.kie.trustyai.service.data.utils;
 
-import java.util.List;
 import java.util.stream.Collectors;
 
 import org.kie.trustyai.explainability.model.Dataframe;
 import org.kie.trustyai.explainability.model.Value;
+import org.kie.trustyai.service.payloads.service.Schema;
 import org.kie.trustyai.service.payloads.service.SchemaItem;
 import org.kie.trustyai.service.payloads.values.DataType;
 
@@ -36,17 +36,17 @@ public class MetadataUtils {
         return schemaItem;
     }
 
-    public static List<SchemaItem> getInputSchema(Dataframe dataframe) {
-        return dataframe
+    public static Schema getInputSchema(Dataframe dataframe) {
+        return Schema.from(dataframe
                 .getInputsIndices()
                 .stream()
                 .filter(i -> !dataframe.getColumnNames().get(i).equals(ID_FIELD))
                 .filter(i -> !dataframe.getColumnNames().get(i).equals(TIMESTAMP_FIELD))
-                .map(i -> extractRowSchema(dataframe, i)).collect(Collectors.toList());
+                .map(i -> extractRowSchema(dataframe, i)).collect(Collectors.toList()));
     }
 
-    public static List<SchemaItem> getOutputSchema(Dataframe dataframe) {
-        return dataframe.getOutputsIndices().stream().map(i -> extractRowSchema(dataframe, i)).collect(Collectors.toList());
+    public static Schema getOutputSchema(Dataframe dataframe) {
+        return Schema.from(dataframe.getOutputsIndices().stream().map(i -> extractRowSchema(dataframe, i)).collect(Collectors.toList()));
     }
 
 }

--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/consumer/ConsumerEndpoint.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/consumer/ConsumerEndpoint.java
@@ -1,10 +1,6 @@
 package org.kie.trustyai.service.endpoints.consumer;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.Base64;
-import java.util.List;
-import java.util.UUID;
 
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
@@ -17,20 +13,16 @@ import javax.ws.rs.core.Response;
 
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.RestResponse;
-import org.kie.trustyai.connectors.kserve.v2.PayloadParser;
-import org.kie.trustyai.connectors.kserve.v2.grpc.ModelInferRequest;
-import org.kie.trustyai.connectors.kserve.v2.grpc.ModelInferResponse;
-import org.kie.trustyai.explainability.model.*;
+import org.kie.trustyai.explainability.model.Dataframe;
+import org.kie.trustyai.explainability.model.Prediction;
 import org.kie.trustyai.service.data.DataSource;
 import org.kie.trustyai.service.data.exceptions.DataframeCreateException;
+import org.kie.trustyai.service.data.exceptions.InvalidSchemaException;
+import org.kie.trustyai.service.data.exceptions.StorageWriteException;
 import org.kie.trustyai.service.data.utils.InferencePayloadReconciler;
-import org.kie.trustyai.service.data.utils.MetadataUtils;
 import org.kie.trustyai.service.payloads.consumer.InferencePartialPayload;
 import org.kie.trustyai.service.payloads.consumer.InferencePayload;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.protobuf.InvalidProtocolBufferException;
+import org.kie.trustyai.service.payloads.consumer.PartialKind;
 
 @Path("/consumer/kserve/v2")
 public class ConsumerEndpoint {
@@ -47,53 +39,30 @@ public class ConsumerEndpoint {
     @Produces(MediaType.TEXT_PLAIN)
     @Path("/full")
     public Response consume(InferencePayload request) throws DataframeCreateException {
-        LOG.info("Got payload on the consumer");
+        LOG.debug("Got full payload on the consumer");
+
+        final String modelId = request.getModelId();
+
+        final byte[] inputBytes = Base64.getDecoder().decode(request.getInput().getBytes());
+        final byte[] outputBytes = Base64.getDecoder().decode(request.getOutput().getBytes());
+
+        final Prediction prediction;
         try {
-            final String modelId = request.getModelId();
+            prediction = reconciler.payloadToPrediction(inputBytes, outputBytes);
+        } catch (DataframeCreateException e) {
+            LOG.error("Could not create dataframe from payloads: " + e.getMessage());
+            return Response.serverError().status(RestResponse.StatusCode.INTERNAL_SERVER_ERROR).build();
+        }
 
-            final byte[] inputBytes = Base64.getDecoder().decode(request.getInput().getBytes());
-            final ModelInferRequest input = ModelInferRequest.parseFrom(inputBytes);
-            final PredictionInput predictionInput = PayloadParser
-                    .inputTensorToPredictionInput(input.getInputs(0), null);
-            LOG.info(predictionInput.getFeatures());
+        final Dataframe dataframe = Dataframe.createFrom(prediction);
 
-            // Check for dataframe metadata name conflicts
-            if (predictionInput.getFeatures()
-                    .stream()
-                    .map(Feature::getName)
-                    .anyMatch(name -> name.equals(MetadataUtils.ID_FIELD) || name.equals(MetadataUtils.TIMESTAMP_FIELD))) {
-                final String message = "An input feature as a protected name: \"_id\" or \"_timestamp\"";
-                LOG.error(message);
-                return Response.serverError().status(Response.Status.BAD_REQUEST).entity(message).build();
-            }
+        // Save data
+        dataSource.get().saveDataframe(dataframe, modelId);
 
-            // enrich with data and id
-            final List<Feature> features = new ArrayList<>();
-            features.add(FeatureFactory.newObjectFeature(MetadataUtils.ID_FIELD, UUID.randomUUID()));
-            features.add(FeatureFactory.newObjectFeature(MetadataUtils.TIMESTAMP_FIELD, LocalDateTime.now()));
-            features.addAll(predictionInput.getFeatures());
-
-            final byte[] outputBytes = Base64.getDecoder().decode(request.getOutput().getBytes());
-            final ModelInferResponse output = ModelInferResponse.parseFrom(outputBytes);
-            final PredictionOutput predictionOutput = PayloadParser
-                    .outputTensorToPredictionOutput(output.getOutputs(0), null);
-            LOG.info(predictionOutput.getOutputs());
-            final Prediction prediction = new SimplePrediction(new PredictionInput(features), predictionOutput);
-
-            final Dataframe dataframe = Dataframe.createFrom(prediction);
-
-            // Save data
-            dataSource.get().saveDataframe(dataframe, modelId);
-
-            try {
-                dataSource.get().updateMetadataObservations(dataframe.getRowDimension(), modelId);
-            } catch (JsonProcessingException e) {
-                LOG.error("Error parsing metadata for model " + modelId + ": " + e.getMessage());
-                return Response.serverError().status(RestResponse.StatusCode.INTERNAL_SERVER_ERROR).build();
-            }
-
-        } catch (InvalidProtocolBufferException e) {
-            LOG.error("Error parsing protobuf message: " + e.getMessage());
+        try {
+            dataSource.get().updateMetadataObservations(dataframe.getRowDimension(), modelId);
+        } catch (StorageWriteException e) {
+            LOG.error("Error saving metadata for model " + modelId + ": " + e.getMessage());
             return Response.serverError().status(RestResponse.StatusCode.INTERNAL_SERVER_ERROR).build();
         }
 
@@ -105,22 +74,26 @@ public class ConsumerEndpoint {
     @Produces(MediaType.TEXT_PLAIN)
     public Response consumeInput(InferencePartialPayload request) throws DataframeCreateException {
 
-        final ObjectMapper mapper = new ObjectMapper();
-        final String v;
-        try {
-            v = mapper.writeValueAsString(request);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
-
-        if (request.getKind().equals("request")) {
-            LOG.info("Got partial input payload on the consumer: " + v);
-            reconciler.addUnreconciledInput(request);
-        } else if (request.getKind().equals("response")) {
-            LOG.info("Got partial output payload on the consumer: " + v);
-            reconciler.addUnreconciledOutput(request);
+        if (request.getKind().equals(PartialKind.request)) {
+            LOG.info("Received partial input payload from model='" + request.getModelId() + "', id=" + request.getId());
+            try {
+                reconciler.addUnreconciledInput(request);
+            } catch (InvalidSchemaException e) {
+                final String message = "Invalid schema for payload request id=" + request.getId();
+                LOG.error(message);
+                return Response.serverError().entity(message).status(Response.Status.BAD_REQUEST).build();
+            }
+        } else if (request.getKind().equals(PartialKind.response)) {
+            LOG.info("Received partial output payload from model='" + request.getModelId() + "', id=" + request.getId());
+            try {
+                reconciler.addUnreconciledOutput(request);
+            } catch (InvalidSchemaException e) {
+                final String message = "Invalid schema for payload response id=" + request.getId();
+                LOG.error(message);
+                return Response.serverError().entity(message).status(Response.Status.BAD_REQUEST).build();
+            }
         } else {
-            return Response.serverError().entity("Unsupported payload kind: " + request.getKind()).status(Response.Status.BAD_REQUEST).build();
+            return Response.serverError().entity("Unsupported payload kind=" + request.getKind()).status(Response.Status.BAD_REQUEST).build();
         }
 
         return Response.ok().build();

--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/consumer/InferencePartialPayload.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/consumer/InferencePartialPayload.java
@@ -8,7 +8,7 @@ public class InferencePartialPayload {
     private String modelId;
     private String data;
 
-    private String kind;
+    private PartialKind kind;
 
     private String id;
 
@@ -36,11 +36,11 @@ public class InferencePartialPayload {
         this.modelId = modelId;
     }
 
-    public String getKind() {
+    public PartialKind getKind() {
         return this.kind;
     }
 
-    public void setKind(String kind) {
+    public void setKind(PartialKind kind) {
         this.kind = kind;
     }
 }

--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/consumer/PartialKind.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/consumer/PartialKind.java
@@ -1,0 +1,6 @@
+package org.kie.trustyai.service.payloads.consumer;
+
+public enum PartialKind {
+    request,
+    response
+}

--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/service/Schema.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/service/Schema.java
@@ -1,0 +1,40 @@
+package org.kie.trustyai.service.payloads.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class Schema {
+    private final List<SchemaItem> items;
+
+    public Schema() {
+        this.items = new ArrayList<>();
+    }
+
+    public Schema(List<SchemaItem> items) {
+        this.items = items;
+    }
+
+    public static Schema from(List<SchemaItem> items) {
+        return new Schema(items);
+    }
+
+    public List<SchemaItem> getItems() {
+        return items;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        Schema schema = (Schema) o;
+        return items.equals(schema.items);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(items);
+    }
+}

--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/service/SchemaItem.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/service/SchemaItem.java
@@ -1,5 +1,7 @@
 package org.kie.trustyai.service.payloads.service;
 
+import java.util.Objects;
+
 import org.kie.trustyai.service.payloads.values.DataType;
 
 public class SchemaItem {
@@ -39,5 +41,20 @@ public class SchemaItem {
 
     public void setIndex(int index) {
         this.index = index;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        SchemaItem that = (SchemaItem) o;
+        return index == that.index && type == that.type && Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, name, index);
     }
 }

--- a/explainability-service/src/main/resources/application.properties
+++ b/explainability-service/src/main/resources/application.properties
@@ -2,6 +2,7 @@ quarkus.http.host=0.0.0.0
 quarkus.container-image.build=false
 quarkus.container-image.group=trustyai
 quarkus.container-image.name=trustyai-service
+quarkus.log.level=${LOG_LEVEL:INFO}
 quarkus.minio.devservices.enabled=false
 # Kubernetes values
 quarkus.kubernetes.ingress.expose=true

--- a/explainability-service/src/test/java/org/kie/trustyai/service/PayloadProducer.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/PayloadProducer.java
@@ -2,6 +2,7 @@ package org.kie.trustyai.service;
 
 import org.kie.trustyai.service.payloads.consumer.InferencePartialPayload;
 import org.kie.trustyai.service.payloads.consumer.InferencePayload;
+import org.kie.trustyai.service.payloads.consumer.PartialKind;
 
 public class PayloadProducer {
 
@@ -33,11 +34,11 @@ public class PayloadProducer {
     };
 
     private final static String[] encondedOutputPayloadsB = new String[] {
-            "CgdleGFtcGxlGg1teSByZXF1ZXN0IGlkKhkKBm91dHB1dBIFSU5UMzIaAgECKgQSAgAA",
-            "CgdleGFtcGxlGg1teSByZXF1ZXN0IGlkKhkKBm91dHB1dBIFSU5UMzIaAgECKgQSAgIA",
-            "CgdleGFtcGxlGg1teSByZXF1ZXN0IGlkKhkKBm91dHB1dBIFSU5UMzIaAgECKgQSAgIA",
+            "CgdleGFtcGxlGg1teSByZXF1ZXN0IGlkKhkKBm91dHB1dBIFSU5UMzIaAgECKgQSAgAB",
             "CgdleGFtcGxlGg1teSByZXF1ZXN0IGlkKhkKBm91dHB1dBIFSU5UMzIaAgECKgQSAgEA",
-            "CgdleGFtcGxlGg1teSByZXF1ZXN0IGlkKhkKBm91dHB1dBIFSU5UMzIaAgECKgQSAgEA"
+            "CgdleGFtcGxlGg1teSByZXF1ZXN0IGlkKhkKBm91dHB1dBIFSU5UMzIaAgECKgQSAgEA",
+            "CgdleGFtcGxlGg1teSByZXF1ZXN0IGlkKhkKBm91dHB1dBIFSU5UMzIaAgECKgQSAgEB",
+            "CgdleGFtcGxlGg1teSByZXF1ZXN0IGlkKhkKBm91dHB1dBIFSU5UMzIaAgECKgQSAgAA"
     };
 
     public static InferencePayload getInferencePayloadA(int number) {
@@ -60,7 +61,7 @@ public class PayloadProducer {
         final InferencePartialPayload payload = new InferencePartialPayload();
         payload.setData(encondedInputPayloadsA[number]);
         payload.setId(id);
-        payload.setKind("request");
+        payload.setKind(PartialKind.request);
         payload.setModelId(MODEL_A_ID);
         return payload;
     }
@@ -69,7 +70,7 @@ public class PayloadProducer {
         final InferencePartialPayload payload = new InferencePartialPayload();
         payload.setData(encondedOutputPayloadsA[number]);
         payload.setId(id);
-        payload.setKind("response");
+        payload.setKind(PartialKind.response);
         payload.setModelId(MODEL_A_ID);
         return payload;
     }

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/service/ServiceMetadataEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/service/ServiceMetadataEndpointTest.java
@@ -62,14 +62,14 @@ class ServiceMetadataEndpointTest {
         assertEquals(0, serviceMetadata.get(0).getMetrics().scheduledMetadata.dir);
         assertEquals(0, serviceMetadata.get(0).getMetrics().scheduledMetadata.spd);
         assertEquals(2, serviceMetadata.get(0).getData().getObservations());
-        assertFalse(serviceMetadata.get(0).getData().getOutputSchema().isEmpty());
-        assertFalse(serviceMetadata.get(0).getData().getInputSchema().isEmpty());
+        assertFalse(serviceMetadata.get(0).getData().getOutputSchema().getItems().isEmpty());
+        assertFalse(serviceMetadata.get(0).getData().getInputSchema().getItems().isEmpty());
         assertEquals(dataframe.getInputNames()
                 .stream()
                 .filter(name -> !name.equals(MetadataUtils.ID_FIELD))
                 .filter(name -> !name.equals(MetadataUtils.TIMESTAMP_FIELD)).collect(Collectors.toList()),
-                serviceMetadata.get(0).getData().getInputSchema().stream().map(SchemaItem::getName).collect(Collectors.toList()));
-        assertEquals(dataframe.getOutputNames(), serviceMetadata.get(0).getData().getOutputSchema().stream().map(SchemaItem::getName).collect(Collectors.toList()));
+                serviceMetadata.get(0).getData().getInputSchema().getItems().stream().map(SchemaItem::getName).collect(Collectors.toList()));
+        assertEquals(dataframe.getOutputNames(), serviceMetadata.get(0).getData().getOutputSchema().getItems().stream().map(SchemaItem::getName).collect(Collectors.toList()));
     }
 
     @Test
@@ -90,8 +90,8 @@ class ServiceMetadataEndpointTest {
         assertEquals(0, serviceMetadata.get(0).getMetrics().scheduledMetadata.dir);
         assertEquals(0, serviceMetadata.get(0).getMetrics().scheduledMetadata.spd);
         assertEquals(1000, serviceMetadata.get(0).getData().getObservations());
-        assertFalse(serviceMetadata.get(0).getData().getOutputSchema().isEmpty());
-        assertFalse(serviceMetadata.get(0).getData().getInputSchema().isEmpty());
+        assertFalse(serviceMetadata.get(0).getData().getOutputSchema().getItems().isEmpty());
+        assertFalse(serviceMetadata.get(0).getData().getInputSchema().getItems().isEmpty());
     }
 
     @Test

--- a/explainability-service/src/test/java/org/kie/trustyai/service/scenarios/batching/TestBatching.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/scenarios/batching/TestBatching.java
@@ -13,6 +13,7 @@ import org.kie.trustyai.explainability.model.Dataframe;
 import org.kie.trustyai.service.data.metadata.Metadata;
 import org.kie.trustyai.service.data.parsers.CSVParser;
 import org.kie.trustyai.service.data.storage.BatchReader;
+import org.kie.trustyai.service.payloads.service.Schema;
 import org.kie.trustyai.service.payloads.service.SchemaItem;
 import org.kie.trustyai.service.payloads.values.DataType;
 
@@ -37,8 +38,8 @@ class TestBatching {
         List<SchemaItem> inputSchema = IntStream.range(0, s).mapToObj(i -> new SchemaItem(DataType.DOUBLE, inputNames.get(i), i)).collect(Collectors.toList());
         List<SchemaItem> outputSchema = IntStream.range(s, s + outputNames.size()).mapToObj(i -> new SchemaItem(DataType.DOUBLE, outputNames.get(i - s), i)).collect(Collectors.toList());
 
-        metadata.setInputSchema(inputSchema);
-        metadata.setOutputSchema(outputSchema);
+        metadata.setInputSchema(Schema.from(inputSchema));
+        metadata.setOutputSchema(Schema.from(outputSchema));
 
         return metadata;
     }

--- a/explainability-service/src/test/java/org/kie/trustyai/service/scenarios/nodata/StorageTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/scenarios/nodata/StorageTest.java
@@ -1,0 +1,136 @@
+package org.kie.trustyai.service.scenarios.nodata;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.kie.trustyai.service.BaseTestProfile;
+import org.kie.trustyai.service.data.exceptions.StorageReadException;
+import org.kie.trustyai.service.data.exceptions.StorageWriteException;
+import org.kie.trustyai.service.mocks.MockDatasource;
+import org.kie.trustyai.service.mocks.MockMemoryStorage;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+@TestProfile(BaseTestProfile.class)
+class StorageTest {
+
+    private final static String MODEL_ID = "non-existing-model";
+    @Inject
+    Instance<MockMemoryStorage> storage;
+    @Inject
+    Instance<MockDatasource> datasource;
+
+    @BeforeEach
+    void emptyStorage() {
+        datasource.get().empty();
+    }
+
+    @Test
+    void readData() {
+        Exception exception = assertThrows(StorageReadException.class, () -> {
+            storage.get().readData(MODEL_ID);
+        });
+        assertEquals("Data file not found", exception.getMessage());
+
+    }
+
+    @Test
+    void dataExists() {
+        assertFalse(storage.get().dataExists(MODEL_ID));
+        storage.get().saveData(ByteBuffer.wrap("data".getBytes()), MODEL_ID);
+        assertTrue(storage.get().dataExists(MODEL_ID));
+    }
+
+    @Test
+    void save() {
+        final String filename = "foobar";
+        // Check file does not yet exist
+        assertFalse(storage.get().fileExists(filename));
+        final ByteBuffer byteBuffer = ByteBuffer.wrap("data".getBytes());
+        // Save file
+        storage.get().save(byteBuffer, filename);
+        // Check file exists
+        assertTrue(storage.get().fileExists(filename));
+    }
+
+    @Test
+    void append() {
+        final String filename = "foobar";
+        final ByteBuffer byteBuffer = ByteBuffer.wrap("data".getBytes());
+        // Append to yet non-existing file
+        Exception exception = assertThrows(StorageWriteException.class, () -> {
+            storage.get().append(byteBuffer, filename);
+        });
+        assertEquals("Destination does not exist: " + filename, exception.getMessage());
+        // Save file
+        storage.get().save(byteBuffer, filename);
+        // Append
+        storage.get().append(ByteBuffer.wrap(" and more".getBytes()), filename);
+        // Check file exists
+        assertTrue(storage.get().fileExists(filename));
+
+        final ByteBuffer result = storage.get().read(filename);
+        assertEquals("data and more", new String(result.array(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void appendData() {
+        final ByteBuffer byteBuffer = ByteBuffer.wrap("data".getBytes());
+        // Append to yet non-existing data file
+        Exception exception = assertThrows(StorageWriteException.class, () -> {
+            storage.get().appendData(byteBuffer, MODEL_ID);
+        });
+        assertEquals("Destination does not exist: " + MODEL_ID + "-data.csv", exception.getMessage());
+        // Save file
+        storage.get().saveData(byteBuffer, MODEL_ID);
+        // Append
+        storage.get().appendData(ByteBuffer.wrap(" and more".getBytes()), MODEL_ID);
+        // Check file exists
+        assertTrue(storage.get().dataExists(MODEL_ID));
+
+        final ByteBuffer result = storage.get().readData(MODEL_ID);
+        assertEquals("data and more", new String(result.array(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void read() {
+        final String filename = "foobar";
+        // Read from yet non-existing file
+        Exception exception = assertThrows(StorageReadException.class, () -> {
+            storage.get().read(filename);
+        });
+        assertEquals("File not found: " + filename, exception.getMessage());
+        storage.get().save(ByteBuffer.wrap("data".getBytes()), filename);
+        final ByteBuffer result = storage.get().read(filename);
+        assertEquals("data", new String(result.array(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void saveData() {
+        // Check data does not yet exist
+        assertFalse(storage.get().dataExists(MODEL_ID));
+        final ByteBuffer byteBuffer = ByteBuffer.wrap("data".getBytes());
+        // Save data
+        storage.get().saveData(byteBuffer, MODEL_ID);
+        // Check data exists
+        assertTrue(storage.get().dataExists(MODEL_ID));
+    }
+
+    @Test
+    void fileExists() {
+        final String filename = "foobar";
+        assertFalse(storage.get().fileExists(filename));
+        storage.get().save(ByteBuffer.wrap("data".getBytes()), filename);
+        assertTrue(storage.get().fileExists(filename));
+    }
+
+}


### PR DESCRIPTION
[FAI-964](https://issues.redhat.com/browse/FAI-964):

This PR adds schema validation for the partial payload consumer.

Once the dataset schema has been established, any attempt to send partial payloads to the consumer endpoint will result in a HTTP 400 error and a error message being logged.

Other changes:
- This PR also introduces setting the service's logging level through a `LOG_LEVEL` environment variable (`INFO` by default).
- A local demo was added for a multi-model, partial inference, memory storage case.
- Inference payload reconciler now uses concurrent hashmaps.
- `Schema` was added as a replacement for a list of `SchemaItem`s. This is mainly to simplify schema comparisons.
- Add unit tests for schema mismatch in consumers

Closes #88 

> Many thanks for submitting your Pull Request :heart:!
> 
> Please make sure that your PR meets the following requirements:
> 
> - [x] You have read the [contributors guide](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md)
> - [x] Pull Request title is properly formatted: `FAI-XYZ Subject`
> - [x] Pull Request title contains the target branch if not targeting main: `[0.3.x] FAI-XYZ Subject`
> - [x] Pull Request contains link to the JIRA issue
> - [x] Pull Request contains link to any dependent or related Pull Request
> - [x] Pull Request contains description of the issue
> - [ ] Pull Request does not include fixes for issues other than the main ticket
> 
> 