### PR TITLE
RHODS-8824: Add Metric Name to Requests return

### DIFF
--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/DisparateImpactRatioEndpoint.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/DisparateImpactRatioEndpoint.java
@@ -59,7 +59,7 @@ public class DisparateImpactRatioEndpoint implements MetricsEndpoint {
 
     @Override
     public String getMetricName() {
-        return "dir";
+        return "DIR";
     }
 
     @POST
@@ -131,6 +131,7 @@ public class DisparateImpactRatioEndpoint implements MetricsEndpoint {
             request.setBatchSize(defaultBatchSize);
         }
 
+        request.setMetricName(getMetricName());
         scheduler.registerDIR(id, request);
 
         final BaseScheduledResponse response =

--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/GroupStatisticalParityDifferenceEndpoint.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/GroupStatisticalParityDifferenceEndpoint.java
@@ -58,7 +58,7 @@ public class GroupStatisticalParityDifferenceEndpoint implements MetricsEndpoint
 
     @Override
     public String getMetricName() {
-        return "spd";
+        return "SPD";
     }
 
     @Override
@@ -142,6 +142,7 @@ public class GroupStatisticalParityDifferenceEndpoint implements MetricsEndpoint
             request.setBatchSize(defaultBatchSize);
         }
 
+        request.setMetricName(getMetricName());
         scheduler.registerSPD(id, request);
 
         final BaseScheduledResponse response =

--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/BaseMetricRequest.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/BaseMetricRequest.java
@@ -15,7 +15,12 @@ public class BaseMetricRequest {
     private TypedValue privilegedAttribute;
     private TypedValue unprivilegedAttribute;
     private String modelId;
+
+    // this is the unique name of this specific request
     private String requestName;
+
+    // this is the name of the metric that this request calculates, e.g., DIR or SPD
+    private String metricName;
     private Double thresholdDelta;
 
     private Integer batchSize;
@@ -96,6 +101,14 @@ public class BaseMetricRequest {
         this.batchSize = batchSize;
     }
 
+    public String getMetricName() {
+        return metricName;
+    }
+
+    public void setMetricName(String metricName) {
+        this.metricName = metricName;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o)
@@ -108,6 +121,7 @@ public class BaseMetricRequest {
                 && outcomeName.equals(that.outcomeName)
                 && privilegedAttribute.equals(that.privilegedAttribute)
                 && unprivilegedAttribute.equals(that.unprivilegedAttribute)
+                && metricName.equals(that.metricName)
                 && Objects.equals(thresholdDelta, that.thresholdDelta)
                 && Objects.equals(batchSize, that.batchSize);
     }
@@ -120,6 +134,7 @@ public class BaseMetricRequest {
                 privilegedAttribute,
                 unprivilegedAttribute,
                 thresholdDelta,
-                batchSize);
+                batchSize,
+                metricName);
     }
 }

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/UniversalListingEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/UniversalListingEndpointTest.java
@@ -83,7 +83,13 @@ class UniversalListingEndpointTest {
                 .get("/metrics/all/requests")
                 .then().statusCode(200).extract().body().as(ScheduleList.class);
         for (ScheduleRequest sr : scheduleList.requests) {
-            assertTrue(sr.id.equals(first) ^ sr.id.equals(second));
+            if (sr.id.equals(first)) {
+                assertEquals("DIR", sr.request.getMetricName());
+            } else if (sr.id.equals(second)) {
+                assertEquals("SPD", sr.request.getMetricName());
+            } else {
+                fail();
+            }
         }
 
         // Correct number of active requests


### PR DESCRIPTION
This adds an auto-generated MetricName (e.g., SPD or DIR) to the metricRequest payload, so that the info payloads return  relevant distinguishing information 

Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `FAI-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.3.x] FAI-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

