### PR TITLE
Added universal requests endpoint to list all active requests

### DIFF
--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/UniversalListingEndpoint.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/UniversalListingEndpoint.java
@@ -1,0 +1,48 @@
+package org.kie.trustyai.service.endpoints.metrics;
+
+import java.util.Map;
+import java.util.UUID;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.jboss.logging.Logger;
+import org.kie.trustyai.service.payloads.BaseMetricRequest;
+import org.kie.trustyai.service.payloads.scheduler.ScheduleList;
+import org.kie.trustyai.service.payloads.scheduler.ScheduleRequest;
+import org.kie.trustyai.service.prometheus.PrometheusScheduler;
+
+@Tag(name = "Metrics Information Endpoint", description = "Return a list of all metrics being currently requested.")
+@Path("/metrics/all")
+public class UniversalListingEndpoint implements MetricsEndpoint {
+    private static final Logger LOG = Logger.getLogger(UniversalListingEndpoint.class);
+
+    @Inject
+    PrometheusScheduler scheduler;
+
+    UniversalListingEndpoint() {
+        super();
+    }
+
+    @Override
+    public String getMetricName() {
+        return "spd";
+    }
+
+    @Override
+    @GET
+    @Path("/requests")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listRequests() {
+        final ScheduleList scheduleList = new ScheduleList();
+        for (Map.Entry<UUID, BaseMetricRequest> entry : scheduler.getAllRequests().entrySet()) {
+            scheduleList.requests.add(new ScheduleRequest(entry.getKey(), entry.getValue()));
+        }
+        return Response.ok(scheduleList).build();
+    }
+}

--- a/explainability-service/src/main/java/org/kie/trustyai/service/prometheus/PrometheusScheduler.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/prometheus/PrometheusScheduler.java
@@ -43,6 +43,13 @@ public class PrometheusScheduler {
         return spdRequests;
     }
 
