### PR TITLE
Broader tagging

### DIFF
--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/model/Dataframe.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/model/Dataframe.java
@@ -152,7 +152,7 @@ public class Dataframe {
             for (int col = 0; col < inputsSize; col++) {
                 df.data.get(col).add(currentInputs.get(col).getValue());
             }
-            df.internalData.datapointSources.add(DatapointSource.UNLABELED);
+            df.internalData.datapointTags.add("");
             df.internalData.ids.add(UUID.randomUUID().toString());
             df.internalData.timestamps.add(LocalDateTime.now());
             df.internalData.groundTruths.add(null);
@@ -305,12 +305,12 @@ public class Dataframe {
 
                 if (alignedMetadata) {
                     PredictionMetadata predictionMetadata = predictionsMetadata.get(i);
-                    internalData.datapointSources.add(predictionMetadata.getDataPointSource());
+                    internalData.datapointTags.add(predictionMetadata.getDataPointTag());
                     internalData.ids.add(predictionMetadata.getId());
                     internalData.timestamps.add(predictionMetadata.getPredictionTime());
                     internalData.groundTruths.add(predictionMetadata.getGroundTruth());
                 } else {
-                    internalData.datapointSources.add(DatapointSource.UNLABELED);
+                    internalData.datapointTags.add("");
                     internalData.ids.add(currentPrediction.getExecutionId().toString());
                     internalData.timestamps.add(LocalDateTime.now());
                     internalData.groundTruths.add(null);
@@ -877,17 +877,17 @@ public class Dataframe {
         int nrows = rows.size();
         List<LocalDateTime> timestamps = new ArrayList<>(nrows);
         List<String> ids = new ArrayList<>(nrows);
-        List<DatapointSource> datapointSources = new ArrayList<>(nrows);
+        List<String> datapointTags = new ArrayList<>(nrows);
         List<Value> groundTruths = new ArrayList<>(nrows);
         rows.forEach(row -> {
             timestamps.add(internalData.timestamps.get(row));
             ids.add(internalData.ids.get(row));
-            datapointSources.add(internalData.datapointSources.get(row));
+            datapointTags.add(internalData.datapointTags.get(row));
             groundTruths.add(internalData.groundTruths.get(row));
         });
 
         Metadata metadataCopy = this.metadata.copy();
-        InternalData internalDataFiltered = new InternalData(datapointSources, ids, timestamps, groundTruths);
+        InternalData internalDataFiltered = new InternalData(datapointTags, ids, timestamps, groundTruths);
 
         final List<List<Value>> dataCopy = columnIndexStream().mapToObj(col -> {
             final List<Value> column = data.get(col);
@@ -930,7 +930,7 @@ public class Dataframe {
                 values = internalData.ids.stream().map(Value::new).collect(Collectors.toList());
                 break;
             case TAG:
-                values = internalData.datapointSources.stream().map(Value::new).collect(Collectors.toList());
+                values = internalData.datapointTags.stream().map(Value::new).collect(Collectors.toList());
                 break;
             case TIMESTAMP:
                 values = internalData.timestamps.stream().map(Value::new).collect(Collectors.toList());
@@ -979,7 +979,7 @@ public class Dataframe {
     }
 
     public Dataframe filterRowsBySynthetic(boolean synthetic) {
-        return synthetic ? filterRowsByTagEquals(DatapointSource.SYNTHETIC) : filterRowsByTagNotEquals(DatapointSource.SYNTHETIC);
+        return synthetic ? filterRowsByTagEquals(InternalTags.SYNTHETIC.get()) : filterRowsByTagNotEquals(InternalTags.SYNTHETIC.get());
     }
 
     public Dataframe filterRowsByTimeRange(LocalDateTime lowerBound, LocalDateTime upperBound) {
@@ -989,13 +989,13 @@ public class Dataframe {
         return filterByRowIndex(rowIndexes);
     }
 
-    public Dataframe filterRowsByTagEquals(DatapointSource dpSource) {
-        List<Integer> rowIndexes = rowIndexStream().filter(rowNumber -> internalData.datapointSources.get(rowNumber) == dpSource).boxed().collect(Collectors.toList());
+    public Dataframe filterRowsByTagEquals(String dpTag) {
+        List<Integer> rowIndexes = rowIndexStream().filter(rowNumber -> internalData.datapointTags.get(rowNumber).equals(dpTag)).boxed().collect(Collectors.toList());
         return filterByRowIndex(rowIndexes);
     }
 
-    public Dataframe filterRowsByTagNotEquals(DatapointSource dpSource) {
-        List<Integer> rowIndexes = rowIndexStream().filter(rowNumber -> internalData.datapointSources.get(rowNumber) != dpSource).boxed().collect(Collectors.toList());
+    public Dataframe filterRowsByTagNotEquals(String dpTag) {
+        List<Integer> rowIndexes = rowIndexStream().filter(rowNumber -> !internalData.datapointTags.get(rowNumber).equals(dpTag)).boxed().collect(Collectors.toList());
         return filterByRowIndex(rowIndexes);
     }
 
@@ -1007,9 +1007,9 @@ public class Dataframe {
      *        One-item lists indicate a single index to be included, while two-item lists describe a slice of indices to include [A, B)
      *        For example, [0], [2,5], [6] would tag the datapoints 0, 2, 3, 4, 6
      */
-    public void tagDataPoints(Map<DatapointSource, List<List<Integer>>> dataTagging) {
+    public void tagDataPoints(Map<String, List<List<Integer>>> dataTagging) {
         int nrows = this.getRowDimension();
-        for (Map.Entry<DatapointSource, List<List<Integer>>> entry : dataTagging.entrySet()) {
+        for (Map.Entry<String, List<List<Integer>>> entry : dataTagging.entrySet()) {
             for (List<Integer> idxs : entry.getValue()) {
                 if (idxs.size() > 2) {
                     throw new IllegalArgumentException("Tag " + entry.getValue() + " keys (" + entry.getKey() + ") contain a sublist with more than two items. Please ensure sublists" +
@@ -1023,10 +1023,10 @@ public class Dataframe {
                 // if a tuple, assign all points in slice to tag
                 if (idxs.size() == 2) {
                     for (int i = idxs.get(0); i < idxs.get(1); i++) {
-                        this.internalData.datapointSources.set(i, entry.getKey());
+                        this.internalData.datapointTags.set(i, entry.getKey());
                     }
                 } else { //otherwise just assign the one provided point
-                    this.internalData.datapointSources.set(idxs.get(0), entry.getKey());
+                    this.internalData.datapointTags.set(idxs.get(0), entry.getKey());
                 }
             }
         }
@@ -1176,16 +1176,12 @@ public class Dataframe {
         return Collections.unmodifiableList(internalData.ids);
     }
 
-    public List<DatapointSource> getTags() {
-        return Collections.unmodifiableList(internalData.datapointSources);
+    public List<String> getTags() {
+        return Collections.unmodifiableList(internalData.datapointTags);
     }
 
     public List<LocalDateTime> getTimestamps() {
         return Collections.unmodifiableList(internalData.timestamps);
-    }
-
-    public List<DatapointSource> getDataSources() {
-        return Collections.unmodifiableList(internalData.datapointSources);
     }
 
     public List<Value> getGroundTruths() {
@@ -1295,28 +1291,45 @@ public class Dataframe {
     }
 
     private class InternalData {
-        private final List<DatapointSource> datapointSources;
+        private final List<String> datapointTags;
         private final List<String> ids;
         private final List<LocalDateTime> timestamps;
         private final List<Value> groundTruths;
 
         InternalData() {
-            this.datapointSources = new ArrayList<>();
+            this.datapointTags = new ArrayList<>();
             this.ids = new ArrayList<>();
             this.timestamps = new ArrayList<>();
             this.groundTruths = new ArrayList<>();
         }
 
-        InternalData(List<DatapointSource> datapointSources, List<String> ids, List<LocalDateTime> timestamps, List<Value> groundTruths) {
-            this.datapointSources = datapointSources;
+        InternalData(List<String> datapointTags, List<String> ids, List<LocalDateTime> timestamps, List<Value> groundTruths) {
+            this.datapointTags = datapointTags;
             this.ids = ids;
             this.timestamps = timestamps;
             this.groundTruths = groundTruths;
         }
 
         InternalData copy() {
-            return new InternalData(new ArrayList<>(this.datapointSources), new ArrayList<>(this.ids),
+            return new InternalData(new ArrayList<>(this.datapointTags), new ArrayList<>(this.ids),
                     new ArrayList<>(this.timestamps), new ArrayList<>(this.groundTruths));
+        }
+    }
+
+    // protected set of tags for internal use only
+    public static final String TRUSTYAI_INTERNAL_TAG_PREFIX = "_trustyai";
+
+    public enum InternalTags {
+        SYNTHETIC(TRUSTYAI_INTERNAL_TAG_PREFIX + "_synthetic");
+
+        private final String tagValue;
+
+        InternalTags(String s) {
+            this.tagValue = s;
+        }
+
+        public String get() {
+            return tagValue;
         }
     }
 }

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/model/Dataframe.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/model/Dataframe.java
@@ -152,7 +152,7 @@ public class Dataframe {
             for (int col = 0; col < inputsSize; col++) {
                 df.data.get(col).add(currentInputs.get(col).getValue());
             }
-            df.internalData.datapointTags.add("");
+            df.internalData.datapointTags.add(InternalTags.UNLABELED.get());
             df.internalData.ids.add(UUID.randomUUID().toString());
             df.internalData.timestamps.add(LocalDateTime.now());
             df.internalData.groundTruths.add(null);
@@ -310,7 +310,7 @@ public class Dataframe {
                     internalData.timestamps.add(predictionMetadata.getPredictionTime());
                     internalData.groundTruths.add(predictionMetadata.getGroundTruth());
                 } else {
-                    internalData.datapointTags.add("");
+                    internalData.datapointTags.add(InternalTags.UNLABELED.get());
                     internalData.ids.add(currentPrediction.getExecutionId().toString());
                     internalData.timestamps.add(LocalDateTime.now());
                     internalData.groundTruths.add(null);
@@ -1320,7 +1320,8 @@ public class Dataframe {
     public static final String TRUSTYAI_INTERNAL_TAG_PREFIX = "_trustyai";
 
     public enum InternalTags {
-        SYNTHETIC(TRUSTYAI_INTERNAL_TAG_PREFIX + "_synthetic");
+        SYNTHETIC(TRUSTYAI_INTERNAL_TAG_PREFIX + "_synthetic"),
+        UNLABELED(TRUSTYAI_INTERNAL_TAG_PREFIX + "_unlabeled");
 
         private final String tagValue;
 

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/model/DatapointSource.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/model/DatapointSource.java
@@ -1,7 +1,0 @@
-package org.kie.trustyai.explainability.model;
-
-public enum DatapointSource {
-    SYNTHETIC,
-    TRAINING,
-    UNLABELED,
-}

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/model/PredictionMetadata.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/model/PredictionMetadata.java
@@ -8,21 +8,28 @@ public class PredictionMetadata {
 
     private final String id;
 
-    private final DatapointSource datapointSource;
+    private final String datapointTag;
 
     private final Value groundTruth;
 
-    public PredictionMetadata(String id, LocalDateTime predictionTime, DatapointSource datapointSource) {
+    public PredictionMetadata(String id, LocalDateTime predictionTime) {
         this.id = id;
         this.predictionTime = predictionTime;
-        this.datapointSource = datapointSource;
+        this.datapointTag = "";
         this.groundTruth = null;
     }
 
-    public PredictionMetadata(String id, LocalDateTime predictionTime, DatapointSource datapointSource, Value groundTruth) {
+    public PredictionMetadata(String id, LocalDateTime predictionTime, String datapointTag) {
         this.id = id;
         this.predictionTime = predictionTime;
-        this.datapointSource = datapointSource;
+        this.datapointTag = datapointTag;
+        this.groundTruth = null;
+    }
+
+    public PredictionMetadata(String id, LocalDateTime predictionTime, String datapointTag, Value groundTruth) {
+        this.id = id;
+        this.predictionTime = predictionTime;
+        this.datapointTag = datapointTag;
         this.groundTruth = groundTruth;
     }
 
@@ -34,8 +41,8 @@ public class PredictionMetadata {
         return predictionTime;
     }
 
-    public DatapointSource getDataPointSource() {
-        return datapointSource;
+    public String getDataPointTag() {
+        return datapointTag;
     }
 
     public Value getGroundTruth() {

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/model/DataframeTest.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/model/DataframeTest.java
@@ -704,7 +704,7 @@ class DataframeTest {
         List<PredictionMetadata> metadata = new ArrayList<>();
         int idx = 0;
         for (Prediction ignored : predictions) {
-            metadata.add(new PredictionMetadata(String.valueOf(idx), LocalDateTime.now(), Dataframe.InternalTags.SYNTHETIC.get()));
+            metadata.add(new PredictionMetadata(String.valueOf(idx), LocalDateTime.now()));
             idx++;
         }
         df.addPredictions(predictions, metadata);

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/model/DataframeTest.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/model/DataframeTest.java
@@ -633,7 +633,7 @@ class DataframeTest {
     @Test
     void testDataFrameFromPredictionAndMetadata() {
         Prediction prediction = createTestPrediction();
-        PredictionMetadata metadata = new PredictionMetadata("123", LocalDateTime.now(), DatapointSource.UNLABELED);
+        PredictionMetadata metadata = new PredictionMetadata("123", LocalDateTime.now());
         Dataframe dataframe = Dataframe.createFrom(prediction, metadata);
         assertThat(dataframe).isNotNull();
         assertThat(dataframe.getRowDimension()).isEqualTo(1);
@@ -649,7 +649,7 @@ class DataframeTest {
         List<PredictionMetadata> metadata = new ArrayList<>();
         int idx = 0;
         for (Prediction ignored : predictions) {
-            metadata.add(new PredictionMetadata(String.valueOf(idx), LocalDateTime.now(), DatapointSource.SYNTHETIC));
+            metadata.add(new PredictionMetadata(String.valueOf(idx), LocalDateTime.now(), Dataframe.InternalTags.SYNTHETIC.get()));
             idx++;
         }
         df.addPredictions(predictions, metadata);
@@ -666,7 +666,7 @@ class DataframeTest {
         List<PredictionMetadata> metadata = new ArrayList<>();
         int idx = 0;
         for (Prediction ignored : predictions) {
-            metadata.add(new PredictionMetadata(String.valueOf(idx), LocalDateTime.now(), DatapointSource.SYNTHETIC));
+            metadata.add(new PredictionMetadata(String.valueOf(idx), LocalDateTime.now(), Dataframe.InternalTags.SYNTHETIC.get()));
             idx++;
         }
         df.addPredictions(predictions, metadata);
@@ -686,7 +686,7 @@ class DataframeTest {
         List<PredictionMetadata> metadata = new ArrayList<>();
         int idx = 0;
         for (Prediction ignored : predictions) {
-            metadata.add(new PredictionMetadata(String.valueOf(idx), LocalDateTime.now(), DatapointSource.UNLABELED));
+            metadata.add(new PredictionMetadata(String.valueOf(idx), LocalDateTime.now()));
             idx++;
         }
         df.addPredictions(predictions, metadata);
@@ -704,7 +704,7 @@ class DataframeTest {
         List<PredictionMetadata> metadata = new ArrayList<>();
         int idx = 0;
         for (Prediction ignored : predictions) {
-            metadata.add(new PredictionMetadata(String.valueOf(idx), LocalDateTime.now(), DatapointSource.UNLABELED));
+            metadata.add(new PredictionMetadata(String.valueOf(idx), LocalDateTime.now(), Dataframe.InternalTags.SYNTHETIC.get()));
             idx++;
         }
         df.addPredictions(predictions, metadata);

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/parsers/CSVParser.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/parsers/CSVParser.java
@@ -14,7 +14,6 @@ import javax.enterprise.context.ApplicationScoped;
 
 import org.jboss.logging.Logger;
 import org.kie.trustyai.explainability.model.Dataframe;
-import org.kie.trustyai.explainability.model.DatapointSource;
 import org.kie.trustyai.explainability.model.Prediction;
 import org.kie.trustyai.explainability.model.PredictionMetadata;
 import org.kie.trustyai.explainability.model.Value;
@@ -67,10 +66,10 @@ public class CSVParser implements DataParser {
         }
         if (values != null) {
             for (int i = 0; i < predictions.size(); i++) {
-                DatapointSource datapointSource = DatapointSource.valueOf(values.get(i).get(0).asString());
+                String datapointTag = values.get(i).get(0).asString();
                 String id = values.get(i).get(1).asString();
                 LocalDateTime predictionTime = LocalDateTime.parse(values.get(i).get(2).asString());
-                PredictionMetadata predictionMetadata = new PredictionMetadata(id, predictionTime, datapointSource);
+                PredictionMetadata predictionMetadata = new PredictionMetadata(id, predictionTime, datapointTag);
                 predictionsMetadata.add(predictionMetadata);
             }
         }
@@ -119,11 +118,11 @@ public class CSVParser implements DataParser {
         if (includeHeader) {
             output.append(String.join(",", "synthetic", "id", "timestamp")).append("\n");
         }
-        List<DatapointSource> datapointSources = dataframe.getDataSources();
+        List<String> datapointTags = dataframe.getTags();
         List<String> ids = dataframe.getIds();
         List<LocalDateTime> timestamps = dataframe.getTimestamps();
         for (int i = 0; i < ids.size(); i++) {
-            output.append(String.join(",", String.valueOf(datapointSources.get(i)), ids.get(i),
+            output.append(String.join(",", datapointTags.get(i), ids.get(i),
                     timestamps.get(i).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))).append("\n");
         }
         String outputString = output.toString();

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/DownloadUtils.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/DownloadUtils.java
@@ -5,7 +5,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.kie.trustyai.explainability.model.Dataframe;
-import org.kie.trustyai.explainability.model.DatapointSource;
 import org.kie.trustyai.service.data.metadata.Metadata;
 import org.kie.trustyai.service.payloads.data.download.RowMatcher;
 import org.kie.trustyai.service.payloads.values.DataType;
@@ -122,7 +121,7 @@ public class DownloadUtils {
     }
 
     public static Dataframe equalsMatcherInternal(Dataframe df, RowMatcher rowMatcher, Dataframe.InternalColumn internalColumn, boolean invert) {
-        if (internalColumn == Dataframe.InternalColumn.ID) {
+        if (internalColumn == Dataframe.InternalColumn.ID || internalColumn == Dataframe.InternalColumn.TAG) {
             Set<String> equalsVals = rowMatcher.getValues().stream().map(JsonNode::textValue).collect(Collectors.toSet());
             return df.filterByInternalColumnValue(internalColumn, value -> invert ^ equalsVals.contains((String) value.getUnderlyingObject()));
         } else if (internalColumn == Dataframe.InternalColumn.TIMESTAMP) {
@@ -131,9 +130,6 @@ public class DownloadUtils {
         } else if (internalColumn == Dataframe.InternalColumn.INDEX) {
             Set<Integer> equalsVals = rowMatcher.getValues().stream().map(JsonNode::intValue).collect(Collectors.toSet());
             return df.filterByInternalColumnValue(internalColumn, value -> invert ^ equalsVals.contains((int) value.getUnderlyingObject()));
-        } else if (internalColumn == Dataframe.InternalColumn.TAG) {
-            Set<DatapointSource> equalsVals = rowMatcher.getValues().stream().map(v -> DatapointSource.valueOf(v.textValue())).collect(Collectors.toSet());
-            return df.filterByInternalColumnValue(internalColumn, value -> invert ^ equalsVals.contains((DatapointSource) value.getUnderlyingObject()));
         } else {
             return df.filterByInternalColumnValue(internalColumn, value -> invert);
         }

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/InferencePayloadReconciler.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/InferencePayloadReconciler.java
@@ -153,8 +153,8 @@ public class InferencePayloadReconciler {
         LOG.debug("Prediction input: " + predictionInput.getFeatures());
         final List<Feature> features = new ArrayList<>(predictionInput.getFeatures());
 
-        DatapointSource datapointSource = metadata.containsKey(ExplainerEndpoint.BIAS_IGNORE_PARAM) ? DatapointSource.SYNTHETIC : DatapointSource.UNLABELED;
-        PredictionMetadata predictionMetadata = new PredictionMetadata(id, LocalDateTime.now(), datapointSource);
+        String datapointTag = metadata.containsKey(ExplainerEndpoint.BIAS_IGNORE_PARAM) ? Dataframe.InternalTags.SYNTHETIC.get() : "";
+        PredictionMetadata predictionMetadata = new PredictionMetadata(id, LocalDateTime.now(), datapointTag);
 
         final ModelInferResponse output;
         try {

--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/consumer/ConsumerEndpoint.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/consumer/ConsumerEndpoint.java
@@ -1,12 +1,7 @@
 package org.kie.trustyai.service.endpoints.consumer;
 
-import java.util.Arrays;
 import java.util.Base64;
-import java.util.EnumMap;
-import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
@@ -19,15 +14,7 @@ import javax.ws.rs.core.Response;
 
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.RestResponse;
-import org.kie.trustyai.connectors.kserve.v2.TensorConverter;
-import org.kie.trustyai.connectors.kserve.v2.grpc.ModelInferRequest;
-import org.kie.trustyai.connectors.kserve.v2.grpc.ModelInferResponse;
 import org.kie.trustyai.explainability.model.Dataframe;
-import org.kie.trustyai.explainability.model.DatapointSource;
-import org.kie.trustyai.explainability.model.Prediction;
-import org.kie.trustyai.explainability.model.PredictionInput;
-import org.kie.trustyai.explainability.model.PredictionOutput;
-import org.kie.trustyai.explainability.model.SimplePrediction;
 import org.kie.trustyai.service.data.DataSource;
 import org.kie.trustyai.service.data.exceptions.DataframeCreateException;
 import org.kie.trustyai.service.data.exceptions.InvalidSchemaException;
@@ -36,10 +23,6 @@ import org.kie.trustyai.service.data.utils.InferencePayloadReconciler;
 import org.kie.trustyai.service.payloads.consumer.InferencePartialPayload;
 import org.kie.trustyai.service.payloads.consumer.InferencePayload;
 import org.kie.trustyai.service.payloads.consumer.PartialKind;
-import org.kie.trustyai.service.payloads.consumer.upload.ModelInferJointPayload;
-import org.kie.trustyai.service.payloads.consumer.upload.UploadUtils;
-
-import static org.kie.trustyai.service.payloads.consumer.upload.UploadUtils.populateRequestBuilder;
 
 @Path("/consumer/kserve/v2")
 public class ConsumerEndpoint {
@@ -115,79 +98,6 @@ public class ConsumerEndpoint {
         }
 
         return Response.ok().build();
-    }
-
-    @POST
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.TEXT_PLAIN)
-    @Path("/upload")
-    public Response directConsumption(ModelInferJointPayload jointPayload) throws DataframeCreateException {
-        if (jointPayload.getRequest() == null || jointPayload.getRequest().getInputs().length < 1) {
-            return Response.serverError().entity("Directly uploaded datapoints must specify at least one `inputs` field.").status(Response.Status.BAD_REQUEST).build();
-        }
-
-        // parse inputs
-        ModelInferRequest.Builder inferRequestBuilder = ModelInferRequest.newBuilder();
-        inferRequestBuilder.setModelName(jointPayload.getModelName());
-        try {
-            UploadUtils.populateRequestBuilder(inferRequestBuilder, jointPayload.getRequest());
-        } catch (IllegalArgumentException e) {
-            return Response.serverError().entity(e.getMessage()).status(Response.Status.BAD_REQUEST).build();
-        }
-
-        List<PredictionInput> predictionInputs;
-        try {
-            predictionInputs = TensorConverter.parseKserveModelInferRequest(inferRequestBuilder.build());
-        } catch (IllegalArgumentException e) {
-            throw new DataframeCreateException("Error parsing input payload: " + e.getMessage());
-        }
-
-        List<PredictionOutput> predictionOutputs;
-        if (jointPayload.getResponse() != null && jointPayload.getResponse().getOutputs().length > 0) {
-            // parse outputs
-            ModelInferResponse.Builder inferResponseBuilder = ModelInferResponse.newBuilder();
-            inferResponseBuilder.setModelName(jointPayload.getModelName());
-            try {
-                UploadUtils.populateResponseBuilder(inferResponseBuilder, jointPayload.getResponse());
-            } catch (IllegalArgumentException e) {
-                return Response.serverError().entity(e.getMessage()).status(Response.Status.BAD_REQUEST).build();
-            }
-
-            try {
-                predictionOutputs = TensorConverter.parseKserveModelInferResponse(inferResponseBuilder.build(), predictionInputs.size());
-            } catch (IllegalArgumentException e) {
-                throw new DataframeCreateException("Error parsing output payload: " + e.getMessage());
-            }
-        } else {
-            //todo, grab automatically from model
-            throw new IllegalArgumentException("No output payload specified in request");
-        }
-
-        final List<Prediction> predictions =
-                IntStream.range(0, predictionInputs.size()).mapToObj(i -> new SimplePrediction(predictionInputs.get(i), predictionOutputs.get(i))).collect(Collectors.toList());
-        final Dataframe dataframe = Dataframe.createFrom(predictions);
-
-        // tag the points accordingly
-        DatapointSource dpSource;
-        if (jointPayload.getDataTag() == null) {
-            dpSource = DatapointSource.UNLABELED;
-        } else {
-            try {
-                dpSource = DatapointSource.valueOf(jointPayload.getDataTag());
-            } catch (IllegalArgumentException e) {
-                return Response.serverError()
-                        .entity("Provided datapoint tag=" + jointPayload.getDataTag() + " is not valid. Must be one of " + Arrays.toString(DatapointSource.values()))
-                        .status(Response.Status.BAD_REQUEST)
-                        .build();
-            }
-        }
-
-        EnumMap<DatapointSource, List<List<Integer>>> taggingMap = new EnumMap<>(DatapointSource.class);
-        taggingMap.put(dpSource, List.of(List.of(0, dataframe.getRowDimension())));
-        dataframe.tagDataPoints(taggingMap);
-
-        dataSource.get().saveDataframe(dataframe, jointPayload.getModelName());
-        return Response.ok().entity(predictions.size() + " datapoints successfully added to " + jointPayload.getModelName() + " data.").build();
     }
 
 }

--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/data/DataEndpoint.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/data/DataEndpoint.java
@@ -194,9 +194,9 @@ public class DataEndpoint {
             dpSource = "";
         } else {
             dpSource = jointPayload.getDataTag();
-            Optional<String> tagValidation = GenericValidationUtils.validateDataTag(dpSource);
-            if (tagValidation.isPresent()) {
-                return Response.serverError().entity(tagValidation.get()).status(Response.Status.BAD_REQUEST).build();
+            Optional<String> tagValidationErrorMessage = GenericValidationUtils.validateDataTag(dpSource);
+            if (tagValidationErrorMessage.isPresent()) {
+                return Response.serverError().entity(tagValidationErrorMessage.get()).status(Response.Status.BAD_REQUEST).build();
             }
         }
 

--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/drift/MeanshiftEndpoint.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/drift/MeanshiftEndpoint.java
@@ -10,7 +10,6 @@ import javax.ws.rs.Path;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.jboss.logging.Logger;
 import org.kie.trustyai.explainability.model.Dataframe;
-import org.kie.trustyai.explainability.model.DatapointSource;
 import org.kie.trustyai.metrics.drift.meanshift.Meanshift;
 import org.kie.trustyai.metrics.drift.meanshift.MeanshiftFitting;
 import org.kie.trustyai.metrics.drift.meanshift.MeanshiftResult;
@@ -90,7 +89,7 @@ public class MeanshiftEndpoint extends DriftEndpoint {
             // get the data that matches the provided reference tag: calibration data
             Dataframe fitting = super.dataSource.get()
                     .getDataframe(request.getModelId())
-                    .filterRowsByTagEquals(DatapointSource.valueOf(dmRequest.getReferenceTag()));
+                    .filterRowsByTagEquals(dmRequest.getReferenceTag());
             msf = Meanshift.precompute(fitting);
             dmRequest.setFitting(msf.getFitStats());
         } else {
@@ -101,7 +100,7 @@ public class MeanshiftEndpoint extends DriftEndpoint {
         LOG.debug("Cache miss. Calculating metric for " + dmRequest.getModelId());
 
         // get data that does _not_ have the provided reference tag: test data
-        Dataframe filtered = dataframe.filterRowsByTagNotEquals(DatapointSource.valueOf(((DriftMetricRequest) request).getReferenceTag()));
+        Dataframe filtered = dataframe.filterRowsByTagNotEquals(((DriftMetricRequest) request).getReferenceTag());
         Map<String, MeanshiftResult> result = ms.calculate(filtered, dmRequest.getThresholdDelta());
 
         Map<String, Double> namedValues = new HashMap<>();

--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/service/ServiceMetadataEndpoint.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/service/ServiceMetadataEndpoint.java
@@ -95,8 +95,8 @@ public class ServiceMetadataEndpoint {
             HashMap<String, List<List<Integer>>> tagMapping = new HashMap<>();
             List<String> tagErrors = new ArrayList<>();
             for (String tag : dataTagging.getDataTagging().keySet()) {
-                Optional<String> tagValidation = GenericValidationUtils.validateDataTag(tag);
-                tagValidation.ifPresent(tagErrors::add);
+                Optional<String> tagValidationErrorMessage = GenericValidationUtils.validateDataTag(tag);
+                tagValidationErrorMessage.ifPresent(tagErrors::add);
                 tagMapping.put(tag, dataTagging.getDataTagging().get(tag));
             }
 

--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/service/ServiceMetadataEndpoint.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/service/ServiceMetadataEndpoint.java
@@ -12,7 +12,6 @@ import javax.ws.rs.core.Response;
 
 import org.jboss.logging.Logger;
 import org.kie.trustyai.explainability.model.Dataframe;
-import org.kie.trustyai.explainability.model.DatapointSource;
 import org.kie.trustyai.service.config.metrics.MetricsConfig;
 import org.kie.trustyai.service.data.DataSource;
 import org.kie.trustyai.service.data.exceptions.DataframeCreateException;
@@ -24,6 +23,7 @@ import org.kie.trustyai.service.payloads.service.NameMapping;
 import org.kie.trustyai.service.payloads.service.Schema;
 import org.kie.trustyai.service.payloads.service.ServiceMetadata;
 import org.kie.trustyai.service.prometheus.PrometheusScheduler;
+import org.kie.trustyai.service.validators.generic.GenericValidationUtils;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
@@ -92,18 +92,16 @@ public class ServiceMetadataEndpoint {
         }
 
         try {
-            EnumMap<DatapointSource, List<List<Integer>>> tagMapping = new EnumMap<>(DatapointSource.class);
+            HashMap<String, List<List<Integer>>> tagMapping = new HashMap<>();
+            List<String> tagErrors = new ArrayList<>();
             for (String tag : dataTagging.getDataTagging().keySet()) {
-                DatapointSource dpSource;
-                try {
-                    dpSource = DatapointSource.valueOf(tag);
-                } catch (IllegalArgumentException e) {
-                    return Response.serverError()
-                            .entity("Provided datapoint tag=" + tag + " is not valid. Must be one of " + Arrays.toString(DatapointSource.values()))
-                            .status(Response.Status.BAD_REQUEST)
-                            .build();
-                }
-                tagMapping.put(dpSource, dataTagging.getDataTagging().get(tag));
+                Optional<String> tagValidation = GenericValidationUtils.validateDataTag(tag);
+                tagValidation.ifPresent(tagErrors::add);
+                tagMapping.put(tag, dataTagging.getDataTagging().get(tag));
+            }
+
+            if (!tagErrors.isEmpty()) {
+                return Response.serverError().entity(String.join(", ", tagErrors)).status(Response.Status.BAD_REQUEST).build();
             }
 
             Dataframe df = dataSource.get().getDataframe(dataTagging.getModelId());

--- a/explainability-service/src/main/java/org/kie/trustyai/service/validators/generic/GenericValidationUtils.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/validators/generic/GenericValidationUtils.java
@@ -1,9 +1,12 @@
 package org.kie.trustyai.service.validators.generic;
 
+import java.util.Optional;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Instance;
 import javax.validation.ConstraintValidatorContext;
 
+import org.kie.trustyai.explainability.model.Dataframe;
 import org.kie.trustyai.service.data.DataSource;
 import org.kie.trustyai.service.data.metadata.Metadata;
 import org.kie.trustyai.service.payloads.PayloadConverter;
@@ -110,5 +113,16 @@ public class GenericValidationUtils {
 
     public static boolean validateFeatureColumnType(ConstraintValidatorContext context, Metadata metadata, String modelId, String columnName, ValueNode valueNode) {
         return validateFeatureColumnType(context, metadata, modelId, columnName, valueNode, "feature");
+    }
+
+    // if tag is invalid, return error string. Else return nothing
+    public static Optional<String> validateDataTag(String dataTag) {
+        if (dataTag.startsWith(Dataframe.TRUSTYAI_INTERNAL_TAG_PREFIX)) {
+            return Optional.of(String.format(
+                    "The tag prefix '%s' is reserved for internal TrustyAI use only. Provided tag '%s' violates this restriction.",
+                    Dataframe.TRUSTYAI_INTERNAL_TAG_PREFIX,
+                    dataTag));
+        }
+        return Optional.empty();
     }
 }

--- a/explainability-service/src/main/java/org/kie/trustyai/service/validators/metrics/drift/DriftMetricRequestValidator.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/validators/metrics/drift/DriftMetricRequestValidator.java
@@ -1,7 +1,7 @@
 package org.kie.trustyai.service.validators.metrics.drift;
 
-import java.util.Arrays;
 import java.util.Objects;
+import java.util.Optional;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Instance;
@@ -9,7 +9,6 @@ import javax.inject.Inject;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 
-import org.kie.trustyai.explainability.model.DatapointSource;
 import org.kie.trustyai.service.data.DataSource;
 import org.kie.trustyai.service.data.metadata.Metadata;
 import org.kie.trustyai.service.payloads.metrics.drift.DriftMetricRequest;
@@ -51,19 +50,16 @@ public class DriftMetricRequestValidator implements ConstraintValidator<ValidDri
 
             boolean tagValidation = true;
             if (Objects.nonNull(request.getReferenceTag())) {
-                try {
-                    DatapointSource.valueOf(request.getReferenceTag());
-                } catch (IllegalArgumentException e) {
-                    context.buildConstraintViolationWithTemplate(
-                            String.format("%s not a valid data tag, must be one of %s",
-                                    request.getReferenceTag(),
-                                    Arrays.toString(DatapointSource.values())))
+                Optional<String> tagValidationErrorMessage = GenericValidationUtils.validateDataTag(request.getReferenceTag());
+                if (tagValidationErrorMessage.isPresent()) {
+                    context.buildConstraintViolationWithTemplate(tagValidationErrorMessage.get())
                             .addConstraintViolation();
                     tagValidation = false;
                 }
             } else {
                 context.buildConstraintViolationWithTemplate(
-                        "Must provide a reference tag defining the original data distribution, one of: " + Arrays.toString(DatapointSource.values())).addConstraintViolation();
+                        "Must provide a reference tag in request defining the original data distribution. This is done by passing a field \"referenceTag\": \"tagString\" in the request body.")
+                        .addConstraintViolation();
                 tagValidation = false;
             }
 

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/DisparateImpactRatioEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/DisparateImpactRatioEndpointTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.kie.trustyai.explainability.model.Dataframe;
-import org.kie.trustyai.explainability.model.DatapointSource;
 import org.kie.trustyai.explainability.model.Prediction;
 import org.kie.trustyai.explainability.model.PredictionMetadata;
 import org.kie.trustyai.service.endpoints.metrics.MetricsEndpointTestProfile;
@@ -550,7 +549,7 @@ class DisparateImpactRatioEndpointTest {
 
         final Dataframe dataframe = datasource.get().generateRandomDataframe(N_SAMPLES);
         Prediction prediction = dataframe.asPredictions().get(0);
-        PredictionMetadata predictionMetadata = new PredictionMetadata("123", LocalDateTime.now(), DatapointSource.SYNTHETIC);
+        PredictionMetadata predictionMetadata = new PredictionMetadata("123", LocalDateTime.now(), Dataframe.InternalTags.SYNTHETIC.get());
         Dataframe newDataframe = Dataframe.createFrom(prediction, predictionMetadata);
 
         datasource.get().saveDataframe(newDataframe, MODEL_ID);

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupStatisticalParityDifferenceEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupStatisticalParityDifferenceEndpointTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.kie.trustyai.explainability.model.Dataframe;
-import org.kie.trustyai.explainability.model.DatapointSource;
 import org.kie.trustyai.explainability.model.Prediction;
 import org.kie.trustyai.explainability.model.PredictionMetadata;
 import org.kie.trustyai.service.endpoints.metrics.MetricsEndpointTestProfile;
@@ -385,7 +384,7 @@ class GroupStatisticalParityDifferenceEndpointTest {
 
         final Dataframe dataframe = datasource.get().generateRandomDataframe(N_SAMPLES);
         Prediction prediction = dataframe.asPredictions().get(0);
-        PredictionMetadata predictionMetadata = new PredictionMetadata("123", LocalDateTime.now(), DatapointSource.SYNTHETIC);
+        PredictionMetadata predictionMetadata = new PredictionMetadata("123", LocalDateTime.now(), Dataframe.InternalTags.SYNTHETIC.get());
         Dataframe newDataframe = Dataframe.createFrom(prediction, predictionMetadata);
 
         datasource.get().saveDataframe(newDataframe, MODEL_ID);

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/service/ServiceMetadataEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/service/ServiceMetadataEndpointTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.kie.trustyai.explainability.model.Dataframe;
-import org.kie.trustyai.explainability.model.DatapointSource;
 import org.kie.trustyai.service.BaseTestProfile;
 import org.kie.trustyai.service.mocks.MockDatasource;
 import org.kie.trustyai.service.mocks.MockPrometheusScheduler;
@@ -483,7 +482,7 @@ class ServiceMetadataEndpointTest {
         final Dataframe dataframe = datasource.get().generateRandomDataframe(50, 10);
         datasource.get().saveDataframe(dataframe, MODEL_ID);
         datasource.get().saveMetadata(datasource.get().createMetadata(dataframe), MODEL_ID);
-        List<DatapointSource> originalTags = datasource.get().getDataframe(MODEL_ID).getTags();
+        List<String> originalTags = datasource.get().getDataframe(MODEL_ID).getTags();
 
         List<String> tags = List.of("TRAINING", "SYNTHETIC");
         int idx = 0;
@@ -511,7 +510,7 @@ class ServiceMetadataEndpointTest {
         assertEquals(50, df.getRowDimension());
 
         for (String tag : tags) {
-            Dataframe subDF = df.filterRowsByTagEquals(DatapointSource.valueOf(tag));
+            Dataframe subDF = df.filterRowsByTagEquals(tag);
 
             // make sure the correct number of points are filtered
             assertEquals(6, subDF.getRowDimension());


### PR DESCRIPTION
Data tags are currently limited to an enum of TRAINING, SYNTHETIC, or UNLABELED. This is arbitrarily restrictive, and thus this PR allows tags to be any string. Certain strings are reserved for internal use (those starting with `_trustyai`), and user requests are validated to ensure they have not tried to specify an illegal tag.

Addresses https://github.com/trustyai-explainability/trustyai-explainability/issues/357

Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `FAI-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.3.x] FAI-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

