### PR TITLE
RHODS-8163: Add configurable threshold delta to metrics endpoint

### DIFF
--- a/explainability-service/README.md
+++ b/explainability-service/README.md
@@ -350,6 +350,31 @@ The metrics will now be pushed to Prometheus with the runtime provided `SERVICE_
 e.g. `SERVICE_METRICS_SCHEDULE=10s`)
 which follows the [Quarkus syntax](https://quarkus.io/guides/scheduler-reference).
 
+You can also specify the bias threshold deltas in the request body:
+```shell
+curl -X POST --location "http://{{host}}/metrics/spd/request" \
+    -H "Content-Type: application/json" \
+    -d "{
+          \"thresholdDelta\": 0.05,
+          \"protectedAttribute\": \"input-2\",
+          \"favorableOutcome\": {
+            \"type\": \"DOUBLE\",
+            \"value\": 1.0
+          },
+          \"outcomeName\": \"output-0\",
+          \"privilegedAttribute\": {
+            \"type\": \"DOUBLE\",
+            \"value\": 1.0
+          },
+          \"unprivilegedAttribute\": {
+            \"type\": \"DOUBLE\",
+            \"value\": 0.0
+          }
+        }"
+```
+This means that _this specific_ metric request will consider SPD values within +/-0.05 to be fair, and values outside
+those bounds to be unfair.
+
 To stop the periodic calculation you can issue an HTTP `DELETE` request to the `/metrics/$METRIC/request` endpoint, with
 the id of periodic task we want to cancel in the payload.
 For instance:

--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/DisparateImpactRatioEndpoint.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/DisparateImpactRatioEndpoint.java
@@ -79,11 +79,20 @@ public class DisparateImpactRatioEndpoint implements MetricsEndpoint {
         }
         final String dirDefinition = calculator.getDIRDefinition(dir, request);
 
-        final MetricThreshold thresholds =
-                new MetricThreshold(
-                        metricsConfig.dir().thresholdLower(),
-                        metricsConfig.dir().thresholdUpper(),
-                        dir);
+        MetricThreshold thresholds;
+        if (request.getThresholdDelta() == null) {
+            thresholds =
+                    new MetricThreshold(
+                            metricsConfig.dir().thresholdLower(),
+                            metricsConfig.dir().thresholdUpper(),
+                            dir);
+        } else {
+            thresholds =
+                    new MetricThreshold(
+                            1 - request.getThresholdDelta(),
+                            1 + request.getThresholdDelta(),
+                            dir);
+        }
         final DisparateImpactRatioResponse dirObj = new DisparateImpactRatioResponse(dir, dirDefinition, thresholds);
         return Response.ok(dirObj).build();
     }

--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/GroupStatisticalParityDifferenceEndpoint.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/GroupStatisticalParityDifferenceEndpoint.java
@@ -90,9 +90,20 @@ public class GroupStatisticalParityDifferenceEndpoint implements MetricsEndpoint
         }
         final String definition = calculator.getSPDDefinition(spd, request);
 
-        final MetricThreshold thresholds = new MetricThreshold(
-                metricsConfig.spd().thresholdLower(),
-                metricsConfig.spd().thresholdUpper(), spd);
+        MetricThreshold thresholds;
+        if (request.getThresholdDelta() == null) {
+            thresholds =
+                    new MetricThreshold(
+                            metricsConfig.spd().thresholdLower(),
+                            metricsConfig.spd().thresholdUpper(),
+                            spd);
+        } else {
+            thresholds =
+                    new MetricThreshold(
+                            0 - request.getThresholdDelta(),
+                            request.getThresholdDelta(),
+                            spd);
+        }
         final GroupStatisticalParityDifferenceResponse spdObj = new GroupStatisticalParityDifferenceResponse(spd, definition, thresholds);
         return Response.ok(spdObj).build();
     }

--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/BaseMetricRequest.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/BaseMetricRequest.java
@@ -16,6 +16,7 @@ public class BaseMetricRequest {
     private TypedValue unprivilegedAttribute;
     private String modelId;
     private String requestName;
+    private Double thresholdDelta;
 
     public BaseMetricRequest() {
         // Public default no-argument constructor
@@ -77,6 +78,14 @@ public class BaseMetricRequest {
         this.unprivilegedAttribute = unprivilegedAttribute;
     }
 
+    public Double getThresholdDelta() {
+        return thresholdDelta;
+    }
+
+    public void setThresholdDelta(Double thresholdDelta) {
+        this.thresholdDelta = thresholdDelta;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o)
@@ -85,11 +94,11 @@ public class BaseMetricRequest {
             return false;
         BaseMetricRequest that = (BaseMetricRequest) o;
         return protectedAttribute.equals(that.protectedAttribute) && favorableOutcome.equals(that.favorableOutcome) && outcomeName.equals(that.outcomeName)
-                && privilegedAttribute.equals(that.privilegedAttribute) && unprivilegedAttribute.equals(that.unprivilegedAttribute);
+                && privilegedAttribute.equals(that.privilegedAttribute) && unprivilegedAttribute.equals(that.unprivilegedAttribute) && thresholdDelta == that.thresholdDelta;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(protectedAttribute, favorableOutcome, outcomeName, privilegedAttribute, unprivilegedAttribute);
+        return Objects.hash(protectedAttribute, favorableOutcome, outcomeName, privilegedAttribute, unprivilegedAttribute, thresholdDelta);
     }
 }

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/GroupStatisticalParityDifferenceEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/GroupStatisticalParityDifferenceEndpointTest.java
@@ -96,9 +96,9 @@ class GroupStatisticalParityDifferenceEndpointTest {
         assertEquals("SPD", response.getName());
         assertFalse(response.getThresholds().outsideBounds);
 
-        // with tiny threshold, the DIR is outside bounds
+        // with negative threshold, every SPD is outside bounds
         payload = RequestPayloadGenerator.correct();
-        payload.setThresholdDelta(.01);
+        payload.setThresholdDelta(-1.);
         response = given()
                 .contentType(ContentType.JSON)
                 .body(payload)

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/GroupStatisticalParityDifferenceEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/GroupStatisticalParityDifferenceEndpointTest.java
@@ -14,6 +14,7 @@ import org.kie.trustyai.service.mocks.MockDatasource;
 import org.kie.trustyai.service.mocks.MockMemoryStorage;
 import org.kie.trustyai.service.payloads.BaseMetricRequest;
 import org.kie.trustyai.service.payloads.BaseScheduledResponse;
+import org.kie.trustyai.service.payloads.dir.DisparateImpactRatioResponse;
 import org.kie.trustyai.service.payloads.scheduler.ScheduleId;
 import org.kie.trustyai.service.payloads.scheduler.ScheduleList;
 import org.kie.trustyai.service.payloads.spd.GroupStatisticalParityDifferenceResponse;
@@ -73,6 +74,43 @@ class GroupStatisticalParityDifferenceEndpointTest {
         assertEquals("metric", response.getType());
         assertEquals("SPD", response.getName());
         assertFalse(Double.isNaN(response.getValue()));
+    }
+
+    @Test
+    void postThresh() throws JsonProcessingException {
+        datasource.get();
+
+        // with large threshold, the DIR is inside bounds
+        BaseMetricRequest payload = RequestPayloadGenerator.correct();
+        payload.setThresholdDelta(.5);
+        DisparateImpactRatioResponse response = given()
+                .contentType(ContentType.JSON)
+                .body(payload)
+                .when().post()
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .extract()
+                .body().as(DisparateImpactRatioResponse.class);
+
+        assertEquals("metric", response.getType());
+        assertEquals("SPD", response.getName());
+        assertFalse(response.getThresholds().outsideBounds);
+
+        // with tiny threshold, the DIR is outside bounds
+        payload = RequestPayloadGenerator.correct();
+        payload.setThresholdDelta(.01);
+        response = given()
+                .contentType(ContentType.JSON)
+                .body(payload)
+                .when().post()
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .extract()
+                .body().as(DisparateImpactRatioResponse.class);
+
+        assertEquals("metric", response.getType());
+        assertEquals("SPD", response.getName());
+        assertTrue(response.getThresholds().outsideBounds);
     }
 
     @Test


### PR DESCRIPTION
### Description:
Adds support for per-metric bias threshold deltas.

### Rationale:
At the moment, all metric requests share the same global threshold bounds. This PR allows to (optionally) define a specific threshold delta to be used for each metric request. This will configure threshold bounds symmetrically around "optimal' fairness, so 0+/-delta for SPD, 1+/-delta for DIR.

If the batch size is omitted, the behavior will be as previously, reverting to the default bounds.

Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `FAI-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.3.x] FAI-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

