### PR TITLE
FAI-968: Add model id to cache keys

### DIFF
--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/cache/DataCacheKeyGen.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/cache/DataCacheKeyGen.java
@@ -31,6 +31,6 @@ public class DataCacheKeyGen implements CacheKeyGenerator {
         final String modelId = (String) methodParams[0];
         LOG.debug("Cache hit for " + modelId + " data");
 
-        return new CompositeCacheKey(storage.get().getLastModified(modelId));
+        return new CompositeCacheKey(modelId, storage.get().getLastModified(modelId));
     }
 }

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/cache/MetricCalculationCacheKeyGen.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/cache/MetricCalculationCacheKeyGen.java
@@ -34,7 +34,8 @@ public class MetricCalculationCacheKeyGen implements CacheKeyGenerator {
     public Object generate(Method method, Object... methodParams) {
 
         final BaseMetricRequest request = (BaseMetricRequest) methodParams[1];
-        LOG.debug("Cache hit for metric for model " + request.getModelId());
-        return new CompositeCacheKey(storage.get().getLastModified(request.getModelId()), request.hashCode());
+        final String modelId = request.getModelId();
+        LOG.debug("Cache hit for metric for model " + modelId);
+        return new CompositeCacheKey(modelId, storage.get().getLastModified(modelId), request.hashCode());
     }
 }


### PR DESCRIPTION
[FAI-968](https://issues.redhat.com/browse/FAI-968):

Cache keys should include the model id.

Example were it could break:
(Before PR)

- `readData(MODEL_A)` -> `key for model A's data = ($model_a_last_modified)`
- `readData(MODEL_B)` -> `key for model A's data = ($model_b_last_modified)`

For, say, model B if (by chance) `$model_a_last_modified==$model_b_last_modified`, but B was updated, we would have the cached result for B.

(After PR)

- `readData(MODEL_A)` -> `key for model A's data = (MODEL_A, $model_a_last_modified)`
- `readData(MODEL_B)` -> `key for model A's data = (MODEL_B, $model_b_last_modified)`

Even if `$model_a_last_modified==$model_b_last_modified`, the keys would be different, since model name is included.



> Many thanks for submitting your Pull Request :heart:!
> 
> Please make sure that your PR meets the following requirements:
> 
> - [x] You have read the [contributors guide](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md)
> - [x] Pull Request title is properly formatted: `FAI-XYZ Subject`
> - [x] Pull Request title contains the target branch if not targeting main: `[0.3.x] FAI-XYZ Subject`
> - [x] Pull Request contains link to the JIRA issue
> - [x] Pull Request contains link to any dependent or related Pull Request
> - [x] Pull Request contains description of the issue
> - [x] Pull Request does not include fixes for issues other than the main ticket
> 
