### PR TITLE
Added ConfigMap Override InitContainer + Prometheus ServiceMonitor

### DIFF
--- a/explainability-service/manifests/deploy.sh
+++ b/explainability-service/manifests/deploy.sh
@@ -1,0 +1,4 @@
+oc delete project $(oc project -q);
+oc new-project $1;
+oc create -f pvc.yaml
+oc apply -f kfdef.yaml

--- a/explainability-service/manifests/opendatahub/base/kustomization.yaml
+++ b/explainability-service/manifests/opendatahub/base/kustomization.yaml
@@ -4,5 +4,6 @@ commonLabels:
   app: trustyai
   app.kubernetes.io/part-of: trustyai
 resources:
-- ../default
-- trustyai-configmap.yaml
+  - ../default
+  - ../servicemonitors
+  - trustyai-configmap.yaml

--- a/explainability-service/manifests/opendatahub/default/trustyai-deployment.yaml
+++ b/explainability-service/manifests/opendatahub/default/trustyai-deployment.yaml
@@ -64,6 +64,26 @@ spec:
         app.kubernetes.io/version: 0.1.0
         app.kubernetes.io/name: trustyai-service
     spec:
+      initContainers:
+        - name: config-map-overrider
+          image: registry.redhat.io/openshift4/ose-cli@sha256:25fef269ac6e7491cb8340119a9b473acbeb53bc6970ad029fdaae59c3d0ca61
+          command: [ "/bin/bash", "-c", "--" ]
+          args:
+            - |
+              # ugly hack: write a configmap that knows its own namespace
+              echo "apiVersion: v1" > /tmp/model-serving-config.yaml
+              echo "kind: ConfigMap" >> /tmp/model-serving-config.yaml
+              echo "metadata:" >> /tmp/model-serving-config.yaml
+              echo "  name: model-serving-config" >> /tmp/model-serving-config.yaml
+              echo "data:" >> /tmp/model-serving-config.yaml
+              echo "  config.yaml: |" >> /tmp/model-serving-config.yaml
+              
+              current_namespace=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+              
+              echo "    payloadProcessors: "http://trustyai-service.$current_namespace/consumer/kserve/v2"" >> /tmp/model-serving-config.yaml
+              cat /tmp/model-serving-config.yaml
+              oc apply -f /tmp/model-serving-config.yaml
+              exit 0
       containers:
         - env:
             - name: STORAGE_DATA_FILENAME
@@ -127,8 +147,44 @@ spec:
             - mountPath: /inputs
               name: volume
               readOnly: false
+      serviceAccountName: trustyai-serviceaccount
       volumes:
         - name: volume
           persistentVolumeClaim:
             claimName: trustyai-service-pvc
             readOnly: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: trustyai-serviceaccount
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: trustyai-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: trustyai-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: trustyai-role
+subjects:
+  - kind: ServiceAccount
+    name: trustyai-serviceaccount

--- a/explainability-service/manifests/opendatahub/servicemonitors/kustomization.yaml
+++ b/explainability-service/manifests/opendatahub/servicemonitors/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - trustyai-metrics.yaml

--- a/explainability-service/manifests/opendatahub/servicemonitors/trustyai-metrics.yaml
+++ b/explainability-service/manifests/opendatahub/servicemonitors/trustyai-metrics.yaml
@@ -16,6 +16,10 @@ spec:
         key: ""
       targetPort: 8080
       scheme: http
+      params:
+        'match[]':
+          - '{__name__= "trusty_spd"}'
+          - '{__name__= "trusty_dir"}'
   selector:
     matchLabels:
       app.kubernetes.io/name: trustyai-service

--- a/explainability-service/manifests/opendatahub/servicemonitors/trustyai-metrics.yaml
+++ b/explainability-service/manifests/opendatahub/servicemonitors/trustyai-metrics.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: trustyai-metrics
+  labels:
+    modelmesh-service: modelmesh-serving
+spec:
+  endpoints:
+    - interval: 30s
+      path: /q/metrics
+      honorLabels: true
+      honorTimestamps: true
+      scrapeTimeout: 10s
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      bearerTokenSecret:
+        key: ""
+      targetPort: 8080
+      scheme: http
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: trustyai-service


### PR DESCRIPTION
- writes a configmap into the same namespace that overrides the model serving config defaults
- creates a servicemonitor to allow the odh-model-monitoring Prometheus to scrape the metrics


Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `FAI-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.3.x] FAI-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

