### PR TITLE
Remove DSP from E2E tests ODH install

### DIFF
--- a/e2e_tests/resources/common/odh-core.yaml
+++ b/e2e_tests/resources/common/odh-core.yaml
@@ -54,16 +54,6 @@ spec:
         path: notebook-images
     name: notebook-images
   - kustomizeConfig:
-      overlays:
-        - metadata-store-mariadb
-        - ds-pipeline-ui
-        - object-store-minio
-        - default-configs
-      repoRef:
-        name: manifests
-        path: data-science-pipelines
-    name: data-science-pipelines
-  - kustomizeConfig:
       parameters:
       - name: monitoring-namespace
         value: opendatahub
@@ -86,11 +76,6 @@ spec:
         name: manifests-trustyai
         path: e2e_tests/resources/manifests/trustyai-service
     name: trustyai
-  - kustomizeConfig:
-      repoRef:
-        name: manifests
-        path: data-science-pipelines-operator/
-    name: data-science-pipelines-operator
   repos:
   - name: manifests
     uri: https://github.com/opendatahub-io/odh-manifests/tarball/master


### PR DESCRIPTION
DSP seems to have been removed from odh-manifests, so it needs to be removed from the e2e test ODH KFDef

Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `FAI-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.3.x] FAI-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

