### PR TITLE
Update: base openjdk image set to "latest" tag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,7 +127,7 @@ Great feature proposals should include a short **Description** of the feature, t
 If you have not done so on this machine, you need to:
 
 * Install Git and configure your GitHub access
-* Install Java SDK (OpenJDK recommended)
+* Install Java SDK (OpenJDK 17 recommended)
 * For Native Image, follow Quarkus instructions at [GraalVM](https://quarkus.io/guides/building-native-image)
 
 ## Build

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ARG CI_CONTAINER_VERSION="unknown"
 
 
 ## Livebuilder CODE BEGIN ##
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.14-3.1661798365 AS build
+FROM registry.access.redhat.com/ubi8/openjdk-17:latest AS build
 
 ## Build args to be used at this step
 ARG SOURCE_CODE
@@ -44,7 +44,7 @@ RUN mvn -B clean package --file pom.xml -P service-minimal -DskipTests; rm -Rf e
 
 
 ###############################################################################
-FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.15 AS runtime
+FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:latest AS runtime
 ENV LANGUAGE='en_US:en'
 
 ## Livebuilder CODE BEGIN ##

--- a/explainability-service/src/main/docker/Dockerfile.jvm
+++ b/explainability-service/src/main/docker/Dockerfile.jvm
@@ -75,7 +75,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.14
+FROM registry.access.redhat.com/ubi8/openjdk-17:latest
 
 ENV LANGUAGE='en_US:en'
 

--- a/explainability-service/src/main/docker/Dockerfile.legacy-jar
+++ b/explainability-service/src/main/docker/Dockerfile.legacy-jar
@@ -75,7 +75,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.14
+FROM registry.access.redhat.com/ubi8/openjdk-17:latest
 
 ENV LANGUAGE='en_US:en'
 


### PR DESCRIPTION

**Description**: to avoid get caught by older base image with CVE, the recommendation from openjdk team is to use "latest" tag than a fix version. since they only patch on the newer version and with latest tag.


Many thanks for submitting your Pull Request :heart:!
Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `FAI-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.3.x] FAI-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

