### PR TITLE
RHODS-8306: Feature+output name mapping endpoint

### DIFF
--- a/explainability-service/README.md
+++ b/explainability-service/README.md
@@ -521,31 +521,31 @@ Will return, for instance
             }
         },
         "data": {
-            "inputSchema": [
-                {
-                    "type": "DOUBLE",
-                    "name": "input-0",
-                    "index": 2
+            "inputSchema": {
+                "items": {
+                    "input-0": {
+                        "type": "DOUBLE",
+                        "name": "input-0",
+                        "index": 1
+                    }, 
                 },
-                {
-                    "type": "DOUBLE",
-                    "name": "input-1",
-                    "index": 3
+                nameMapping: {
+                    "input-0": "Age",
+                }
+            },
+            "outputSchema": {
+                "items": {
+                    "output-0": {
+                        "type": "INT32",
+                        "name": "output-0",
+                        "index": 5
+                    }
                 },
-                {
-                    "type": "DOUBLE",
-                    "name": "input-2",
-                    "index": 4
+                "nameMapping:" {
+                    "output-0": "Income",
                 }
-            ],
-            "outputSchema": [
-                {
-                    "type": "DOUBLE",
-                    "name": "output-0",
-                    "index": 5
-                }
-            ],
-            "observations": 83,
+            },
+            "observations": 105,
             "modelId": "example-model-1"
         }
     },
@@ -557,31 +557,37 @@ Will return, for instance
             }
         },
         "data": {
-            "inputSchema": [
-                {
-                    "type": "DOUBLE",
-                    "name": "input-0",
-                    "index": 2
+            "inputSchema": {
+                "items": {
+                    "input-0": {
+                        "type": "DOUBLE",
+                        "name": "input-0",
+                        "index": 1
+                    },
+                     "input-1": {
+                        "type": "DOUBLE",
+                        "name": "input-1",
+                        "index": 2
+                    }              
                 },
-                {
-                    "type": "DOUBLE",
-                    "name": "input-1",
-                    "index": 3
+                nameMapping: {
+                    "input-0": "Age",
+                    "input-2": "Race",
+                }
+            },
+            "outputSchema": {
+                "items": {
+                    "output-0": {
+                        "type": "INT32",
+                        "name": "output-0",
+                        "index": 5
+                    }
                 },
-                {
-                    "type": "DOUBLE",
-                    "name": "input-2",
-                    "index": 4
+                "nameMapping:" {
+                    "output-0": "Income",
                 }
-            ],
-            "outputSchema": [
-                {
-                    "type": "DOUBLE",
-                    "name": "output-0",
-                    "index": 5
-                }
-            ],
-            "observations": 83,
+            },
+            "observations": 105,
             "modelId": "example-model-2"
         }
     },
@@ -593,41 +599,79 @@ Will return, for instance
             }
         },
         "data": {
-            "inputSchema": [
-                {
-                    "type": "DOUBLE",
-                    "name": "input-0",
-                    "index": 2
+            "inputSchema": {
+                "items": {
+                    "input-0": {
+                        "type": "DOUBLE",
+                        "name": "input-0",
+                        "index": 1
+                    },
+                     "input-1": {
+                        "type": "DOUBLE",
+                        "name": "input-1",
+                        "index": 2
+                    },
+                    "input-2": {
+                        "type": "DOUBLE",
+                        "name": "input-1",
+                        "index": 3
+                    },
+                    "input-3": {
+                        "type": "DOUBLE",
+                        "name": "input-3",
+                        "index": 4
+                    }
                 },
-                {
-                    "type": "DOUBLE",
-                    "name": "input-1",
-                    "index": 3
-                },
-                {
-                    "type": "DOUBLE",
-                    "name": "input-2",
-                    "index": 4
+                nameMapping: {
+                    "input-0": "Age",
+                    "input-2": "Race",
+                    "input-3": "Gender",
+                    "input-4": "Employment",
                 }
-            ],
-            "outputSchema": [
-                {
-                    "type": "INT32",
-                    "name": "output-0",
-                    "index": 5
+            },
+            "outputSchema": {
+                "items": {
+                    "output-0": {
+                        "type": "INT32",
+                        "name": "output-0",
+                        "index": 5
+                    },
+                    "output-1": {
+                            "type": "INT32",
+                            "name": "output-1",
+                            "index": 6
+                    }
                 },
-                {
-                    "type": "INT32",
-                    "name": "output-1",
-                    "index": 6
+                "nameMapping:" {
+                    "output-0": "Income",
+                    "output-1": "Credit Score",
                 }
-            ],
+            },
             "observations": 85,
             "modelId": "example-model-3"
         }
     }
 ]
 ```
+## Defining Feature/Output Names
+```bash
+curl -X POST --location "http://localhost:8080/q/info" \
+    -H "Content-Type: application/json" \
+    -d '{
+        "modelId": "example-model-1", 
+        "inputMapping": 
+            {
+                "input-0": "age", 
+                "input-1": "race",
+                "input-2": "gender"
+            },
+        "outputMapping": 
+            {
+                "output-0": "predictedIncome=high"
+            }
+    }'
+```
+
 
 # Data sources
 

--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/service/NameMapping.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/service/NameMapping.java
@@ -1,0 +1,43 @@
+package org.kie.trustyai.service.payloads.service;
+
+import java.util.Map;
+import java.util.Objects;
+
+public class NameMapping {
+    private final String modelID;
+    private final Map<String, String> inputMapping;
+    private final Map<String, String> outputMapping;
+
+    public NameMapping(String modelID, Map<String, String> inputMapping, Map<String, String> outputMapping) {
+        this.modelID = modelID;
+        this.inputMapping = inputMapping;
+        this.outputMapping = outputMapping;
+    }
+
+    public String getModelID() {
+        return modelID;
+    }
+
+    public Map<String, String> getInputMapping() {
+        return inputMapping;
+    }
+
+    public Map<String, String> getOutputMapping() {
+        return outputMapping;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        NameMapping that = (NameMapping) o;
+        return modelID.equals(that.modelID) && inputMapping.equals(that.inputMapping) && outputMapping.equals(that.outputMapping);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(modelID, inputMapping, outputMapping);
+    }
+}

--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/service/Schema.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/service/Schema.java
@@ -1,11 +1,13 @@
 package org.kie.trustyai.service.payloads.service;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class Schema {
     private final Map<String, SchemaItem> items;
+    private Map<String, String> nameMapping = new HashMap<>();
 
     public Schema() {
         this.items = new ConcurrentHashMap<>();
@@ -21,6 +23,14 @@ public class Schema {
 
     public Map<String, SchemaItem> getItems() {
         return items;
+    }
+
+    public Map<String, String> getNameMapping() {
+        return nameMapping;
+    }
+
+    public void setNameMapping(Map<String, String> nameMapping) {
+        this.nameMapping = nameMapping;
     }
 
     @Override


### PR DESCRIPTION
Adds the ability to post a `NameMapping` to the metadata endpoint to assign feature and output name aliases to the service metadata. This does not overwrite the existing names of features or outputs, but rather adds an optional mapping to allow for non-destructive renaming.


Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `FAI-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.3.x] FAI-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

