### PR TITLE
Fix hash collisions from namedValue metrics

### DIFF
--- a/explainability-service/src/main/java/org/kie/trustyai/service/prometheus/PrometheusPublisher.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/prometheus/PrometheusPublisher.java
@@ -1,5 +1,6 @@
 package org.kie.trustyai.service.prometheus;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -7,11 +8,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import org.graalvm.nativeimage.Platform;
 import org.jboss.logging.Logger;
 import org.kie.trustyai.service.config.ServiceConfig;
 import org.kie.trustyai.service.payloads.metrics.BaseMetricRequest;
@@ -80,11 +83,13 @@ public class PrometheusPublisher {
     }
 
     public void gauge(@ValidReconciledMetricRequest BaseMetricRequest request, String modelName, UUID id, Map<String, Double> namedValues) {
+        AtomicInteger idx = new AtomicInteger();
         for (Map.Entry<String, Double> entry : namedValues.entrySet()) {
-            values.put(id, new AtomicDouble(entry.getValue()));
-            List<Tag> tags = generateTags(modelName, id, Optional.of(request));
-            tags.add(Tag.of("columnName", entry.getKey()));
-            createOrUpdateGauge(METRIC_PREFIX + request.getMetricName().toLowerCase(), tags, id);
+            UUID newID = UUID.nameUUIDFromBytes((id.toString() + idx.getAndIncrement()).getBytes(StandardCharsets.UTF_8));
+            values.put(newID, new AtomicDouble(entry.getValue()));
+            List<Tag> tags = generateTags(modelName, newID, Optional.of(request));
+            tags.add(Tag.of("subcategory", entry.getKey()));
+            createOrUpdateGauge(METRIC_PREFIX + request.getMetricName().toLowerCase(), tags, newID);
         }
         LOG.debug(String.format("Scheduled request for %s id=%s, value=%s", request.getMetricName(), id, namedValues));
     }

--- a/explainability-service/src/main/java/org/kie/trustyai/service/prometheus/PrometheusPublisher.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/prometheus/PrometheusPublisher.java
@@ -14,7 +14,6 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import org.graalvm.nativeimage.Platform;
 import org.jboss.logging.Logger;
 import org.kie.trustyai.service.config.ServiceConfig;
 import org.kie.trustyai.service.payloads.metrics.BaseMetricRequest;


### PR DESCRIPTION
Previously, all submetrics within a namedValues metricvaluecarrier were published under the same id, causing hash collisions. Now, they are published under unique ids. Additionally, the submetrics (stored as some key:value pairs where key represents the name of the corresponding value) now are tagged with "subcategory=key", as opposed to "columnName=key" as previously, to allow for more generalized usage of multiple-valued metrics. 


Addresses https://github.com/trustyai-explainability/trustyai-explainability/issues/371

Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `FAI-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.3.x] FAI-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

