### PR TITLE
RHODS-8280: Fix flaky tests for metric threshs and unique value counts

### DIFF
--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/DisparateImpactRatioEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/DisparateImpactRatioEndpointTest.java
@@ -102,9 +102,9 @@ class DisparateImpactRatioEndpointTest {
         assertEquals("DIR", response.getName());
         assertFalse(response.getThresholds().outsideBounds);
 
-        // with tiny threshold, the DIR is outside bounds
+        // with negative threshold, the DIR is guaranteed outside bounds
         payload = RequestPayloadGenerator.correct();
-        payload.setThresholdDelta(.01);
+        payload.setThresholdDelta(-.5);
         response = given()
                 .contentType(ContentType.JSON)
                 .body(payload)

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/service/ServiceMetadataEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/service/ServiceMetadataEndpointTest.java
@@ -75,7 +75,7 @@ class ServiceMetadataEndpointTest {
 
     @Test
     void getThousandObservations() throws JsonProcessingException {
-        final Dataframe dataframe = datasource.get().generateRandomDataframe(1000);
+        final Dataframe dataframe = datasource.get().generateRandomDataframe(1000, 50);
         datasource.get().saveDataframe(dataframe, MODEL_ID);
         datasource.get().saveMetadata(datasource.get().createMetadata(dataframe), MODEL_ID);
 
@@ -93,7 +93,7 @@ class ServiceMetadataEndpointTest {
         assertEquals(1000, serviceMetadata.get(0).getData().getObservations());
 
         // check column values
-        assertEquals(100, serviceMetadata.get(0).getData().getInputSchema().getItems().get(0).getValues().size());
+        assertEquals(50, serviceMetadata.get(0).getData().getInputSchema().getItems().get(0).getValues().size());
         assertEquals(2, serviceMetadata.get(0).getData().getInputSchema().getItems().get(1).getValues().size());
         assertFalse(serviceMetadata.get(0).getData().getOutputSchema().getItems().isEmpty());
         assertFalse(serviceMetadata.get(0).getData().getInputSchema().getItems().isEmpty());

--- a/explainability-service/src/test/java/org/kie/trustyai/service/mocks/MockDatasource.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/mocks/MockDatasource.java
@@ -45,7 +45,8 @@ public class MockDatasource extends DataSource {
                     FeatureFactory.newObjectFeature(MetadataUtils.ID_FIELD, UUID.randomUUID()),
                     FeatureFactory.newObjectFeature(MetadataUtils.TIMESTAMP_FIELD, LocalDateTime.now()),
 
-                    FeatureFactory.newNumericalFeature("age", random.nextInt(featureDiversity)),
+                    // guarantee feature diversity for age is min(observations, featureDiversity)
+                    FeatureFactory.newNumericalFeature("age", i%featureDiversity),
                     FeatureFactory.newNumericalFeature("gender", random.nextBoolean() ? 1 : 0),
                     FeatureFactory.newNumericalFeature("race", random.nextBoolean() ? 1 : 0));
             final PredictionInput predictionInput = new PredictionInput(featureList);

--- a/explainability-service/src/test/java/org/kie/trustyai/service/mocks/MockDatasource.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/mocks/MockDatasource.java
@@ -46,7 +46,7 @@ public class MockDatasource extends DataSource {
                     FeatureFactory.newObjectFeature(MetadataUtils.TIMESTAMP_FIELD, LocalDateTime.now()),
 
                     // guarantee feature diversity for age is min(observations, featureDiversity)
-                    FeatureFactory.newNumericalFeature("age", i%featureDiversity),
+                    FeatureFactory.newNumericalFeature("age", i % featureDiversity),
                     FeatureFactory.newNumericalFeature("gender", random.nextBoolean() ? 1 : 0),
                     FeatureFactory.newNumericalFeature("race", random.nextBoolean() ? 1 : 0));
             final PredictionInput predictionInput = new PredictionInput(featureList);


### PR DESCRIPTION
This changes:

- The DIR OutsideThresholdDelta check now has a negative delta, so will always return outsidebounds=true for any value (avoids RNG issues)
- The serviceMetadata feature diversity checks now guarantee the feature diversity is equal to the specified value, which will avoid the hash collisions from randomly generated feature values we were seeing before



Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `FAI-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.3.x] FAI-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

