### PR TITLE
Improved endpoint filtering by prediction ID

### DIFF
--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/model/Dataframe.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/model/Dataframe.java
@@ -973,8 +973,12 @@ public class Dataframe {
     }
 
     public Dataframe filterRowsById(String id) {
-        List<Integer> rowIndexes = rowIndexStream().filter(rowNumber -> internalData.ids.get(rowNumber).equals(id))
-                .boxed().collect(Collectors.toList());
+        return filterRowsById(id, false, 1);
+    }
+
+    public Dataframe filterRowsById(String id, boolean negate, int size) {
+        List<Integer> rowIndexes = rowIndexStream().filter(rowNumber -> !negate == internalData.ids.get(rowNumber)
+                        .equals(id)).distinct().limit(size).boxed().collect(Collectors.toList());
         return filterByRowIndex(rowIndexes);
     }
 

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/model/Dataframe.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/model/Dataframe.java
@@ -978,7 +978,7 @@ public class Dataframe {
 
     public Dataframe filterRowsById(String id, boolean negate, int size) {
         List<Integer> rowIndexes = rowIndexStream().filter(rowNumber -> !negate == internalData.ids.get(rowNumber)
-                        .equals(id)).distinct().limit(size).boxed().collect(Collectors.toList());
+                .equals(id)).distinct().limit(size).boxed().collect(Collectors.toList());
         return filterByRowIndex(rowIndexes);
     }
 

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/model/DataframeTest.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/model/DataframeTest.java
@@ -711,5 +711,11 @@ class DataframeTest {
         assertThat(df.getRows().size()).isEqualTo(11);
         Dataframe filteredById = df.filterRowsById("5");
         assertThat(filteredById.getRowDimension()).isEqualTo(1);
+        Dataframe filteredById2 = df.filterRowsById("5", false, 1);
+        assertThat(filteredById2.getRowDimension()).isEqualTo(1);
+        Dataframe filteredByIdNegated = df.filterRowsById("5", true, 9);
+        assertThat(filteredByIdNegated.getRowDimension()).isEqualTo(9);
+        Dataframe filteredByIdNegated2 = df.filterRowsById("5", true, 5);
+        assertThat(filteredByIdNegated2.getRowDimension()).isEqualTo(5);
     }
 }

--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/explainers/local/LocalExplainerEndpoint.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/explainers/local/LocalExplainerEndpoint.java
@@ -16,8 +16,6 @@
 package org.kie.trustyai.service.endpoints.explainers.local;
 
 import java.util.List;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import javax.ws.rs.core.Response;
 
@@ -41,7 +39,7 @@ public abstract class LocalExplainerEndpoint extends ExplainerEndpoint {
             Prediction predictionToExplain;
             List<Prediction> predictions = dataframe.filterRowsById(request.getPredictionId()).asPredictions();
             if (predictions.isEmpty()) {
-                return Response.status(Response.Status.NOT_FOUND).entity( "No prediction found with id="
+                return Response.status(Response.Status.NOT_FOUND).entity("No prediction found with id="
                         + request.getPredictionId()).build();
             } else if (predictions.size() == 1) {
                 predictionToExplain = predictions.get(0);
@@ -51,7 +49,7 @@ public abstract class LocalExplainerEndpoint extends ExplainerEndpoint {
                 BaseExplanationResponse entity = generateExplanation(model, predictionToExplain, testDataDistribution);
                 return Response.ok(entity).build();
             } else {
-                return Response.status(Response.Status.BAD_REQUEST).entity( "Found " + predictions.size()
+                return Response.status(Response.Status.BAD_REQUEST).entity("Found " + predictions.size()
                         + " predictions with id=" + request.getPredictionId()).build();
             }
         } catch (Exception e) {
@@ -60,7 +58,7 @@ public abstract class LocalExplainerEndpoint extends ExplainerEndpoint {
     }
 
     protected abstract BaseExplanationResponse generateExplanation(PredictionProvider model, Prediction predictionToExplain,
-                                                                   List<PredictionInput> inputs);
+            List<PredictionInput> inputs);
 
     protected abstract Prediction prepare(Prediction prediction, LocalExplanationRequest request, List<PredictionInput> testData);
 


### PR DESCRIPTION
This allows filtering to rely on actual prediction id rather than on prediction hash in the service endpoints.