### PR TITLE
FAI-980: Provide validation for metric requests

### DIFF
--- a/explainability-service/pom.xml
+++ b/explainability-service/pom.xml
@@ -109,6 +109,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-cache</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-validator</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/DisparateImpactRatioEndpoint.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/DisparateImpactRatioEndpoint.java
@@ -17,7 +17,6 @@ import org.kie.trustyai.explainability.model.Dataframe;
 import org.kie.trustyai.service.config.metrics.MetricsConfig;
 import org.kie.trustyai.service.data.DataSource;
 import org.kie.trustyai.service.data.exceptions.DataframeCreateException;
-import org.kie.trustyai.service.data.exceptions.InvalidSchemaException;
 import org.kie.trustyai.service.data.exceptions.MetricCalculationException;
 import org.kie.trustyai.service.payloads.BaseMetricRequest;
 import org.kie.trustyai.service.payloads.BaseScheduledResponse;
@@ -28,6 +27,7 @@ import org.kie.trustyai.service.payloads.scheduler.ScheduleId;
 import org.kie.trustyai.service.payloads.scheduler.ScheduleList;
 import org.kie.trustyai.service.payloads.scheduler.ScheduleRequest;
 import org.kie.trustyai.service.prometheus.PrometheusScheduler;
+import org.kie.trustyai.service.validators.ValidBaseMetricRequest;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
@@ -109,16 +109,9 @@ public class DisparateImpactRatioEndpoint implements MetricsEndpoint {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/request")
-    public Response createRequest(BaseMetricRequest request) throws JsonProcessingException {
+    public Response createRequest(@ValidBaseMetricRequest BaseMetricRequest request) throws JsonProcessingException {
 
         final UUID id = UUID.randomUUID();
-
-        try {
-            scheduler.validateRequest(request);
-        } catch (InvalidSchemaException e) {
-            LOG.error(e.getMessage());
-            return Response.serverError().status(Response.Status.BAD_REQUEST).entity(e.getMessage()).build();
-        }
 
         scheduler.registerDIR(id, request);
 

--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/DisparateImpactRatioEndpoint.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/DisparateImpactRatioEndpoint.java
@@ -29,8 +29,6 @@ import org.kie.trustyai.service.payloads.scheduler.ScheduleRequest;
 import org.kie.trustyai.service.prometheus.PrometheusScheduler;
 import org.kie.trustyai.service.validators.ValidBaseMetricRequest;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-
 @Tag(name = "Disparate Impact Ratio Endpoint", description = "Disparate Impact Ratio (DIR) measures imbalances in " +
         "classifications by calculating the ratio between the proportion of the majority and protected classes getting" +
         " a particular outcome.")
@@ -109,7 +107,7 @@ public class DisparateImpactRatioEndpoint implements MetricsEndpoint {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/request")
-    public Response createRequest(@ValidBaseMetricRequest BaseMetricRequest request) throws JsonProcessingException {
+    public Response createRequest(@ValidBaseMetricRequest BaseMetricRequest request) {
 
         final UUID id = UUID.randomUUID();
 

--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/GroupStatisticalParityDifferenceEndpoint.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/GroupStatisticalParityDifferenceEndpoint.java
@@ -29,8 +29,6 @@ import org.kie.trustyai.service.payloads.spd.GroupStatisticalParityDifferenceRes
 import org.kie.trustyai.service.prometheus.PrometheusScheduler;
 import org.kie.trustyai.service.validators.ValidBaseMetricRequest;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-
 @Tag(name = "Statistical Parity Difference Endpoint", description = "Statistical Parity Difference (SPD) measures imbalances in classifications by calculating the " +
         "difference between the proportion of the majority and protected classes getting a particular outcome.")
 @Path("/metrics/spd")
@@ -118,7 +116,7 @@ public class GroupStatisticalParityDifferenceEndpoint implements MetricsEndpoint
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/request")
-    public Response createaRequest(@ValidBaseMetricRequest BaseMetricRequest request) throws JsonProcessingException {
+    public Response createaRequest(@ValidBaseMetricRequest BaseMetricRequest request) {
 
         final UUID id = UUID.randomUUID();
 

--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/GroupStatisticalParityDifferenceEndpoint.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/GroupStatisticalParityDifferenceEndpoint.java
@@ -30,7 +30,6 @@ import org.kie.trustyai.service.payloads.spd.GroupStatisticalParityDifferenceRes
 import org.kie.trustyai.service.prometheus.PrometheusScheduler;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Tag(name = "Statistical Parity Difference Endpoint", description = "Statistical Parity Difference (SPD) measures imbalances in classifications by calculating the " +
         "difference between the proportion of the majority and protected classes getting a particular outcome.")
@@ -135,8 +134,7 @@ public class GroupStatisticalParityDifferenceEndpoint implements MetricsEndpoint
         final BaseScheduledResponse response =
                 new BaseScheduledResponse(id);
 
-        ObjectMapper mapper = new ObjectMapper();
-        return Response.ok().entity(mapper.writeValueAsString(response)).build();
+        return Response.ok().entity(response).build();
     }
 
     @DELETE

--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/GroupStatisticalParityDifferenceEndpoint.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/GroupStatisticalParityDifferenceEndpoint.java
@@ -17,7 +17,6 @@ import org.kie.trustyai.explainability.model.Dataframe;
 import org.kie.trustyai.service.config.metrics.MetricsConfig;
 import org.kie.trustyai.service.data.DataSource;
 import org.kie.trustyai.service.data.exceptions.DataframeCreateException;
-import org.kie.trustyai.service.data.exceptions.InvalidSchemaException;
 import org.kie.trustyai.service.data.exceptions.MetricCalculationException;
 import org.kie.trustyai.service.payloads.BaseMetricRequest;
 import org.kie.trustyai.service.payloads.BaseScheduledResponse;
@@ -28,6 +27,7 @@ import org.kie.trustyai.service.payloads.scheduler.ScheduleList;
 import org.kie.trustyai.service.payloads.scheduler.ScheduleRequest;
 import org.kie.trustyai.service.payloads.spd.GroupStatisticalParityDifferenceResponse;
 import org.kie.trustyai.service.prometheus.PrometheusScheduler;
+import org.kie.trustyai.service.validators.ValidBaseMetricRequest;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
@@ -118,16 +118,9 @@ public class GroupStatisticalParityDifferenceEndpoint implements MetricsEndpoint
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/request")
-    public Response createaRequest(BaseMetricRequest request) throws JsonProcessingException {
+    public Response createaRequest(@ValidBaseMetricRequest BaseMetricRequest request) throws JsonProcessingException {
 
         final UUID id = UUID.randomUUID();
-
-        try {
-            scheduler.validateRequest(request);
-        } catch (InvalidSchemaException e) {
-            LOG.error(e.getMessage());
-            return Response.serverError().status(Response.Status.BAD_REQUEST).entity(e.getMessage()).build();
-        }
 
         scheduler.registerSPD(id, request);
 

--- a/explainability-service/src/main/java/org/kie/trustyai/service/prometheus/PrometheusScheduler.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/prometheus/PrometheusScheduler.java
@@ -14,8 +14,11 @@ import org.kie.trustyai.explainability.model.Dataframe;
 import org.kie.trustyai.service.config.ServiceConfig;
 import org.kie.trustyai.service.data.DataSource;
 import org.kie.trustyai.service.data.exceptions.DataframeCreateException;
+import org.kie.trustyai.service.data.exceptions.InvalidSchemaException;
+import org.kie.trustyai.service.data.metadata.Metadata;
 import org.kie.trustyai.service.endpoints.metrics.MetricsCalculator;
 import org.kie.trustyai.service.payloads.BaseMetricRequest;
+import org.kie.trustyai.service.payloads.service.SchemaItem;
 
 import io.quarkus.scheduler.Scheduled;
 
@@ -105,5 +108,38 @@ public class PrometheusScheduler {
                 .flatMap(Collection::stream)
                 .map(BaseMetricRequest::getModelId)
                 .collect(Collectors.toSet());
+    }
+
+    public void validateRequest(BaseMetricRequest request) throws InvalidSchemaException {
+        final String modelId = request.getModelId();
+        if (!dataSource.get().hasMetadata(modelId)) {
+            throw new InvalidSchemaException("No metadata found for model=" + modelId);
+        } else {
+            final Metadata metadata = dataSource.get().getMetadata(modelId);
+            final String outcomeName = request.getOutcomeName();
+            // Outcome name is not present
+            if (metadata.getOutputSchema().getItems().stream().noneMatch(item -> Objects.equals(item.getName(), outcomeName))) {
+                throw new InvalidSchemaException("No outcome found with name=" + outcomeName);
+            }
+            final String protectedAttribute = request.getProtectedAttribute();
+            if (metadata.getInputSchema().getItems().stream().noneMatch(item -> Objects.equals(item.getName(), protectedAttribute))) {
+                throw new InvalidSchemaException("No protected attribute found with name=" + protectedAttribute);
+            }
+            // Outcome name guaranteed to exist
+            final SchemaItem outcomeSchema = metadata.getOutputSchema().getItems().stream().filter(item -> item.getName().equals(outcomeName)).findFirst().get();
+            if (!outcomeSchema.getType().equals(request.getFavorableOutcome().getType())) {
+                throw new InvalidSchemaException("Invalid type for outcome. Got '" + request.getFavorableOutcome().getType().toString() + "', expected '" + outcomeSchema.getType().toString() + "'");
+            }
+            // Protected attribute guaranteed to exist
+            final SchemaItem protectedAttrSchema = metadata.getInputSchema().getItems().stream().filter(item -> item.getName().equals(protectedAttribute)).findFirst().get();
+            if (!protectedAttrSchema.getType().equals(request.getPrivilegedAttribute().getType())) {
+                throw new InvalidSchemaException(
+                        "Invalid type for privileged attribute. Got '" + request.getPrivilegedAttribute().getType().toString() + "', expected '" + protectedAttrSchema.getType().toString() + "'");
+            }
+            if (!protectedAttrSchema.getType().equals(request.getUnprivilegedAttribute().getType())) {
+                throw new InvalidSchemaException(
+                        "Invalid type for unprivileged attribute. Got '" + request.getUnprivilegedAttribute().getType().toString() + "', expected '" + protectedAttrSchema.getType().toString() + "'");
+            }
+        }
     }
 }

--- a/explainability-service/src/main/java/org/kie/trustyai/service/prometheus/PrometheusScheduler.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/prometheus/PrometheusScheduler.java
@@ -11,7 +11,6 @@ import javax.inject.Singleton;
 
 import org.jboss.logging.Logger;
 import org.kie.trustyai.explainability.model.Dataframe;
-import org.kie.trustyai.service.config.ServiceConfig;
 import org.kie.trustyai.service.data.DataSource;
 import org.kie.trustyai.service.data.exceptions.DataframeCreateException;
 import org.kie.trustyai.service.data.exceptions.InvalidSchemaException;
@@ -32,8 +31,6 @@ public class PrometheusScheduler {
     Instance<DataSource> dataSource;
     @Inject
     PrometheusPublisher publisher;
-    @Inject
-    ServiceConfig serviceConfig;
     @Inject
     MetricsCalculator calculator;
 

--- a/explainability-service/src/main/java/org/kie/trustyai/service/prometheus/PrometheusScheduler.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/prometheus/PrometheusScheduler.java
@@ -13,11 +13,8 @@ import org.jboss.logging.Logger;
 import org.kie.trustyai.explainability.model.Dataframe;
 import org.kie.trustyai.service.data.DataSource;
 import org.kie.trustyai.service.data.exceptions.DataframeCreateException;
-import org.kie.trustyai.service.data.exceptions.InvalidSchemaException;
-import org.kie.trustyai.service.data.metadata.Metadata;
 import org.kie.trustyai.service.endpoints.metrics.MetricsCalculator;
 import org.kie.trustyai.service.payloads.BaseMetricRequest;
-import org.kie.trustyai.service.payloads.service.SchemaItem;
 
 import io.quarkus.scheduler.Scheduled;
 
@@ -105,38 +102,5 @@ public class PrometheusScheduler {
                 .flatMap(Collection::stream)
                 .map(BaseMetricRequest::getModelId)
                 .collect(Collectors.toSet());
-    }
-
-    public void validateRequest(BaseMetricRequest request) throws InvalidSchemaException {
-        final String modelId = request.getModelId();
-        if (!dataSource.get().hasMetadata(modelId)) {
-            throw new InvalidSchemaException("No metadata found for model=" + modelId);
-        } else {
-            final Metadata metadata = dataSource.get().getMetadata(modelId);
-            final String outcomeName = request.getOutcomeName();
-            // Outcome name is not present
-            if (metadata.getOutputSchema().getItems().stream().noneMatch(item -> Objects.equals(item.getName(), outcomeName))) {
-                throw new InvalidSchemaException("No outcome found with name=" + outcomeName);
-            }
-            final String protectedAttribute = request.getProtectedAttribute();
-            if (metadata.getInputSchema().getItems().stream().noneMatch(item -> Objects.equals(item.getName(), protectedAttribute))) {
-                throw new InvalidSchemaException("No protected attribute found with name=" + protectedAttribute);
-            }
-            // Outcome name guaranteed to exist
-            final SchemaItem outcomeSchema = metadata.getOutputSchema().getItems().stream().filter(item -> item.getName().equals(outcomeName)).findFirst().get();
-            if (!outcomeSchema.getType().equals(request.getFavorableOutcome().getType())) {
-                throw new InvalidSchemaException("Invalid type for outcome. Got '" + request.getFavorableOutcome().getType().toString() + "', expected '" + outcomeSchema.getType().toString() + "'");
-            }
-            // Protected attribute guaranteed to exist
-            final SchemaItem protectedAttrSchema = metadata.getInputSchema().getItems().stream().filter(item -> item.getName().equals(protectedAttribute)).findFirst().get();
-            if (!protectedAttrSchema.getType().equals(request.getPrivilegedAttribute().getType())) {
-                throw new InvalidSchemaException(
-                        "Invalid type for privileged attribute. Got '" + request.getPrivilegedAttribute().getType().toString() + "', expected '" + protectedAttrSchema.getType().toString() + "'");
-            }
-            if (!protectedAttrSchema.getType().equals(request.getUnprivilegedAttribute().getType())) {
-                throw new InvalidSchemaException(
-                        "Invalid type for unprivileged attribute. Got '" + request.getUnprivilegedAttribute().getType().toString() + "', expected '" + protectedAttrSchema.getType().toString() + "'");
-            }
-        }
     }
 }

--- a/explainability-service/src/main/java/org/kie/trustyai/service/validators/BaseMetricRequestValidator.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/validators/BaseMetricRequestValidator.java
@@ -1,0 +1,69 @@
+package org.kie.trustyai.service.validators;
+
+import java.util.Objects;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+import org.kie.trustyai.service.data.DataSource;
+import org.kie.trustyai.service.data.metadata.Metadata;
+import org.kie.trustyai.service.payloads.BaseMetricRequest;
+import org.kie.trustyai.service.payloads.service.SchemaItem;
+
+@ApplicationScoped
+public class BaseMetricRequestValidator implements ConstraintValidator<ValidBaseMetricRequest, BaseMetricRequest> {
+    @Inject
+    Instance<DataSource> dataSource;
+
+    @Override
+    public void initialize(ValidBaseMetricRequest constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(BaseMetricRequest request, ConstraintValidatorContext context) {
+        final String modelId = request.getModelId();
+        if (!dataSource.get().hasMetadata(modelId)) {
+            context.buildConstraintViolationWithTemplate("No metadadata found for model=" + modelId).addConstraintViolation();
+            return false;
+        } else {
+            final Metadata metadata = dataSource.get().getMetadata(modelId);
+            final String outcomeName = request.getOutcomeName();
+            // Outcome name is not present
+            if (metadata.getOutputSchema().getItems().stream().noneMatch(item -> Objects.equals(item.getName(), outcomeName))) {
+                context.buildConstraintViolationWithTemplate("No outcome found with name=" + outcomeName).addConstraintViolation();
+                return false;
+            }
+            final String protectedAttribute = request.getProtectedAttribute();
+            if (metadata.getInputSchema().getItems().stream().noneMatch(item -> Objects.equals(item.getName(), protectedAttribute))) {
+                context.buildConstraintViolationWithTemplate("No protected attribute found with name=" + protectedAttribute).addConstraintViolation();
+                return false;
+            }
+            // Outcome name guaranteed to exist
+            final SchemaItem outcomeSchema = metadata.getOutputSchema().getItems().stream().filter(item -> item.getName().equals(outcomeName)).findFirst().get();
+            if (!outcomeSchema.getType().equals(request.getFavorableOutcome().getType())) {
+                context.buildConstraintViolationWithTemplate(
+                        "Invalid type for outcome. Got '" + request.getFavorableOutcome().getType().toString() + "', expected '" + outcomeSchema.getType().toString() + "'").addConstraintViolation();
+                return false;
+            }
+            // Protected attribute guaranteed to exist
+            final SchemaItem protectedAttrSchema = metadata.getInputSchema().getItems().stream().filter(item -> item.getName().equals(protectedAttribute)).findFirst().get();
+            if (!protectedAttrSchema.getType().equals(request.getPrivilegedAttribute().getType())) {
+                context.buildConstraintViolationWithTemplate(
+                        "Invalid type for privileged attribute. Got '" + request.getPrivilegedAttribute().getType().toString() + "', expected '" + protectedAttrSchema.getType().toString() + "'")
+                        .addConstraintViolation();
+                return false;
+            }
+            if (!protectedAttrSchema.getType().equals(request.getUnprivilegedAttribute().getType())) {
+                context.buildConstraintViolationWithTemplate(
+                        "Invalid type for unprivileged attribute. Got '" + request.getUnprivilegedAttribute().getType().toString() + "', expected '" + protectedAttrSchema.getType().toString() + "'")
+                        .addConstraintViolation();
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/explainability-service/src/main/java/org/kie/trustyai/service/validators/ValidBaseMetricRequest.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/validators/ValidBaseMetricRequest.java
@@ -1,0 +1,21 @@
+package org.kie.trustyai.service.validators;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Target({ ElementType.PARAMETER, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = BaseMetricRequestValidator.class)
+public @interface ValidBaseMetricRequest {
+    String message() default "The supplied metric request details are not valid.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/DisparateImpactRatioEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/DisparateImpactRatioEndpointTest.java
@@ -27,8 +27,7 @@ import io.restassured.http.ContentType;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
-import static org.hamcrest.Matchers.any;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 @QuarkusTest
@@ -242,7 +241,8 @@ class DisparateImpactRatioEndpointTest {
                 .body(wrongPayload)
                 .when()
                 .post("/request")
-                .then().statusCode(RestResponse.StatusCode.BAD_REQUEST).body(is("Invalid type for outcome. Got 'STRING', expected 'INT32'"));
+                .then().statusCode(RestResponse.StatusCode.BAD_REQUEST)
+                .body(containsString("Invalid type for outcome. Got 'STRING', expected 'INT32'"));
 
         ScheduleList scheduleList = given()
                 .when()

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/GroupStatisticalParityDifferenceEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/GroupStatisticalParityDifferenceEndpointTest.java
@@ -204,4 +204,112 @@ class GroupStatisticalParityDifferenceEndpointTest {
         assertEquals(0, scheduleList.requests.size());
     }
 
+    @Test
+    void requestWrongType() {
+
+        // No schedule request made yet
+        final ScheduleList emptyList = given()
+                .when()
+                .get("/requests")
+                .then().statusCode(200).extract().body().as(ScheduleList.class);
+
+        assertEquals(0, emptyList.requests.size());
+
+        // Perform multiple schedule requests
+        final BaseMetricRequest payload = RequestPayloadGenerator.correct();
+        final BaseScheduledResponse firstRequest = given()
+                .contentType(ContentType.JSON)
+                .body(payload)
+                .when()
+                .post("/request")
+                .then().statusCode(200).extract().body().as(BaseScheduledResponse.class);
+
+        assertNotNull(firstRequest.getRequestId());
+
+        final BaseMetricRequest wrongPayload = RequestPayloadGenerator.incorrectType();
+        given()
+                .contentType(ContentType.JSON)
+                .body(wrongPayload)
+                .when()
+                .post("/request")
+                .then().statusCode(RestResponse.StatusCode.BAD_REQUEST).body(is("Invalid type for outcome. Got 'STRING', expected 'INT32'"));
+
+        ScheduleList scheduleList = given()
+                .when()
+                .get("/requests")
+                .then().statusCode(200).extract().body().as(ScheduleList.class);
+
+        // Correct number of active requests
+        assertEquals(1, scheduleList.requests.size());
+
+        // Remove one request
+        final ScheduleId firstRequestId = new ScheduleId();
+        firstRequestId.requestId = firstRequest.getRequestId();
+        given().contentType(ContentType.JSON).when().body(firstRequestId).delete("/request")
+                .then().statusCode(200).body(is("Removed"));
+
+        scheduleList = given()
+                .when()
+                .get("/requests")
+                .then().statusCode(200).extract().body().as(ScheduleList.class);
+
+        // Correct number of active requests
+        assertEquals(0, scheduleList.requests.size());
+
+    }
+
+    @Test
+    void requestUnknowType() {
+
+        // No schedule request made yet
+        final ScheduleList emptyList = given()
+                .when()
+                .get("/requests")
+                .then().statusCode(200).extract().body().as(ScheduleList.class);
+
+        assertEquals(0, emptyList.requests.size());
+
+        // Perform multiple schedule requests
+        final BaseMetricRequest payload = RequestPayloadGenerator.correct();
+        final BaseScheduledResponse firstRequest = given()
+                .contentType(ContentType.JSON)
+                .body(payload)
+                .when()
+                .post("/request")
+                .then().statusCode(200).extract().body().as(BaseScheduledResponse.class);
+
+        assertNotNull(firstRequest.getRequestId());
+
+        final Map<String, Object> unknownPayload = RequestPayloadGenerator.unknownType();
+        given()
+                .contentType(ContentType.JSON)
+                .body(unknownPayload)
+                .when()
+                .post("/request")
+                .then().statusCode(RestResponse.StatusCode.BAD_REQUEST);
+
+        ScheduleList scheduleList = given()
+                .when()
+                .get("/requests")
+                .then().statusCode(200).extract().body().as(ScheduleList.class);
+
+        // Correct number of active requests
+        assertEquals(1, scheduleList.requests.size());
+
+        // Remove one request
+        final ScheduleId firstRequestId = new ScheduleId();
+        firstRequestId.requestId = firstRequest.getRequestId();
+        given().contentType(ContentType.JSON).when().body(firstRequestId).delete("/request")
+                .then().statusCode(200).body(is("Removed"));
+
+        scheduleList = given()
+                .when()
+                .get("/requests")
+                .then().statusCode(200).extract().body().as(ScheduleList.class);
+
+        // Correct number of active requests
+        assertEquals(0, scheduleList.requests.size());
+
+    }
+
 }

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/GroupStatisticalParityDifferenceEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/GroupStatisticalParityDifferenceEndpointTest.java
@@ -27,8 +27,7 @@ import io.restassured.http.ContentType;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
-import static org.hamcrest.Matchers.any;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 @QuarkusTest
@@ -232,7 +231,8 @@ class GroupStatisticalParityDifferenceEndpointTest {
                 .body(wrongPayload)
                 .when()
                 .post("/request")
-                .then().statusCode(RestResponse.StatusCode.BAD_REQUEST).body(is("Invalid type for outcome. Got 'STRING', expected 'INT32'"));
+                .then().statusCode(RestResponse.StatusCode.BAD_REQUEST)
+                .body(containsString("Invalid type for outcome. Got 'STRING', expected 'INT32'"));
 
         ScheduleList scheduleList = given()
                 .when()

--- a/explainability-service/src/test/java/org/kie/trustyai/service/scenarios/nodata/DisparateImpactRatioEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/scenarios/nodata/DisparateImpactRatioEndpointTest.java
@@ -1,6 +1,7 @@
 package org.kie.trustyai.service.scenarios.nodata;
 
 import java.util.Map;
+import java.util.UUID;
 
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
@@ -14,7 +15,6 @@ import org.kie.trustyai.service.endpoints.metrics.RequestPayloadGenerator;
 import org.kie.trustyai.service.mocks.MockDatasource;
 import org.kie.trustyai.service.mocks.MockMemoryStorage;
 import org.kie.trustyai.service.payloads.BaseMetricRequest;
-import org.kie.trustyai.service.payloads.BaseScheduledResponse;
 import org.kie.trustyai.service.payloads.scheduler.ScheduleId;
 import org.kie.trustyai.service.payloads.scheduler.ScheduleList;
 
@@ -27,7 +27,6 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @QuarkusTest
 @TestProfile(BaseTestProfile.class)
@@ -98,7 +97,6 @@ class DisparateImpactRatioEndpointTest {
 
     }
 
-    @Test
     void listSchedules() {
 
         // No schedule request made yet
@@ -111,53 +109,14 @@ class DisparateImpactRatioEndpointTest {
 
         // Perform multiple schedule requests
         final BaseMetricRequest payload = RequestPayloadGenerator.correct();
-        final BaseScheduledResponse firstRequest = given()
+        given()
                 .contentType(ContentType.JSON)
                 .body(payload)
                 .when()
                 .post("/request")
-                .then().statusCode(RestResponse.StatusCode.OK).extract().body().as(BaseScheduledResponse.class);
-
-        assertNotNull(firstRequest.getRequestId());
-
-        final BaseScheduledResponse secondRequest = given()
-                .contentType(ContentType.JSON)
-                .body(payload)
-                .when()
-                .post("/request")
-                .then().statusCode(RestResponse.StatusCode.OK).extract().body().as(BaseScheduledResponse.class);
-
-        assertNotNull(secondRequest.getRequestId());
+                .then().statusCode(RestResponse.StatusCode.BAD_REQUEST).body(is("No metadata found for model=" + payload.getModelId()));
 
         ScheduleList scheduleList = given()
-                .when()
-                .get("/requests")
-                .then().statusCode(RestResponse.StatusCode.OK).extract().body().as(ScheduleList.class);
-
-        // Correct number of active requests
-        assertEquals(2, scheduleList.requests.size());
-
-        // Remove one request
-        final ScheduleId firstRequestId = new ScheduleId();
-        firstRequestId.requestId = firstRequest.getRequestId();
-        given().contentType(ContentType.JSON).when().body(firstRequestId).delete("/request")
-                .then().statusCode(RestResponse.StatusCode.OK).body(is("Removed"));
-
-        scheduleList = given()
-                .when()
-                .get("/requests")
-                .then().statusCode(RestResponse.StatusCode.OK).extract().body().as(ScheduleList.class);
-
-        // Correct number of active requests
-        assertEquals(1, scheduleList.requests.size());
-
-        // Remove second request
-        final ScheduleId secondRequestId = new ScheduleId();
-        secondRequestId.requestId = secondRequest.getRequestId();
-        given().contentType(ContentType.JSON).when().body(secondRequestId).delete("/request")
-                .then().statusCode(RestResponse.StatusCode.OK).body(is("Removed"));
-
-        scheduleList = given()
                 .when()
                 .get("/requests")
                 .then().statusCode(RestResponse.StatusCode.OK).extract().body().as(ScheduleList.class);
@@ -167,7 +126,7 @@ class DisparateImpactRatioEndpointTest {
 
         // Remove non-existing request
         final ScheduleId nonExistingRequestId = new ScheduleId();
-        nonExistingRequestId.requestId = secondRequest.getRequestId();
+        nonExistingRequestId.requestId = UUID.randomUUID();
         given().contentType(ContentType.JSON).when().body(nonExistingRequestId).delete("/request")
                 .then().statusCode(RestResponse.StatusCode.NOT_FOUND).body(is(""));
 

--- a/explainability-service/src/test/java/org/kie/trustyai/service/scenarios/nodata/GroupStatisticalParityDifferenceEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/scenarios/nodata/GroupStatisticalParityDifferenceEndpointTest.java
@@ -1,6 +1,7 @@
 package org.kie.trustyai.service.scenarios.nodata;
 
 import java.util.Map;
+import java.util.UUID;
 
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
@@ -14,7 +15,6 @@ import org.kie.trustyai.service.endpoints.metrics.RequestPayloadGenerator;
 import org.kie.trustyai.service.mocks.MockDatasource;
 import org.kie.trustyai.service.mocks.MockMemoryStorage;
 import org.kie.trustyai.service.payloads.BaseMetricRequest;
-import org.kie.trustyai.service.payloads.BaseScheduledResponse;
 import org.kie.trustyai.service.payloads.scheduler.ScheduleId;
 import org.kie.trustyai.service.payloads.scheduler.ScheduleList;
 
@@ -29,7 +29,6 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @QuarkusTest
 @TestProfile(BaseTestProfile.class)
@@ -112,53 +111,14 @@ class GroupStatisticalParityDifferenceEndpointTest {
 
         // Perform multiple schedule requests
         final BaseMetricRequest payload = RequestPayloadGenerator.correct();
-        final BaseScheduledResponse firstRequest = given()
+        given()
                 .contentType(ContentType.JSON)
                 .body(payload)
                 .when()
                 .post("/request")
-                .then().statusCode(RestResponse.StatusCode.OK).extract().body().as(BaseScheduledResponse.class);
-
-        assertNotNull(firstRequest.getRequestId());
-
-        final BaseScheduledResponse secondRequest = given()
-                .contentType(ContentType.JSON)
-                .body(payload)
-                .when()
-                .post("/request")
-                .then().statusCode(RestResponse.StatusCode.OK).extract().body().as(BaseScheduledResponse.class);
-
-        assertNotNull(secondRequest.getRequestId());
+                .then().statusCode(RestResponse.StatusCode.BAD_REQUEST).body(is("No metadata found for model=" + payload.getModelId()));
 
         ScheduleList scheduleList = given()
-                .when()
-                .get("/requests")
-                .then().statusCode(RestResponse.StatusCode.OK).extract().body().as(ScheduleList.class);
-
-        // Correct number of active requests
-        assertEquals(2, scheduleList.requests.size());
-
-        // Remove one request
-        final ScheduleId firstRequestId = new ScheduleId();
-        firstRequestId.requestId = firstRequest.getRequestId();
-        given().contentType(ContentType.JSON).when().body(firstRequestId).delete("/request")
-                .then().statusCode(RestResponse.StatusCode.OK).body(is("Removed"));
-
-        scheduleList = given()
-                .when()
-                .get("/requests")
-                .then().statusCode(RestResponse.StatusCode.OK).extract().body().as(ScheduleList.class);
-
-        // Correct number of active requests
-        assertEquals(1, scheduleList.requests.size());
-
-        // Remove second request
-        final ScheduleId secondRequestId = new ScheduleId();
-        secondRequestId.requestId = secondRequest.getRequestId();
-        given().contentType(ContentType.JSON).when().body(secondRequestId).delete("/request")
-                .then().statusCode(RestResponse.StatusCode.OK).body(is("Removed"));
-
-        scheduleList = given()
                 .when()
                 .get("/requests")
                 .then().statusCode(RestResponse.StatusCode.OK).extract().body().as(ScheduleList.class);
@@ -168,7 +128,7 @@ class GroupStatisticalParityDifferenceEndpointTest {
 
         // Remove non-existing request
         final ScheduleId nonExistingRequestId = new ScheduleId();
-        nonExistingRequestId.requestId = secondRequest.getRequestId();
+        nonExistingRequestId.requestId = UUID.randomUUID();
         given().contentType(ContentType.JSON).when().body(nonExistingRequestId).delete("/request")
                 .then().statusCode(RestResponse.StatusCode.NOT_FOUND).body(is(""));
 

--- a/explainability-service/src/test/java/org/kie/trustyai/service/scenarios/nodata/GroupStatisticalParityDifferenceEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/scenarios/nodata/GroupStatisticalParityDifferenceEndpointTest.java
@@ -27,6 +27,7 @@ import io.restassured.http.ContentType;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -116,7 +117,8 @@ class GroupStatisticalParityDifferenceEndpointTest {
                 .body(payload)
                 .when()
                 .post("/request")
-                .then().statusCode(RestResponse.StatusCode.BAD_REQUEST).body(is("No metadata found for model=" + payload.getModelId()));
+                .then().statusCode(RestResponse.StatusCode.BAD_REQUEST)
+                .body(containsString("No metadadata found for model=" + payload.getModelId()));
 
         ScheduleList scheduleList = given()
                 .when()


### PR DESCRIPTION
[FAI-980](https://issues.redhat.com/browse/FAI-980):

At the moment metric requests fail silently if ill-formed (e.g. feature types not compatible) requests are made.

This PR introduces metric request validation:

- Feature names must be present in the dataset
- Request types must be consistent with the ones in the dataset

And also provide informative messages when validation fails.

The only service behaviour change is that previously it was allowed to create metric request even when no data was available. Trying to create a metric request when no data is available will now return an error response, since the service checks the metadata exists before registering the resquest.

> Many thanks for submitting your Pull Request :heart:!
> 
> Please make sure that your PR meets the following requirements:
> 
> - [x] You have read the [contributors guide](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md)
> - [x] Pull Request title is properly formatted: `FAI-XYZ Subject`
> - [x] Pull Request title contains the target branch if not targeting main: `[0.3.x] FAI-XYZ Subject`
> - [x] Pull Request contains link to the JIRA issue
> - [x] Pull Request contains link to any dependent or related Pull Request
> - [x] Pull Request contains description of the issue
> - [x] Pull Request does not include fixes for issues other than the main ticket
> 
> 