### PR TITLE
Return correct number of registered metrics per model

### DIFF
--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/service/ServiceMetadataEndpoint.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/service/ServiceMetadataEndpoint.java
@@ -1,20 +1,12 @@
 package org.kie.trustyai.service.endpoints.service;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
+import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -32,6 +24,7 @@ import org.kie.trustyai.service.prometheus.PrometheusScheduler;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
+@ApplicationScoped
 @Path("/info")
 public class ServiceMetadataEndpoint {
 
@@ -59,7 +52,12 @@ public class ServiceMetadataEndpoint {
             final ServiceMetadata serviceMetadata = new ServiceMetadata();
 
             for (Map.Entry<String, ConcurrentHashMap<UUID, BaseMetricRequest>> metricDict : scheduler.getAllRequests().entrySet()) {
-                serviceMetadata.getMetrics().scheduledMetadata.setCount(metricDict.getKey(), metricDict.getValue().size());
+                metricDict.getValue().values().forEach(metric -> {
+                    if (metric.getModelId().equals(modelId)) {
+                        final String metricName = metricDict.getKey();
+                        serviceMetadata.getMetrics().scheduledMetadata.setCount(metricName, serviceMetadata.getMetrics().scheduledMetadata.getCount(metricName) + 1);
+                    }
+                });
             }
 
             try {

--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/service/ServiceMetadata.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/service/ServiceMetadata.java
@@ -8,7 +8,7 @@ public class ServiceMetadata {
     private Metadata data = new Metadata();
 
     public ServiceMetadata() {
-
+        // empty constructor
     }
 
     public ServiceMetricsMetadata getMetrics() {

--- a/explainability-service/src/test/java/org/kie/trustyai/service/BaseTestProfile.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/BaseTestProfile.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 import org.kie.trustyai.service.mocks.MockDatasource;
 import org.kie.trustyai.service.mocks.MockMemoryStorage;
+import org.kie.trustyai.service.mocks.MockPrometheusScheduler;
 
 import io.quarkus.test.junit.QuarkusTestProfile;
 
@@ -27,8 +28,7 @@ public class BaseTestProfile implements QuarkusTestProfile {
 
     @Override
     public Set<Class<?>> getEnabledAlternatives() {
-        return Set.of(MockDatasource.class, MockMemoryStorage.class);
-
+        return Set.of(MockDatasource.class, MockMemoryStorage.class, MockPrometheusScheduler.class);
     }
 
 }

--- a/explainability-service/src/test/java/org/kie/trustyai/service/mocks/MockDatasource.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/mocks/MockDatasource.java
@@ -11,16 +11,19 @@ import javax.inject.Inject;
 
 import org.kie.trustyai.explainability.model.*;
 import org.kie.trustyai.service.data.DataSource;
+import org.kie.trustyai.service.data.exceptions.InvalidSchemaException;
 import org.kie.trustyai.service.data.metadata.Metadata;
 import org.kie.trustyai.service.data.utils.MetadataUtils;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
+import io.quarkus.arc.Priority;
 import io.quarkus.test.Mock;
 
 @Mock
 @Alternative
 @ApplicationScoped
+@Priority(1)
 public class MockDatasource extends DataSource {
 
     private static final String MODEL_ID = "example1";
@@ -75,4 +78,8 @@ public class MockDatasource extends DataSource {
         this.knownModels.clear();
     }
 
+    @Override
+    public void saveDataframe(Dataframe dataframe, String modelId) throws InvalidSchemaException {
+        super.saveDataframe(dataframe, modelId);
+    }
 }

--- a/explainability-service/src/test/java/org/kie/trustyai/service/mocks/MockMemoryStorage.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/mocks/MockMemoryStorage.java
@@ -5,16 +5,17 @@ import javax.enterprise.inject.Alternative;
 
 import org.kie.trustyai.service.data.storage.MemoryStorage;
 
+import io.quarkus.arc.Priority;
 import io.quarkus.test.Mock;
 
 @Mock
 @Alternative
 @ApplicationScoped
+@Priority(1)
 public class MockMemoryStorage extends MemoryStorage {
 
     public MockMemoryStorage() {
         super(new MockMemoryServiceConfig(), new MockMemoryStorageConfig());
-
     }
 
     public void emptyStorage() {

--- a/explainability-service/src/test/java/org/kie/trustyai/service/mocks/MockPrometheusScheduler.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/mocks/MockPrometheusScheduler.java
@@ -5,10 +5,17 @@ import javax.enterprise.inject.Alternative;
 
 import org.kie.trustyai.service.prometheus.PrometheusScheduler;
 
+import io.quarkus.arc.Priority;
 import io.quarkus.test.Mock;
 
 @Mock
 @Alternative
 @ApplicationScoped
+@Priority(1)
 public class MockPrometheusScheduler extends PrometheusScheduler {
+
+    public void empty() {
+        this.getAllRequests().clear();
+    }
+
 }


### PR DESCRIPTION
For each model, the number of registered metrics on the service's metadata endpoint was the global one, rather than the number of metrics registered for a specific model.

This PR returns the correct number of metrics registered for each model in the metadata.

See #323 

