### PR TITLE
RHODS-7993: Added requestName field to metric requests

### DIFF
--- a/explainability-service/README.md
+++ b/explainability-service/README.md
@@ -64,7 +64,8 @@ Issue a metric request to, for instance:
 curl -X POST --location "http://localhost:8080/metrics/spd/request" \
     -H "Content-Type: application/json" \
     -d "{
-            \"modelId\": \"example-1\",
+            \"modelId\": \"example-model-1\",
+            \"requestName\": \"lala\",
             \"protectedAttribute\": \"input-2\",
             \"favorableOutcome\": {
                 \"type\": \"DOUBLE\",

--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/BaseMetricRequest.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/BaseMetricRequest.java
@@ -29,9 +29,13 @@ public class BaseMetricRequest {
         this.modelId = modelId;
     }
 
-    public String getRequestName() {return requestName; }
+    public String getRequestName() {
+        return requestName;
+    }
 
-    public void setRequestName(String requestName) { this.requestName = requestName; }
+    public void setRequestName(String requestName) {
+        this.requestName = requestName;
+    }
 
     public String getProtectedAttribute() {
         return protectedAttribute;

--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/BaseMetricRequest.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/BaseMetricRequest.java
@@ -10,12 +10,12 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 public class BaseMetricRequest {
 
     private String protectedAttribute;
-
     private TypedValue favorableOutcome;
     private String outcomeName;
     private TypedValue privilegedAttribute;
     private TypedValue unprivilegedAttribute;
     private String modelId;
+    private String requestName;
 
     public BaseMetricRequest() {
         // Public default no-argument constructor
@@ -28,6 +28,10 @@ public class BaseMetricRequest {
     public void setModelId(String modelId) {
         this.modelId = modelId;
     }
+
+    public String getRequestName() {return requestName; }
+
+    public void setRequestName(String requestName) { this.requestName = requestName; }
 
     public String getProtectedAttribute() {
         return protectedAttribute;

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/RequestPayloadGenerator.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/RequestPayloadGenerator.java
@@ -41,6 +41,33 @@ public class RequestPayloadGenerator {
         return request;
     }
 
+    public static BaseMetricRequest named(String name) {
+        BaseMetricRequest request = new BaseMetricRequest();
+        request.setProtectedAttribute("gender");
+
+        TypedValue favorableOutcome = new TypedValue();
+        favorableOutcome.setType(INT32);
+        favorableOutcome.setValue(JsonNodeFactory.instance.numberNode(1));
+        request.setFavorableOutcome(favorableOutcome);
+
+        request.setOutcomeName("income");
+
+        TypedValue privilegedAttribute = new TypedValue();
+        privilegedAttribute.setType(INT32);
+        privilegedAttribute.setValue(JsonNodeFactory.instance.numberNode(1));
+        request.setPrivilegedAttribute(privilegedAttribute);
+
+        TypedValue unprivilegedAttribute = new TypedValue();
+        unprivilegedAttribute.setType(INT32);
+        unprivilegedAttribute.setValue(JsonNodeFactory.instance.numberNode(0));
+        request.setUnprivilegedAttribute(unprivilegedAttribute);
+
+        request.setModelId(MODEL_ID);
+        request.setRequestName(name);
+
+        return request;
+    }
+
     public static BaseMetricRequest incorrectType() {
         BaseMetricRequest request = new BaseMetricRequest();
         request.setProtectedAttribute("gender");

--- a/explainability-service/src/test/java/org/kie/trustyai/service/scenarios/nodata/DisparateImpactRatioEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/scenarios/nodata/DisparateImpactRatioEndpointTest.java
@@ -1,5 +1,7 @@
 package org.kie.trustyai.service.scenarios.nodata;
 
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -9,12 +11,14 @@ import javax.inject.Inject;
 import org.jboss.resteasy.reactive.RestResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.kie.trustyai.explainability.model.Dataframe;
 import org.kie.trustyai.service.BaseTestProfile;
 import org.kie.trustyai.service.endpoints.metrics.DisparateImpactRatioEndpoint;
 import org.kie.trustyai.service.endpoints.metrics.RequestPayloadGenerator;
 import org.kie.trustyai.service.mocks.MockDatasource;
 import org.kie.trustyai.service.mocks.MockMemoryStorage;
 import org.kie.trustyai.service.payloads.BaseMetricRequest;
+import org.kie.trustyai.service.payloads.BaseScheduledResponse;
 import org.kie.trustyai.service.payloads.scheduler.ScheduleId;
 import org.kie.trustyai.service.payloads.scheduler.ScheduleList;
 
@@ -33,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @TestHTTPEndpoint(DisparateImpactRatioEndpoint.class)
 class DisparateImpactRatioEndpointTest {
 
+    private static final String MODEL_ID = "example1";
     @Inject
     Instance<MockDatasource> datasource;
 
@@ -44,7 +49,7 @@ class DisparateImpactRatioEndpointTest {
      *
      */
     @BeforeEach
-    void populateStorage() {
+    void populateStorageEmpty() {
         storage.get().emptyStorage();
     }
 
@@ -97,6 +102,7 @@ class DisparateImpactRatioEndpointTest {
 
     }
 
+    @Test
     void listSchedules() {
 
         // No schedule request made yet
@@ -129,6 +135,74 @@ class DisparateImpactRatioEndpointTest {
         nonExistingRequestId.requestId = UUID.randomUUID();
         given().contentType(ContentType.JSON).when().body(nonExistingRequestId).delete("/request")
                 .then().statusCode(RestResponse.StatusCode.NOT_FOUND).body(is(""));
+
+        scheduleList = given()
+                .when()
+                .get("/requests")
+                .then().statusCode(RestResponse.StatusCode.OK).extract().body().as(ScheduleList.class);
+
+        // Correct number of active requests
+        assertEquals(0, scheduleList.requests.size());
+    }
+
+    void populateStorage() {
+        populateStorageEmpty();
+        final Dataframe dataframe = datasource.get().generateRandomDataframe(1000);
+        datasource.get().saveDataframe(dataframe, MODEL_ID);
+        datasource.get().saveMetadata(datasource.get().createMetadata(dataframe), MODEL_ID);
+    }
+
+    @Test
+    void listNames() {
+        populateStorage();
+
+        // No schedule request made yet
+        final ScheduleList emptyList = given()
+                .when()
+                .get("/requests")
+                .then().statusCode(RestResponse.StatusCode.OK).extract().body().as(ScheduleList.class);
+        assertEquals(0, emptyList.requests.size());
+
+        List<String> names = List.of("name1", "name2", "name3");
+        Map<UUID, String> nameIDs = new HashMap<>();
+
+        // Perform multiple schedule requests
+        for (String name : names) {
+            final BaseMetricRequest payload = RequestPayloadGenerator.named(name);
+            BaseScheduledResponse scheduledResponse = given()
+                    .contentType(ContentType.JSON)
+                    .body(payload)
+                    .when()
+                    .post("/request")
+                    .then().statusCode(RestResponse.StatusCode.OK).extract().body().as(BaseScheduledResponse.class);
+            nameIDs.put(scheduledResponse.getRequestId(), name);
+        }
+
+        ScheduleList scheduleList = given()
+                .when()
+                .get("/requests")
+                .then().statusCode(RestResponse.StatusCode.OK).extract().body().as(ScheduleList.class);
+
+        // Correct number of active requests
+        assertEquals(3, scheduleList.requests.size());
+
+        // check that names are as expected
+        for (int i = 0; i < scheduleList.requests.size(); i++) {
+            UUID returnedID = scheduleList.requests.get(i).id;
+            assertEquals(nameIDs.get(returnedID), scheduleList.requests.get(i).request.getRequestName());
+
+            // delete the corresponding request
+            final ScheduleId thisRequestId = new ScheduleId();
+            thisRequestId.requestId = returnedID;
+            given()
+                    .contentType(ContentType.JSON)
+                    .when()
+                    .body(thisRequestId)
+                    .delete("/request")
+                    .then()
+                    .statusCode(200)
+                    .body(is("Removed"));
+        }
 
         scheduleList = given()
                 .when()

--- a/explainability-service/src/test/java/org/kie/trustyai/service/scenarios/nodata/DisparateImpactRatioEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/scenarios/nodata/DisparateImpactRatioEndpointTest.java
@@ -33,7 +33,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @TestHTTPEndpoint(DisparateImpactRatioEndpoint.class)
 class DisparateImpactRatioEndpointTest {
 
-    private static final String MODEL_ID = "example1";
     @Inject
     Instance<MockDatasource> datasource;
 
@@ -98,7 +97,6 @@ class DisparateImpactRatioEndpointTest {
 
     }
 
-    @Test
     void listSchedules() {
 
         // No schedule request made yet


### PR DESCRIPTION
Allows the user to specify a human-readable name for each metric request. These are purely decorative and do not affect anything on the service side of things.


Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `FAI-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.3.x] FAI-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