+    public Map<UUID, BaseMetricRequest> getAllRequests() {
+        // extend this with other metrics when more are added
+        Map<UUID, BaseMetricRequest> result = getDirRequests();
+        result.putAll(getSpdRequests());
+        return result;
+    }
+
     @Scheduled(every = "{service.metrics-schedule}")
     void calculate() {
 

--- a/explainability-service/src/main/java/org/kie/trustyai/service/prometheus/PrometheusScheduler.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/prometheus/PrometheusScheduler.java
@@ -1,6 +1,7 @@
 package org.kie.trustyai.service.prometheus;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -23,8 +24,8 @@ import io.quarkus.scheduler.Scheduled;
 public class PrometheusScheduler {
 
     private static final Logger LOG = Logger.getLogger(PrometheusScheduler.class);
-    private final Map<UUID, BaseMetricRequest> spdRequests = new HashMap<>();
-    private final Map<UUID, BaseMetricRequest> dirRequests = new HashMap<>();
+    private final ConcurrentHashMap<UUID, BaseMetricRequest> spdRequests = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<UUID, BaseMetricRequest> dirRequests = new ConcurrentHashMap<>();
     @Inject
     Instance<DataSource> dataSource;
     @Inject
@@ -45,7 +46,8 @@ public class PrometheusScheduler {
 
     public Map<UUID, BaseMetricRequest> getAllRequests() {
         // extend this with other metrics when more are added
-        Map<UUID, BaseMetricRequest> result = getDirRequests();
+        ConcurrentHashMap<UUID, BaseMetricRequest> result = new ConcurrentHashMap<>();
+        result.putAll(getDirRequests());
         result.putAll(getSpdRequests());
         return result;
     }

--- a/explainability-service/src/main/java/org/kie/trustyai/service/prometheus/PrometheusScheduler.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/prometheus/PrometheusScheduler.java
@@ -45,7 +45,8 @@ public class PrometheusScheduler {
 
     public Map<UUID, BaseMetricRequest> getAllRequests() {
         // extend this with other metrics when more are added
-        Map<UUID, BaseMetricRequest> result = getDirRequests();
+        Map<UUID, BaseMetricRequest> result = new HashMap<>();
+        result.putAll(getDirRequests());
         result.putAll(getSpdRequests());
         return result;
     }

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/UniversalListingEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/UniversalListingEndpointTest.java
@@ -1,0 +1,87 @@
+package org.kie.trustyai.service.endpoints.metrics;
+
+import java.util.UUID;
+
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.kie.trustyai.explainability.model.Dataframe;
+import org.kie.trustyai.service.mocks.MockDatasource;
+import org.kie.trustyai.service.mocks.MockMemoryStorage;
+import org.kie.trustyai.service.payloads.BaseMetricRequest;
+import org.kie.trustyai.service.payloads.BaseScheduledResponse;
+import org.kie.trustyai.service.payloads.scheduler.ScheduleList;
+import org.kie.trustyai.service.payloads.scheduler.ScheduleRequest;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.http.ContentType;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+@TestProfile(MetricsEndpointTestProfile.class)
+class UniversalListingEndpointTest {
+    private static final String MODEL_ID = "example1";
+    @Inject
+    Instance<MockDatasource> datasource;
+    @Inject
+    Instance<MockMemoryStorage> storage;
+
+    @BeforeEach
+    void populateStorage() throws JsonProcessingException {
+        storage.get().emptyStorage();
+        final Dataframe dataframe = datasource.get().generateRandomDataframe(1000);
+        datasource.get().saveDataframe(dataframe, MODEL_ID);
+        datasource.get().saveMetadata(datasource.get().createMetadata(dataframe), MODEL_ID);
+    }
+
+    @DisplayName("Check multi-metrics requests are returned")
+    @Test
+    void requestCustomBatchSize() {
+        // No schedule request made yet
+        final ScheduleList emptyList = given()
+                .when()
+                .get("/metrics/all/requests")
+                .then().statusCode(200).extract().body().as(ScheduleList.class);
+        assertEquals(0, emptyList.requests.size());
+
+        // Perform multiple schedule requests
+        final BaseMetricRequest payload = RequestPayloadGenerator.correct();
+        final BaseScheduledResponse firstRequest = given()
+                .contentType(ContentType.JSON)
+                .body(payload)
+                .when()
+                .post("/metrics/dir/request")
+                .then().statusCode(200).extract().body().as(BaseScheduledResponse.class);
+        assertNotNull(firstRequest.getRequestId());
+        UUID first = firstRequest.getRequestId();
+
+        final BaseScheduledResponse secondRequest = given()
+                .contentType(ContentType.JSON)
+                .body(payload)
+                .when()
+                .post("/metrics/spd/request")
+                .then().statusCode(200).extract().body().as(BaseScheduledResponse.class);
+        assertNotNull(secondRequest.getRequestId());
+        UUID second = secondRequest.getRequestId();
+
+        ScheduleList scheduleList = given()
+                .when()
+                .get("/metrics/all/requests")
+                .then().statusCode(200).extract().body().as(ScheduleList.class);
+        for (ScheduleRequest sr : scheduleList.requests) {
+            assertTrue(sr.id.equals(first) ^ sr.id.equals(second));
+        }
+
+        // Correct number of active requests
+        assertEquals(2, scheduleList.requests.size());
+    }
+
+}

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/UniversalListingEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/UniversalListingEndpointTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.kie.trustyai.explainability.model.Dataframe;
 import org.kie.trustyai.service.mocks.MockDatasource;
 import org.kie.trustyai.service.mocks.MockMemoryStorage;
+import org.kie.trustyai.service.mocks.MockPrometheusScheduler;
 import org.kie.trustyai.service.payloads.BaseMetricRequest;
 import org.kie.trustyai.service.payloads.BaseScheduledResponse;
 import org.kie.trustyai.service.payloads.scheduler.ScheduleList;
@@ -34,9 +35,14 @@ class UniversalListingEndpointTest {
     @Inject
     Instance<MockMemoryStorage> storage;
 
+    @Inject
+    Instance<MockPrometheusScheduler> scheduler;
+
     @BeforeEach
     void populateStorage() throws JsonProcessingException {
         storage.get().emptyStorage();
+        scheduler.get().getDirRequests().clear();
+        scheduler.get().getSpdRequests().clear();
         final Dataframe dataframe = datasource.get().generateRandomDataframe(1000);
         datasource.get().saveDataframe(dataframe, MODEL_ID);
         datasource.get().saveMetadata(datasource.get().createMetadata(dataframe), MODEL_ID);
@@ -44,7 +50,7 @@ class UniversalListingEndpointTest {
 
     @DisplayName("Check multi-metrics requests are returned")
     @Test
-    void requestCustomBatchSize() {
+    void requestMultipleMetricsSize() {
         // No schedule request made yet
         final ScheduleList emptyList = given()
                 .when()


### PR DESCRIPTION
Now have `/metrics/all/requests` to concatenate outputs of other metrics listings endpoints


Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `FAI-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.3.x] FAI-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

