### PR TITLE
Fix name subsitution in CI

### DIFF
--- a/tests/resources/trustyai/trustyai_operator_kfdef.yaml
+++ b/tests/resources/trustyai/trustyai_operator_kfdef.yaml
@@ -10,11 +10,11 @@ spec:
           path: config
         parameters:
           - name: trustyaiServiceImageName
-            value: quay.io/trustyai/trustyai-service
+            value: serviceImagePlaceholder
           - name: trustyaiServiceImageTag
             value: serviceTagPlaceholder
           - name: trustyaiOperatorImageName
-            value: quay.io/trustyai/trustyai-service-operator
+            value: operatorImagePlaceholder
           - name: trustyai/OperatorImageTag
             value: operatorTagPlaceholder
       name: trustyai-service-operator

--- a/tests/scripts/install.sh
+++ b/tests/scripts/install.sh
@@ -43,10 +43,17 @@ fi
 popd
 ## Point manifests repo uri in the KFDEF to the manifests in the PR
 pushd ~/kfdef
+
+# put in latest values for operator image
 sed -i "s#value: operatorTagPlaceholder#value: latest#" $HOME/peak/operator-tests/trustyai-explainability/resources/trustyai/trustyai_operator_kfdef.yaml
+sed -i "s#value: operatorImagePlaceholder#value: quay.io/trustyai/trustyai-service-operator#" $HOME/peak/operator-tests/trustyai-explainability/resources/trustyai/trustyai_operator_kfdef.yaml
+
+
 if [ -z "$PULL_NUMBER" ]; then
   echo "No pull number, not modifying ${KFDEF_FILENAME}"
+      # if not a pull, use latest version of service
       sed -i "s#value: serviceTagPlaceholder#value: latest#" $HOME/peak/operator-tests/trustyai-explainability/resources/trustyai/trustyai_operator_kfdef.yaml
+      sed -i "s#value: serviceImagePlaceholder#value: quay.io/trustyai/trustyai-service#" $HOME/peak/operator-tests/trustyai-explainability/resources/trustyai/trustyai_operator_kfdef.yaml
 else
   if [ $REPO_NAME == "trustyai-explainability" ]; then
     echo "Setting manifests in kfctl_openshift to use pull number: $PULL_NUMBER"
@@ -54,11 +61,9 @@ else
 
     BRANCH_SHA=$(curl  https://api.github.com/repos/trustyai-explainability/trustyai-explainability/pulls/${PULL_NUMBER} | jq ".head.sha"  | tr -d '"')
 
-    # echo "Setting TrustyAI service kfdef to use PR image"
-    # sed -i "s#value: \"quay.io/trustyai/trustyai-service:latest\"#value: \"quay.io/trustyai/trustyai-service-ci:${BRANCH_SHA}\"#" ../resources/trustyai/trustyai_service_kfdef.yaml
-
+    # if a pull, use version built from CI
     echo "Setting TrustyAI operator configmap to use PR image"
-    sed -i "s#value: quay.io/trustyai/trustyai-service#value: quay.io/trustyai/trustyai-service-ci#" $HOME/peak/operator-tests/trustyai-explainability/resources/trustyai/trustyai_operator_kfdef.yaml
+    sed -i "s#value: serviceImagePlaceholder#value: quay.io/trustyai/trustyai-service-ci#" $HOME/peak/operator-tests/trustyai-explainability/resources/trustyai/trustyai_operator_kfdef.yaml
     sed -i "s#value: serviceTagPlaceholder#value: ${BRANCH_SHA}#" $HOME/peak/operator-tests/trustyai-explainability/resources/trustyai/trustyai_operator_kfdef.yaml
 
     echo "TrustyAI Operator KFDEF"


### PR DESCRIPTION
Sed'ing on `trustyai-service` was catching both `trustyai-service` and `trustyai-service-operator`, and therefore performing an unwanted subsitution.


Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `FAI-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.3.x] FAI-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

