### PR TITLE
Updated dev profile with missing mandatory properties

### DIFF
--- a/explainability-service/src/main/resources/application.properties
+++ b/explainability-service/src/main/resources/application.properties
@@ -31,6 +31,12 @@ quarkus.openshift.mounts.volume.path=/inputs
 quarkus.openshift.pvc-volumes.volume.claim-name=trustyai-service-pvc
 # Dev
 quarkus.kubernetes.deployment-target=openshift
+service.storage-format=memory
+service.data-format=csv
+service.metrics-schedule=5s
+storage.data-filename=data.csv
+storage.data-folder=/inputs
+service.batch-size=5000
 # Development/testing options
 quarkus.kubernetes.image-pull-policy=Never
 quarkus.kubernetes.env.vars.model-name=example

--- a/explainability-service/src/main/resources/application.properties
+++ b/explainability-service/src/main/resources/application.properties
@@ -31,12 +31,12 @@ quarkus.openshift.mounts.volume.path=/inputs
 quarkus.openshift.pvc-volumes.volume.claim-name=trustyai-service-pvc
 # Dev
 quarkus.kubernetes.deployment-target=openshift
-service.storage-format=memory
-service.data-format=csv
-service.metrics-schedule=5s
-storage.data-filename=data.csv
-storage.data-folder=/inputs
-service.batch-size=5000
+%dev.service.storage-format=memory
+%dev.service.data-format=csv
+%dev.service.metrics-schedule=5s
+%dev.storage.data-filename=data.csv
+%dev.storage.data-folder=/inputs
+%dev.service.batch-size=5000
 # Development/testing options
 quarkus.kubernetes.image-pull-policy=Never
 quarkus.kubernetes.env.vars.model-name=example


### PR DESCRIPTION
Fixed dev profile with missing mandatory properties, to allow running the _explainability-service_ with `mvn quarkus:dev` .

Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [X] You have read the [contributors guide](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `FAI-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting main: `[0.3.x] FAI-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

