### PR TITLE
RHODS-8228: Add guard against batch size larger than data

### DIFF
--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/BaseMetricRequest.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/BaseMetricRequest.java
@@ -108,8 +108,8 @@ public class BaseMetricRequest {
                 && outcomeName.equals(that.outcomeName)
                 && privilegedAttribute.equals(that.privilegedAttribute)
                 && unprivilegedAttribute.equals(that.unprivilegedAttribute)
-                && thresholdDelta == that.thresholdDelta
-                && batchSize == that.batchSize;
+                && Objects.equals(thresholdDelta, that.thresholdDelta)
+                && Objects.equals(batchSize, that.batchSize);
     }
 
     @Override

--- a/explainability-service/src/main/java/org/kie/trustyai/service/prometheus/PrometheusScheduler.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/prometheus/PrometheusScheduler.java
@@ -68,14 +68,14 @@ public class PrometheusScheduler {
 
                     // SPD requests
                     modelSpdRequest.forEach(entry -> {
-                        final Dataframe batch = df.tail(entry.getValue().getBatchSize());
+                        final Dataframe batch = df.tail(Math.min(df.getRowDimension(), entry.getValue().getBatchSize()));
                         final double spd = calculator.calculateSPD(batch, entry.getValue());
                         publisher.gaugeSPD(entry.getValue(), modelId, entry.getKey(), spd);
                     });
 
                     // DIR requests
                     modelDirRequest.forEach(entry -> {
-                        final Dataframe batch = df.tail(entry.getValue().getBatchSize());
+                        final Dataframe batch = df.tail(Math.min(df.getRowDimension(), entry.getValue().getBatchSize()));
                         final double dir = calculator.calculateDIR(batch, entry.getValue());
                         publisher.gaugeDIR(entry.getValue(), modelId, entry.getKey(), dir);
                     });

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/DisparateImpactRatioEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/DisparateImpactRatioEndpointTest.java
@@ -40,16 +40,16 @@ import static org.junit.jupiter.api.Assertions.*;
 class DisparateImpactRatioEndpointTest {
 
     private static final String MODEL_ID = "example1";
+    private static final int N_SAMPLES = 100;
     @Inject
     Instance<MockDatasource> datasource;
-
     @Inject
     Instance<MockMemoryStorage> storage;
 
     @BeforeEach
     void populateStorage() throws JsonProcessingException {
         storage.get().emptyStorage();
-        final Dataframe dataframe = datasource.get().generateRandomDataframe(1000);
+        final Dataframe dataframe = datasource.get().generateRandomDataframe(N_SAMPLES);
         datasource.get().saveDataframe(dataframe, MODEL_ID);
         datasource.get().saveMetadata(datasource.get().createMetadata(dataframe), MODEL_ID);
     }

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/GroupStatisticalParityDifferenceRequestsEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/GroupStatisticalParityDifferenceRequestsEndpointTest.java
@@ -9,6 +9,7 @@ import javax.ws.rs.core.Response;
 
 import org.jboss.resteasy.reactive.RestResponse;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.kie.trustyai.explainability.model.Dataframe;
 import org.kie.trustyai.service.config.ServiceConfig;
@@ -17,6 +18,7 @@ import org.kie.trustyai.service.mocks.MockMemoryStorage;
 import org.kie.trustyai.service.mocks.MockPrometheusScheduler;
 import org.kie.trustyai.service.payloads.BaseMetricRequest;
 import org.kie.trustyai.service.payloads.BaseScheduledResponse;
+import org.kie.trustyai.service.payloads.scheduler.ScheduleList;
 
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
@@ -25,8 +27,7 @@ import io.restassured.http.ContentType;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 @QuarkusTest
 @TestProfile(MetricsEndpointTestProfile.class)
@@ -34,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class GroupStatisticalParityDifferenceRequestsEndpointTest {
 
     private static final String MODEL_ID = "example1";
+    private static final int N_SAMPLES = 100;
     @Inject
     Instance<MockDatasource> datasource;
 
@@ -139,6 +141,56 @@ class GroupStatisticalParityDifferenceRequestsEndpointTest {
                 .getDirRequests();
 
         assertTrue(requests.isEmpty());
+    }
+
+    @DisplayName("DIR request with custom batch size")
+    void requestCustomBatchSize() {
+
+        // No schedule request made yet
+        final ScheduleList emptyList = given()
+                .when()
+                .get("/requests")
+                .then().statusCode(200).extract().body().as(ScheduleList.class);
+
+        assertEquals(0, emptyList.requests.size());
+
+        // Perform multiple schedule requests
+        final BaseMetricRequest payload = RequestPayloadGenerator.correct();
+        payload.setBatchSize(N_SAMPLES - 10);
+        final BaseScheduledResponse firstRequest = given()
+                .contentType(ContentType.JSON)
+                .body(payload)
+                .when()
+                .post("/request")
+                .then().statusCode(200).extract().body().as(BaseScheduledResponse.class);
+
+        assertNotNull(firstRequest.getRequestId());
+
+        payload.setBatchSize(N_SAMPLES + 1000);
+        final BaseScheduledResponse secondRequest = given()
+                .contentType(ContentType.JSON)
+                .body(payload)
+                .when()
+                .post("/request")
+                .then().statusCode(200).extract().body().as(BaseScheduledResponse.class);
+
+        assertNotNull(secondRequest.getRequestId());
+
+        payload.setBatchSize(0);
+        given()
+                .contentType(ContentType.JSON)
+                .body(payload)
+                .when()
+                .post("/request")
+                .then().statusCode(400).body(containsString("Request batch size must be bigger than 0."));
+
+        ScheduleList scheduleList = given()
+                .when()
+                .get("/requests")
+                .then().statusCode(200).extract().body().as(ScheduleList.class);
+
+        // Correct number of active requests
+        assertEquals(2, scheduleList.requests.size());
     }
 
 }


### PR DESCRIPTION
Add guard against metric calculation requests with a batch size larger than the dataframe (and associated tests).

