### PR TITLE
Fix floating-point edge case in payload conversion

### DIFF
--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/BaseMetricRequest.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/BaseMetricRequest.java
@@ -3,17 +3,17 @@ package org.kie.trustyai.service.payloads;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ValueNode;
 
 @JsonPropertyOrder({ "protected", "favorable" })
 public class BaseMetricRequest {
 
     private String protectedAttribute;
-    private JsonNode favorableOutcome;
+    private ValueNode favorableOutcome;
     private String outcomeName;
 
-    private JsonNode privilegedAttribute;
-    private JsonNode unprivilegedAttribute;
+    private ValueNode privilegedAttribute;
+    private ValueNode unprivilegedAttribute;
 
     private String modelId;
 
@@ -62,29 +62,29 @@ public class BaseMetricRequest {
         this.outcomeName = outcomeName;
     }
 
-    // raw getters and setters  ================================================
-    public void setFavorableOutcome(JsonNode favorableOutcome) {
-        this.favorableOutcome = favorableOutcome;
-    }
-
-    public void setPrivilegedAttribute(JsonNode privilegedAttribute) {
-        this.privilegedAttribute = privilegedAttribute;
-    }
-
-    public void setUnprivilegedAttribute(JsonNode unprivilegedAttribute) {
-        this.unprivilegedAttribute = unprivilegedAttribute;
-    }
-
-    public JsonNode getFavorableOutcome() {
+    public ValueNode getFavorableOutcome() {
         return favorableOutcome;
     }
 
-    public JsonNode getPrivilegedAttribute() {
+    // raw getters and setters  ================================================
+    public void setFavorableOutcome(ValueNode favorableOutcome) {
+        this.favorableOutcome = favorableOutcome;
+    }
+
+    public ValueNode getPrivilegedAttribute() {
         return privilegedAttribute;
     }
 
-    public JsonNode getUnprivilegedAttribute() {
+    public void setPrivilegedAttribute(ValueNode privilegedAttribute) {
+        this.privilegedAttribute = privilegedAttribute;
+    }
+
+    public ValueNode getUnprivilegedAttribute() {
         return unprivilegedAttribute;
+    }
+
+    public void setUnprivilegedAttribute(ValueNode unprivilegedAttribute) {
+        this.unprivilegedAttribute = unprivilegedAttribute;
     }
 
     public Double getThresholdDelta() {

--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/PayloadConverter.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/PayloadConverter.java
@@ -5,7 +5,7 @@ import org.kie.trustyai.explainability.model.Value;
 import org.kie.trustyai.service.payloads.values.DataType;
 import org.kie.trustyai.service.payloads.values.TypedValue;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ValueNode;
 
 import static org.kie.trustyai.service.payloads.values.DataType.*;
 
@@ -30,7 +30,7 @@ public class PayloadConverter {
         }
     }
 
-    public static boolean checkValueType(DataType type, JsonNode v) {
+    public static boolean checkValueType(DataType type, ValueNode v) {
         if (type == BOOL) {
             return v.isBoolean();
         } else if (type == FLOAT) {
@@ -38,9 +38,9 @@ public class PayloadConverter {
         } else if (type == DOUBLE) {
             return v.isNumber();
         } else if (type == INT32) {
-            return v.isInt();
+            return v.canConvertToExactIntegral();
         } else if (type == INT64) {
-            return v.isLong() || v.isInt();
+            return v.canConvertToExactIntegral();
         } else if (type == STRING) {
             return v.isTextual();
         } else {

--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/PayloadConverter.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/PayloadConverter.java
@@ -34,9 +34,9 @@ public class PayloadConverter {
         if (type == BOOL) {
             return v.isBoolean();
         } else if (type == FLOAT) {
-            return v.isFloat() || v.isDouble();
+            return v.isNumber();
         } else if (type == DOUBLE) {
-            return v.isDouble();
+            return v.isNumber();
         } else if (type == INT32) {
             return v.isInt();
         } else if (type == INT64) {

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/DisparateImpactRatioEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/DisparateImpactRatioEndpointTest.java
@@ -151,7 +151,7 @@ class DisparateImpactRatioEndpointTest {
     void postIncorrectInput() throws JsonProcessingException {
         datasource.get().reset();
 
-        final Map<String, Object> payload = RequestPayloadGenerator.incorrectInput();
+        final BaseMetricRequest payload = RequestPayloadGenerator.incorrectInput();
 
         given()
                 .contentType(ContentType.JSON)

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/GroupStatisticalParityDifferenceEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/GroupStatisticalParityDifferenceEndpointTest.java
@@ -143,7 +143,7 @@ class GroupStatisticalParityDifferenceEndpointTest {
     @Test
     @DisplayName("SPD request with incorrect input")
     void postIncorrectInput() {
-        final Map<String, Object> payload = RequestPayloadGenerator.incorrectInput();
+        final BaseMetricRequest payload = RequestPayloadGenerator.incorrectInput();
 
         given()
                 .contentType(ContentType.JSON)

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/RequestPayloadGenerator.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/RequestPayloadGenerator.java
@@ -5,7 +5,8 @@ import java.util.Map;
 
 import org.kie.trustyai.service.payloads.BaseMetricRequest;
 
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 
 public class RequestPayloadGenerator {
 
@@ -14,10 +15,10 @@ public class RequestPayloadGenerator {
     public static BaseMetricRequest correct() {
         BaseMetricRequest request = new BaseMetricRequest();
         request.setProtectedAttribute("gender");
-        request.setFavorableOutcome(JsonNodeFactory.instance.numberNode(1));
+        request.setFavorableOutcome(IntNode.valueOf(1));
         request.setOutcomeName("income");
-        request.setPrivilegedAttribute(JsonNodeFactory.instance.numberNode(1));
-        request.setUnprivilegedAttribute(JsonNodeFactory.instance.numberNode(0));
+        request.setPrivilegedAttribute(IntNode.valueOf(1));
+        request.setUnprivilegedAttribute(IntNode.valueOf(0));
         request.setModelId(MODEL_ID);
 
         return request;
@@ -26,10 +27,10 @@ public class RequestPayloadGenerator {
     public static BaseMetricRequest named(String name) {
         BaseMetricRequest request = new BaseMetricRequest();
         request.setProtectedAttribute("gender");
-        request.setFavorableOutcome(JsonNodeFactory.instance.numberNode(1));
+        request.setFavorableOutcome(IntNode.valueOf(1));
         request.setOutcomeName("income");
-        request.setPrivilegedAttribute(JsonNodeFactory.instance.numberNode(1));
-        request.setUnprivilegedAttribute(JsonNodeFactory.instance.numberNode(0));
+        request.setPrivilegedAttribute(IntNode.valueOf(1));
+        request.setUnprivilegedAttribute(IntNode.valueOf(0));
         request.setModelId(MODEL_ID);
         request.setRequestName(name);
 
@@ -39,35 +40,24 @@ public class RequestPayloadGenerator {
     public static BaseMetricRequest incorrectType() {
         BaseMetricRequest request = new BaseMetricRequest();
         request.setProtectedAttribute("gender");
-        request.setFavorableOutcome(JsonNodeFactory.instance.textNode("male"));
+        request.setFavorableOutcome(TextNode.valueOf("male"));
         request.setOutcomeName("income");
-        request.setPrivilegedAttribute(JsonNodeFactory.instance.numberNode(1));
-        request.setUnprivilegedAttribute(JsonNodeFactory.instance.numberNode(0));
+        request.setPrivilegedAttribute(IntNode.valueOf(1));
+        request.setUnprivilegedAttribute(IntNode.valueOf(0));
         request.setModelId(MODEL_ID);
 
         return request;
     }
 
-    public static Map<String, Object> incorrectInput() {
-        final Map<String, Object> payload = new HashMap<>();
-        payload.put("protectedAttribute", "city");
-        Map<String, Object> favorableOutcome = new HashMap<>();
-        favorableOutcome.put("type", "STRING");
-        favorableOutcome.put("value", "approved");
-        payload.put("favorableOutcome", favorableOutcome);
-        payload.put("outcomeName", "income");
-        Map<String, Object> privilegedAttribute = new HashMap<>();
-        privilegedAttribute.put("type", "INT32");
-        privilegedAttribute.put("value", 1);
-        payload.put("privilegedAttribute", privilegedAttribute);
-        Map<String, Object> unprivilegedAttribute = new HashMap<>();
-        unprivilegedAttribute.put("type", "INT32");
-        unprivilegedAttribute.put("value", 0);
-        payload.put("unprivilegedAttribute", unprivilegedAttribute);
-
-        payload.put("modelId", MODEL_ID);
-
-        return payload;
+    public static BaseMetricRequest incorrectInput() {
+        BaseMetricRequest request = new BaseMetricRequest();
+        request.setProtectedAttribute("city");
+        request.setFavorableOutcome(TextNode.valueOf("approved"));
+        request.setOutcomeName("income");
+        request.setPrivilegedAttribute(IntNode.valueOf(1));
+        request.setUnprivilegedAttribute(IntNode.valueOf(0));
+        request.setModelId(MODEL_ID);
+        return request;
     }
 
     public static Map<String, Object> unknownType() {

--- a/explainability-service/src/test/java/org/kie/trustyai/service/payloads/PayloadConverterTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/payloads/PayloadConverterTest.java
@@ -10,7 +10,7 @@ import org.kie.trustyai.service.payloads.values.TypedValue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -121,8 +121,8 @@ class PayloadConverterTest {
 
     @Test
     void testCheckValueTypeBool() {
-        JsonNode boolNode = JsonNodeFactory.instance.booleanNode(true);
-        JsonNode nonBoolNode = JsonNodeFactory.instance.textNode("true");
+        ValueNode boolNode = JsonNodeFactory.instance.booleanNode(true);
+        ValueNode nonBoolNode = JsonNodeFactory.instance.textNode("true");
 
         assertTrue(PayloadConverter.checkValueType(DataType.BOOL, boolNode));
         assertFalse(PayloadConverter.checkValueType(DataType.BOOL, nonBoolNode));
@@ -130,61 +130,76 @@ class PayloadConverterTest {
 
     @Test
     void testCheckValueTypeFloat() {
-        JsonNode floatNode1 = JsonNodeFactory.instance.numberNode(1.1f);
-        JsonNode floatNode2 = JsonNodeFactory.instance.numberNode(1); // edge case
-        JsonNode nonFloatNode = JsonNodeFactory.instance.textNode("1.1");
+        ValueNode node1 = JsonNodeFactory.instance.numberNode(1.1f);
+        ValueNode node2 = JsonNodeFactory.instance.numberNode(1); // edge case
+        ValueNode node3 = JsonNodeFactory.instance.numberNode(1.1d);
+        ValueNode node4 = JsonNodeFactory.instance.numberNode(1d);
+        ValueNode nonFloatNode = JsonNodeFactory.instance.textNode("1.1");
 
-        assertTrue(PayloadConverter.checkValueType(DataType.FLOAT, floatNode1));
-        assertTrue(PayloadConverter.checkValueType(DataType.FLOAT, floatNode2)); // edge case
+        assertTrue(PayloadConverter.checkValueType(DataType.FLOAT, node1));
+        assertTrue(PayloadConverter.checkValueType(DataType.FLOAT, node2)); // edge case
+        assertTrue(PayloadConverter.checkValueType(DataType.FLOAT, node3));
+        assertTrue(PayloadConverter.checkValueType(DataType.FLOAT, node4));
         assertFalse(PayloadConverter.checkValueType(DataType.FLOAT, nonFloatNode));
     }
 
     @Test
     void testCheckValueTypeDouble() {
-        JsonNode doubleNode1 = JsonNodeFactory.instance.numberNode(1.1f);
-        JsonNode doubleNode2 = JsonNodeFactory.instance.numberNode(1);
-        JsonNode nonFloatNode = JsonNodeFactory.instance.textNode("1.1");
 
-        assertTrue(PayloadConverter.checkValueType(DataType.DOUBLE, doubleNode1));
-        assertTrue(PayloadConverter.checkValueType(DataType.DOUBLE, doubleNode2));
-        assertFalse(PayloadConverter.checkValueType(DataType.DOUBLE, nonFloatNode));
+        ValueNode node1 = DoubleNode.valueOf(1.1);
+        ValueNode node2 = IntNode.valueOf(1);
+        ValueNode nonDoubleNode = TextNode.valueOf("1.1");
+        ValueNode node3 = FloatNode.valueOf(1.1f);
+        ValueNode node4 = FloatNode.valueOf(1f);
+
+        assertTrue(PayloadConverter.checkValueType(DataType.DOUBLE, node1));
+        assertTrue(PayloadConverter.checkValueType(DataType.DOUBLE, node2));
+        assertFalse(PayloadConverter.checkValueType(DataType.DOUBLE, nonDoubleNode));
+        assertTrue(PayloadConverter.checkValueType(DataType.DOUBLE, node3));
+        assertTrue(PayloadConverter.checkValueType(DataType.DOUBLE, node4));
     }
 
     @Test
     void testCheckValueTypeInt32() {
-        JsonNode int32Node1 = JsonNodeFactory.instance.numberNode(1.1f);
-        JsonNode int32Node2 = JsonNodeFactory.instance.numberNode(1);
-        JsonNode nonInt32Node = JsonNodeFactory.instance.textNode("1.1");
 
-        assertFalse(PayloadConverter.checkValueType(DataType.INT32, int32Node1));
-        assertTrue(PayloadConverter.checkValueType(DataType.INT32, int32Node2));
+        ValueNode node1 = FloatNode.valueOf(1.1f);
+        ValueNode node2 = IntNode.valueOf(1);
+        ValueNode nonInt32Node = TextNode.valueOf("1.1");
+        ValueNode node3 = DoubleNode.valueOf(1.1d);
+        ValueNode node4 = DoubleNode.valueOf(1d);
+        ValueNode node5 = FloatNode.valueOf(1f);
+
+        assertFalse(PayloadConverter.checkValueType(DataType.INT32, node1));
+        assertTrue(PayloadConverter.checkValueType(DataType.INT32, node2));
         assertFalse(PayloadConverter.checkValueType(DataType.INT32, nonInt32Node));
+        assertFalse(PayloadConverter.checkValueType(DataType.INT32, node3));
+        assertTrue(PayloadConverter.checkValueType(DataType.INT32, node4));
+        assertTrue(PayloadConverter.checkValueType(DataType.INT32, node5));
     }
 
     @Test
     void testCheckValueTypeInt64() {
-        JsonNode int64Node1 = JsonNodeFactory.instance.numberNode(1.1f);
-        JsonNode int64Node2 = JsonNodeFactory.instance.numberNode(1);
-        JsonNode nonInt64Node = JsonNodeFactory.instance.textNode("1.1");
+        ValueNode node1 = FloatNode.valueOf(1.1f);
+        ValueNode node2 = IntNode.valueOf(1);
+        ValueNode nonInt64Node = TextNode.valueOf("1.1");
+        ValueNode node3 = DoubleNode.valueOf(1.1d);
+        ValueNode node4 = DoubleNode.valueOf(1d);
+        ValueNode node5 = FloatNode.valueOf(1f);
 
-        assertFalse(PayloadConverter.checkValueType(DataType.INT64, int64Node1));
-        assertTrue(PayloadConverter.checkValueType(DataType.INT64, int64Node2));
+        assertFalse(PayloadConverter.checkValueType(DataType.INT64, node1));
+        assertTrue(PayloadConverter.checkValueType(DataType.INT64, node2));
         assertFalse(PayloadConverter.checkValueType(DataType.INT64, nonInt64Node));
+        assertFalse(PayloadConverter.checkValueType(DataType.INT64, node3));
+        assertTrue(PayloadConverter.checkValueType(DataType.INT64, node4));
+        assertTrue(PayloadConverter.checkValueType(DataType.INT64, node5));
+
     }
 
     @Test
     void testCheckValueTypeUnknown() {
-        JsonNode node = JsonNodeFactory.instance.textNode("unknown");
+        ValueNode node = JsonNodeFactory.instance.textNode("unknown");
 
         assertFalse(PayloadConverter.checkValueType(DataType.UNKNOWN, node));
     }
 
-    @Test
-    void testCheckValueTypeMap() {
-        // Map is not covered in your function, it will always return false
-        JsonNode node = JsonNodeFactory.instance.objectNode().put("key", "value");
-
-        assertFalse(PayloadConverter.checkValueType(DataType.MAP, node));
-
-    }
 }

--- a/explainability-service/src/test/java/org/kie/trustyai/service/payloads/PayloadConverterTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/payloads/PayloadConverterTest.java
@@ -10,9 +10,9 @@ import org.kie.trustyai.service.payloads.values.TypedValue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class PayloadConverterTest {
 
@@ -117,5 +117,74 @@ class PayloadConverterTest {
         assertEquals(Type.NUMBER, PayloadConverter.convertToType(DataType.INT32));
         assertEquals(Type.NUMBER, PayloadConverter.convertToType(DataType.INT64));
         assertEquals(Type.CATEGORICAL, PayloadConverter.convertToType(DataType.STRING));
+    }
+
+    @Test
+    void testCheckValueTypeBool() {
+        JsonNode boolNode = JsonNodeFactory.instance.booleanNode(true);
+        JsonNode nonBoolNode = JsonNodeFactory.instance.textNode("true");
+
+        assertTrue(PayloadConverter.checkValueType(DataType.BOOL, boolNode));
+        assertFalse(PayloadConverter.checkValueType(DataType.BOOL, nonBoolNode));
+    }
+
+    @Test
+    void testCheckValueTypeFloat() {
+        JsonNode floatNode1 = JsonNodeFactory.instance.numberNode(1.1f);
+        JsonNode floatNode2 = JsonNodeFactory.instance.numberNode(1); // edge case
+        JsonNode nonFloatNode = JsonNodeFactory.instance.textNode("1.1");
+
+        assertTrue(PayloadConverter.checkValueType(DataType.FLOAT, floatNode1));
+        assertTrue(PayloadConverter.checkValueType(DataType.FLOAT, floatNode2)); // edge case
+        assertFalse(PayloadConverter.checkValueType(DataType.FLOAT, nonFloatNode));
+    }
+
+    @Test
+    void testCheckValueTypeDouble() {
+        JsonNode doubleNode1 = JsonNodeFactory.instance.numberNode(1.1f);
+        JsonNode doubleNode2 = JsonNodeFactory.instance.numberNode(1);
+        JsonNode nonFloatNode = JsonNodeFactory.instance.textNode("1.1");
+
+        assertTrue(PayloadConverter.checkValueType(DataType.DOUBLE, doubleNode1));
+        assertTrue(PayloadConverter.checkValueType(DataType.DOUBLE, doubleNode2));
+        assertFalse(PayloadConverter.checkValueType(DataType.DOUBLE, nonFloatNode));
+    }
+
+    @Test
+    void testCheckValueTypeInt32() {
+        JsonNode int32Node1 = JsonNodeFactory.instance.numberNode(1.1f);
+        JsonNode int32Node2 = JsonNodeFactory.instance.numberNode(1);
+        JsonNode nonInt32Node = JsonNodeFactory.instance.textNode("1.1");
+
+        assertFalse(PayloadConverter.checkValueType(DataType.INT32, int32Node1));
+        assertTrue(PayloadConverter.checkValueType(DataType.INT32, int32Node2));
+        assertFalse(PayloadConverter.checkValueType(DataType.INT32, nonInt32Node));
+    }
+
+    @Test
+    void testCheckValueTypeInt64() {
+        JsonNode int64Node1 = JsonNodeFactory.instance.numberNode(1.1f);
+        JsonNode int64Node2 = JsonNodeFactory.instance.numberNode(1);
+        JsonNode nonInt64Node = JsonNodeFactory.instance.textNode("1.1");
+
+        assertFalse(PayloadConverter.checkValueType(DataType.INT64, int64Node1));
+        assertTrue(PayloadConverter.checkValueType(DataType.INT64, int64Node2));
+        assertFalse(PayloadConverter.checkValueType(DataType.INT64, nonInt64Node));
+    }
+
+    @Test
+    void testCheckValueTypeUnknown() {
+        JsonNode node = JsonNodeFactory.instance.textNode("unknown");
+
+        assertFalse(PayloadConverter.checkValueType(DataType.UNKNOWN, node));
+    }
+
+    @Test
+    void testCheckValueTypeMap() {
+        // Map is not covered in your function, it will always return false
+        JsonNode node = JsonNodeFactory.instance.objectNode().put("key", "value");
+
+        assertFalse(PayloadConverter.checkValueType(DataType.MAP, node));
+
     }
 }

--- a/explainability-service/src/test/java/org/kie/trustyai/service/scenarios/nodata/DisparateImpactRatioEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/scenarios/nodata/DisparateImpactRatioEndpointTest.java
@@ -1,6 +1,5 @@
 package org.kie.trustyai.service.scenarios.nodata;
 
-import java.util.Map;
 import java.util.UUID;
 
 import javax.enterprise.inject.Instance;
@@ -87,7 +86,7 @@ class DisparateImpactRatioEndpointTest {
 
     @Test
     void dirPostIncorrectInput() {
-        final Map<String, Object> payload = RequestPayloadGenerator.incorrectInput();
+        final BaseMetricRequest payload = RequestPayloadGenerator.incorrectInput();
 
         given()
                 .contentType(ContentType.JSON)
@@ -95,7 +94,7 @@ class DisparateImpactRatioEndpointTest {
                 .when().post()
                 .then()
                 .statusCode(RestResponse.StatusCode.BAD_REQUEST)
-                .body(containsString("No metadadata found for model=" + payload.get("modelId")));
+                .body(containsString("No metadadata found for model=" + payload.getModelId()));
 
     }
 

--- a/explainability-service/src/test/java/org/kie/trustyai/service/scenarios/nodata/GroupStatisticalParityDifferenceEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/scenarios/nodata/GroupStatisticalParityDifferenceEndpointTest.java
@@ -1,6 +1,5 @@
 package org.kie.trustyai.service.scenarios.nodata;
 
-import java.util.Map;
 import java.util.UUID;
 
 import javax.enterprise.inject.Instance;
@@ -91,7 +90,7 @@ class GroupStatisticalParityDifferenceEndpointTest {
     @Test
     @DisplayName("SPD POST incorrect input (no data)")
     void spdPostIncorrectInput() {
-        final Map<String, Object> payload = RequestPayloadGenerator.incorrectInput();
+        final BaseMetricRequest payload = RequestPayloadGenerator.incorrectInput();
 
         given()
                 .contentType(ContentType.JSON)


### PR DESCRIPTION
- Change `JSONNode` to `ValueNode` in order to use floating point checks
- Added type checker unit tests
