### PR TITLE
Disable HTTP/2 support

### DIFF
--- a/explainability-service/src/main/resources/application.properties
+++ b/explainability-service/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 quarkus.http.host=0.0.0.0
+quarkus.http.http2=false
 quarkus.container-image.builder=docker
 quarkus.container-image.build=false
 quarkus.container-image.group=trustyai


### PR DESCRIPTION
Disable HTTP/2 temporarily (until next Quarkus upgrade)

