### PR TITLE
Upgrade Quarkus to 2.16.10 Final

### DIFF
--- a/explainability-service/pom.xml
+++ b/explainability-service/pom.xml
@@ -18,7 +18,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>2.13.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.16.10.Final</quarkus.platform.version>
         <apache.commons.collections.version>4.4</apache.commons.collections.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>


### PR DESCRIPTION
Upgrade Quarkus to 2.16.10 Final.
BOM updates fixing security issues:

- `quarkus-vertx-http` to 2.16.10
- `netty-codec-haproxy` to 4.1.94.Final
- `graal-sdk` to 22.3.0

