### PR TITLE
Fix Multi-output data extraction bug in parser

### DIFF
--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/PayloadParser.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/PayloadParser.java
@@ -211,7 +211,6 @@ public class PayloadParser {
     public static PredictionOutput outputFromContentList(List<?> values, Type type, List<String> outputNames) {
         final int size = values.size();
         List<String> names = outputNames == null ? IntStream.range(0, size).mapToObj(i -> "outputs-" + i).collect(Collectors.toList()) : outputNames;
-
         if (names.size() != size) {
             throw new IllegalArgumentException("Output names list has an incorrect size (" + names.size() + ", when it should be " + size + ")");
         }

--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/PayloadParser.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/PayloadParser.java
@@ -211,6 +211,7 @@ public class PayloadParser {
     public static PredictionOutput outputFromContentList(List<?> values, Type type, List<String> outputNames) {
         final int size = values.size();
         List<String> names = outputNames == null ? IntStream.range(0, size).mapToObj(i -> "outputs-" + i).collect(Collectors.toList()) : outputNames;
+
         if (names.size() != size) {
             throw new IllegalArgumentException("Output names list has an incorrect size (" + names.size() + ", when it should be " + size + ")");
         }

--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/TensorConverter.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/TensorConverter.java
@@ -291,6 +291,7 @@ public class TensorConverter {
     // converting an entire batch of raw contents is faster, so prefer this function when possible
     private static List<Output> rawHandlerMultiOutput(ModelInferResponse data, ModelInferResponse.InferOutputTensor tensor, List<String> names, int secondShape, boolean raw) {
         if (raw) {
+            logger.info("raw converter raw handler multi list<output>");
             return PayloadParser.rawContentToPredictionOutput(data, names).getOutputs();
         }
         return IntStream.range(0, secondShape)
@@ -298,10 +299,15 @@ public class TensorConverter {
                 .collect(Collectors.toCollection(ArrayList::new));
     }
 
-    // converting an entire batch of raw contents is faster, so prefer this function when possible
+
     private static List<PredictionOutput> rawHandlerMulti(ModelInferResponse data, ModelInferResponse.InferOutputTensor tensor, List<String> names, int secondShape, boolean raw) {
+        return rawHandlerMulti(data, tensor, names, secondShape, raw, 0);
+    }
+
+    // converting an entire batch of raw contents is faster, so prefer this function when possible
+    private static List<PredictionOutput> rawHandlerMulti(ModelInferResponse data, ModelInferResponse.InferOutputTensor tensor, List<String> names, int secondShape, boolean raw, int idx) {
         if (raw) {
-            return new ArrayList<>(List.of(PayloadParser.rawContentToPredictionOutput(data, names)));
+            return new ArrayList<>(List.of(PayloadParser.rawContentToPredictionOutput(data, names, idx)));
         }
         final List<Output> output = IntStream.range(0, secondShape)
                 .mapToObj(i -> contentsToOutput(tensor, names.get(i), i))
@@ -409,7 +415,7 @@ public class TensorConverter {
                                     tensors.get(tensorIDX),
                                     names,
                                     perTensorSecondShape.get(tensorIDX),
-                                    raw).get(0).getOutputs();
+                                    raw, tensorIDX).get(0).getOutputs();
                         }).flatMap(Collection::stream).collect(Collectors.toList());
                 return List.of(new PredictionOutput(outputs));
 

--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/TensorConverter.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/TensorConverter.java
@@ -298,7 +298,6 @@ public class TensorConverter {
                 .collect(Collectors.toCollection(ArrayList::new));
     }
 
-
     private static List<PredictionOutput> rawHandlerMulti(ModelInferResponse data, ModelInferResponse.InferOutputTensor tensor, List<String> names, int secondShape, boolean raw) {
         return rawHandlerMulti(data, tensor, names, secondShape, raw, 0);
     }

--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/TensorConverter.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/TensorConverter.java
@@ -291,7 +291,6 @@ public class TensorConverter {
     // converting an entire batch of raw contents is faster, so prefer this function when possible
     private static List<Output> rawHandlerMultiOutput(ModelInferResponse data, ModelInferResponse.InferOutputTensor tensor, List<String> names, int secondShape, boolean raw) {
         if (raw) {
-            logger.info("raw converter raw handler multi list<output>");
             return PayloadParser.rawContentToPredictionOutput(data, names).getOutputs();
         }
         return IntStream.range(0, secondShape)


### PR DESCRIPTION
Multiple-output'd tensors were not correctly incrementing the index, thus leading to a name-size + data-size mismatch

Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `FAI-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.3.x] FAI-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

