### PR TITLE
Fix null value enumeration merging

### DIFF
--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/metadata/Metadata.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/metadata/Metadata.java
@@ -47,7 +47,7 @@ public class Metadata {
         if (otherSchema.equals(this.inputSchema)) {
             for (String columnName : this.inputSchema.getItems().keySet()) {
                 // propagate nulls: null values mean there too many unique values to enumerate, therefore null + x = x + null = null
-                if (this.inputSchema.getItems().get(columnName).getValues() == null || otherSchema.getItems().get(columnName).getValues() == null){
+                if (this.inputSchema.getItems().get(columnName).getValues() == null || otherSchema.getItems().get(columnName).getValues() == null) {
                     this.inputSchema.getItems().get(columnName).setValues(null);
                 } else {
                     this.inputSchema.getItems().get(columnName).getValues().addAll(otherSchema.getItems().get(columnName).getValues());
@@ -63,7 +63,7 @@ public class Metadata {
         if (otherSchema.equals(this.outputSchema)) {
             for (String columnName : this.outputSchema.getItems().keySet()) {
                 // propagate nulls: null values mean there too many unique values to enumerate, therefore null + x = x + null = null
-                if (this.outputSchema.getItems().get(columnName).getValues() == null || otherSchema.getItems().get(columnName).getValues() == null){
+                if (this.outputSchema.getItems().get(columnName).getValues() == null || otherSchema.getItems().get(columnName).getValues() == null) {
                     this.outputSchema.getItems().get(columnName).setValues(null);
                 } else {
                     this.outputSchema.getItems().get(columnName).getValues().addAll(otherSchema.getItems().get(columnName).getValues());

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/metadata/Metadata.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/metadata/Metadata.java
@@ -46,7 +46,12 @@ public class Metadata {
     public void mergeInputSchema(Schema otherSchema) {
         if (otherSchema.equals(this.inputSchema)) {
             for (String columnName : this.inputSchema.getItems().keySet()) {
-                this.inputSchema.getItems().get(columnName).getValues().addAll(otherSchema.getItems().get(columnName).getValues());
+                // propagate nulls: null values mean there too many unique values to enumerate, therefore null + x = x + null = null
+                if (this.inputSchema.getItems().get(columnName).getValues() == null || otherSchema.getItems().get(columnName).getValues() == null){
+                    this.inputSchema.getItems().get(columnName).setValues(null);
+                } else {
+                    this.inputSchema.getItems().get(columnName).getValues().addAll(otherSchema.getItems().get(columnName).getValues());
+                }
             }
         } else {
             final String message = "Original schema and schema-to-merge are not compatible";
@@ -57,7 +62,12 @@ public class Metadata {
     public void mergeOutputSchema(Schema otherSchema) {
         if (otherSchema.equals(this.outputSchema)) {
             for (String columnName : this.outputSchema.getItems().keySet()) {
-                this.outputSchema.getItems().get(columnName).getValues().addAll(otherSchema.getItems().get(columnName).getValues());
+                // propagate nulls: null values mean there too many unique values to enumerate, therefore null + x = x + null = null
+                if (this.outputSchema.getItems().get(columnName).getValues() == null || otherSchema.getItems().get(columnName).getValues() == null){
+                    this.outputSchema.getItems().get(columnName).setValues(null);
+                } else {
+                    this.outputSchema.getItems().get(columnName).getValues().addAll(otherSchema.getItems().get(columnName).getValues());
+                }
             }
         } else {
             final String message = "Original schema and schema-to-merge are not compatible";

--- a/explainability-service/src/test/java/org/kie/trustyai/service/data/metadata/MetadataTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/data/metadata/MetadataTest.java
@@ -1,0 +1,68 @@
+package org.kie.trustyai.service.data.metadata;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.kie.trustyai.service.payloads.service.Schema;
+import org.kie.trustyai.service.payloads.service.SchemaItem;
+import org.kie.trustyai.service.payloads.values.DataType;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MetadataTest {
+    private Map<String, SchemaItem> generateSchema(int n, double valueOffset, boolean makeNulls) {
+        Map<String, SchemaItem> out = new HashMap<>();
+        for (int i = 0; i < n; i++) {
+            Set<Object> values;
+            if (i % 2 == 0 && makeNulls) {
+                values = null;
+            } else {
+                values = new HashSet<>();
+                values.add(i + valueOffset);
+            }
+            SchemaItem row = new SchemaItem(DataType.DOUBLE, Integer.toString(i), values, i);
+            out.put(Integer.toString(i), row);
+        }
+        return out;
+    }
+
+    @Test
+    void validateNullValueMerge() {
+        Schema s1 = Schema.from(generateSchema(10, .1, true));
+        Schema s2 = Schema.from(generateSchema(10, .2, false));
+        Metadata m1 = new Metadata();
+        m1.setInputSchema(s1);
+        m1.setOutputSchema(s2);
+
+        m1.mergeInputSchema(s2);
+        m1.mergeOutputSchema(s1);
+
+        // check for merging null, nonnull
+        for (Map.Entry<String, SchemaItem> entry : m1.getInputSchema().getItems().entrySet()) {
+            int idx = Integer.parseInt(entry.getKey());
+            //if null
+            if (idx % 2 == 0) {
+                assertNull(entry.getValue().getValues());
+            } else {
+                assertTrue(entry.getValue().getValues().contains(idx + .1));
+                assertTrue(entry.getValue().getValues().contains(idx + .2));
+            }
+        }
+
+        // check for merging nonnull, null
+        for (Map.Entry<String, SchemaItem> entry : m1.getOutputSchema().getItems().entrySet()) {
+            int idx = Integer.parseInt(entry.getKey());
+
+            if (idx % 2 == 0) {
+                assertNull(entry.getValue().getValues());
+            } else {
+                assertTrue(entry.getValue().getValues().contains(idx + .1));
+                assertTrue(entry.getValue().getValues().contains(idx + .2));
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
Many thanks for submitting your Pull Request :heart:!
Null value enumerations in the metadata (the list of all values that a column takes on) would crash when trying to merge a null-valued enumeration. Null value enumerations happen when there are too many unique column values to reasonably enumerate, and therefore when merging a null enumeration with any other enumeration, the end result should also be null.

Addresses https://github.com/trustyai-explainability/trustyai-explainability/issues/373


Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `FAI-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.3.x] FAI-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

