### PR TITLE
Refactor Dataframe Metadata

### DIFF
--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/model/Dataframe.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/model/Dataframe.java
@@ -84,24 +84,12 @@ public class Dataframe {
 
         // Process inputs metadata
         for (Feature feature : prediction.getInput().getFeatures()) {
-            df.metadata.add(
-                    feature.getName(),
-                    null,
-                    feature.getType(),
-                    feature.isConstrained(),
-                    feature.getDomain(),
-                    true);
+            df.metadata.add(feature);
             df.data.add(new ArrayList<>());
         }
         // Process outputs metadata
         for (Output output : prediction.getOutput().getOutputs()) {
-            df.metadata.add(
-                    output.getName(),
-                    null,
-                    output.getType(),
-                    true,
-                    EmptyFeatureDomain.create(),
-                    false);
+            df.metadata.add(output);
             df.data.add(new ArrayList<>());
         }
 
@@ -154,13 +142,7 @@ public class Dataframe {
 
         // Process inputs metadata
         for (Feature feature : inputs.get(0).getFeatures()) {
-            df.metadata.add(
-                    feature.getName(),
-                    null,
-                    feature.getType(),
-                    feature.isConstrained(),
-                    feature.getDomain(),
-                    true);
+            df.metadata.add(feature);
             df.data.add(new ArrayList<>());
         }
 
@@ -213,24 +195,12 @@ public class Dataframe {
         } else {
             // Process inputs metadata
             for (Feature feature : predictions.get(0).getInput().getFeatures()) {
-                df.metadata.add(
-                        feature.getName(),
-                        null,
-                        feature.getType(),
-                        feature.isConstrained(),
-                        feature.getDomain(),
-                        true);
+                df.metadata.add(feature);
                 df.data.add(new ArrayList<>());
             }
             // Process outputs metadata
             for (Output output : predictions.get(0).getOutput().getOutputs()) {
-                df.metadata.add(
-                        output.getName(),
-                        null,
-                        output.getType(),
-                        true,
-                        EmptyFeatureDomain.create(),
-                        false);
+                df.metadata.add(output);
                 df.data.add(new ArrayList<>());
             }
 

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/model/DataframeMetadata.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/model/DataframeMetadata.java
@@ -1,11 +1,11 @@
 package org.kie.trustyai.explainability.model;
 
-import org.kie.trustyai.explainability.model.domain.EmptyFeatureDomain;
-import org.kie.trustyai.explainability.model.domain.FeatureDomain;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
+import org.kie.trustyai.explainability.model.domain.EmptyFeatureDomain;
+import org.kie.trustyai.explainability.model.domain.FeatureDomain;
 
 public class DataframeMetadata {
     private final List<String> names;
@@ -22,7 +22,7 @@ public class DataframeMetadata {
     }
 
     public DataframeMetadata(List<String> names, List<String> nameAliases, List<Type> types, List<Boolean> constrained, List<FeatureDomain> domains,
-                             List<Boolean> inputs) {
+            List<Boolean> inputs) {
         this.names = new ArrayList<>(names);
         this.nameAliases = new ArrayList<>(nameAliases);
         this.types = new ArrayList<>(types);
@@ -60,7 +60,7 @@ public class DataframeMetadata {
         this.constrained.add(constraint);
         this.domains.add(domain);
         this.inputs.add(input);
-        this.cachedColumnNames.add(nameAlias == null ? name :  nameAlias);
+        this.cachedColumnNames.add(nameAlias == null ? name : nameAlias);
     }
 
     public void add(Feature feature) {
@@ -70,8 +70,7 @@ public class DataframeMetadata {
                 feature.getType(),
                 feature.isConstrained(),
                 feature.getDomain(),
-                true
-        );
+                true);
     }
 
     public void add(Output output) {
@@ -81,8 +80,7 @@ public class DataframeMetadata {
                 output.getType(),
                 true,
                 EmptyFeatureDomain.create(),
-                false
-        );
+                false);
     }
 
     // column name accessors ===========================================================================================
@@ -173,7 +171,6 @@ public class DataframeMetadata {
     public void setNameAlias(int i, String nameAlias) {
         this.nameAliases.set(i, nameAlias);
     }
-
 
     public void setType(int i, Type type) {
         this.types.set(i, type);

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/model/DataframeMetadata.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/model/DataframeMetadata.java
@@ -1,6 +1,7 @@
 package org.kie.trustyai.explainability.model;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -23,6 +24,9 @@ public class DataframeMetadata {
 
     public DataframeMetadata(List<String> names, List<String> nameAliases, List<Type> types, List<Boolean> constrained, List<FeatureDomain> domains,
             List<Boolean> inputs) {
+        if (names == null || nameAliases == null || types == null || constrained == null || domains == null || inputs == null) {
+            throw new IllegalArgumentException("DataframeMetadata cannot be constructed from null arguments");
+        }
         this.names = new ArrayList<>(names);
         this.nameAliases = new ArrayList<>(nameAliases);
         this.types = new ArrayList<>(types);
@@ -42,7 +46,7 @@ public class DataframeMetadata {
                 new ArrayList<>(this.inputs));
     }
 
-    public void remove(int column) {
+    public synchronized void remove(int column) {
         names.remove(column);
         nameAliases.remove(column);
         types.remove(column);
@@ -53,7 +57,7 @@ public class DataframeMetadata {
     }
 
     // row adders ======================================================================================================
-    public void add(String name, String nameAlias, Type type, Boolean constraint, FeatureDomain domain, Boolean input) {
+    public synchronized void add(String name, String nameAlias, Type type, Boolean constraint, FeatureDomain domain, Boolean input) {
         this.names.add(name);
         this.nameAliases.add(nameAlias);
         this.types.add(type);
@@ -63,7 +67,7 @@ public class DataframeMetadata {
         this.cachedColumnNames.add(nameAlias == null ? name : nameAlias);
     }
 
-    public void add(Feature feature) {
+    public synchronized void add(Feature feature) {
         add(
                 feature.getName(),
                 null,
@@ -73,7 +77,7 @@ public class DataframeMetadata {
                 true);
     }
 
-    public void add(Output output) {
+    public synchronized void add(Output output) {
         add(
                 output.getName(),
                 null,
@@ -97,7 +101,7 @@ public class DataframeMetadata {
     }
 
     protected List<String> getNames() {
-        return cachedColumnNames;
+        return Collections.unmodifiableList(cachedColumnNames);
     }
 
     protected String getNames(int i) {
@@ -147,10 +151,6 @@ public class DataframeMetadata {
         return nameAliases;
     }
 
-    public List<String> getCachedColumnNames() {
-        return cachedColumnNames;
-    }
-
     public List<Type> getTypes() {
         return types;
     }
@@ -168,23 +168,23 @@ public class DataframeMetadata {
     }
 
     //setters ==========================================================================================================
-    public void setNameAlias(int i, String nameAlias) {
+    public synchronized void setNameAlias(int i, String nameAlias) {
         this.nameAliases.set(i, nameAlias);
     }
 
-    public void setType(int i, Type type) {
+    public synchronized void setType(int i, Type type) {
         this.types.set(i, type);
     }
 
-    public void setConstrained(int i, Boolean constraint) {
+    public synchronized void setConstrained(int i, Boolean constraint) {
         this.constrained.set(i, constraint);
     }
 
-    public void setDomain(int i, FeatureDomain domain) {
+    public synchronized void setDomain(int i, FeatureDomain domain) {
         this.domains.set(i, domain);
     }
 
-    public void setInput(int i, Boolean input) {
+    public synchronized void setInput(int i, Boolean input) {
         this.inputs.set(i, input);
     }
 }

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/model/DataframeMetadata.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/model/DataframeMetadata.java
@@ -1,11 +1,11 @@
 package org.kie.trustyai.explainability.model;
 
+import org.kie.trustyai.explainability.model.domain.EmptyFeatureDomain;
+import org.kie.trustyai.explainability.model.domain.FeatureDomain;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-
-import org.kie.trustyai.explainability.model.domain.EmptyFeatureDomain;
-import org.kie.trustyai.explainability.model.domain.FeatureDomain;
 
 public class DataframeMetadata {
     private final List<String> names;
@@ -22,7 +22,7 @@ public class DataframeMetadata {
     }
 
     public DataframeMetadata(List<String> names, List<String> nameAliases, List<Type> types, List<Boolean> constrained, List<FeatureDomain> domains,
-            List<Boolean> inputs) {
+                             List<Boolean> inputs) {
         this.names = new ArrayList<>(names);
         this.nameAliases = new ArrayList<>(nameAliases);
         this.types = new ArrayList<>(types);
@@ -60,7 +60,7 @@ public class DataframeMetadata {
         this.constrained.add(constraint);
         this.domains.add(domain);
         this.inputs.add(input);
-        this.cachedColumnNames.add(nameAlias == null ? name : nameAlias);
+        this.cachedColumnNames.add(nameAlias == null ? name :  nameAlias);
     }
 
     public void add(Feature feature) {
@@ -70,7 +70,8 @@ public class DataframeMetadata {
                 feature.getType(),
                 feature.isConstrained(),
                 feature.getDomain(),
-                true);
+                true
+        );
     }
 
     public void add(Output output) {
@@ -80,7 +81,8 @@ public class DataframeMetadata {
                 output.getType(),
                 true,
                 EmptyFeatureDomain.create(),
-                false);
+                false
+        );
     }
 
     // column name accessors ===========================================================================================
@@ -171,6 +173,7 @@ public class DataframeMetadata {
     public void setNameAlias(int i, String nameAlias) {
         this.nameAliases.set(i, nameAlias);
     }
+
 
     public void setType(int i, Type type) {
         this.types.set(i, type);

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/model/DataframeMetadata.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/model/DataframeMetadata.java
@@ -1,0 +1,166 @@
+package org.kie.trustyai.explainability.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.kie.trustyai.explainability.model.domain.FeatureDomain;
+
+public class DataframeMetadata {
+    private final List<String> names;
+    private List<String> nameAliases;
+    private List<String> cachedColumnNames;
+    private List<Type> types;
+    private final List<Boolean> constrained;
+    private List<FeatureDomain> domains;
+    private final List<Boolean> inputs;
+
+    public DataframeMetadata() {
+        this(new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+    }
+
+    public DataframeMetadata(List<String> names, List<String> nameAliases, List<Type> types, List<Boolean> constrained, List<FeatureDomain> domains,
+            List<Boolean> inputs) {
+        this.names = new ArrayList<>(names);
+        this.nameAliases = new ArrayList<>(nameAliases);
+        this.types = new ArrayList<>(types);
+        this.constrained = new ArrayList<>(constrained);
+        this.domains = new ArrayList<>(domains);
+        this.inputs = new ArrayList<>(inputs);
+        updateCachedColumnNames();
+    }
+
+    public void remove(int column) {
+        names.remove(column);
+        nameAliases.remove(column);
+        types.remove(column);
+        constrained.remove(column);
+        domains.remove(column);
+        inputs.remove(column);
+        cachedColumnNames.remove(column);
+    }
+
+    public void add(String name, String nameAlias, Type type, Boolean constraint, FeatureDomain domain, Boolean input) {
+        this.names.add(name);
+        this.nameAliases.add(nameAlias);
+        this.types.add(type);
+        this.constrained.add(constraint);
+        this.domains.add(domain);
+        this.inputs.add(input);
+        this.cachedColumnNames.add(nameAlias == null ? name : nameAlias);
+    }
+
+    public DataframeMetadata copy() {
+        return new DataframeMetadata(
+                new ArrayList<>(this.names),
+                new ArrayList<>(this.nameAliases),
+                new ArrayList<>(this.types),
+                new ArrayList<>(this.constrained),
+                new ArrayList<>(this.domains),
+                new ArrayList<>(this.inputs));
+    }
+
+    private void updateCachedColumnNames() {
+        List<String> newNames = new ArrayList<>();
+        for (int i = 0; i < this.names.size(); i++) {
+            if (this.nameAliases.get(i) != null) {
+                newNames.add(this.nameAliases.get(i));
+            } else {
+                newNames.add(this.names.get(i));
+            }
+        }
+        this.cachedColumnNames = newNames;
+    }
+
+    protected List<String> getNames() {
+        return cachedColumnNames;
+    }
+
+    protected String getNames(int i) {
+        return cachedColumnNames.get(i);
+    }
+
+    protected void setNameAliases(Map<String, String> aliases) {
+        List<String> newAliases = new ArrayList<>();
+        for (String name : names) {
+            if (aliases.containsKey(name)) {
+                newAliases.add(aliases.get(name));
+            } else {
+                newAliases.add(null);
+            }
+        }
+        this.nameAliases = newAliases;
+        updateCachedColumnNames();
+    }
+
+    // item getters ====================================================================================================
+    public String getRawName(int i) {
+        return names.get(i);
+    }
+
+    public String getNameAlias(int i) {
+        return nameAliases.get(i);
+    }
+
+    public Type getType(int i) {
+        return types.get(i);
+    }
+
+    public Boolean getConstrained(int i) {
+        return constrained.get(i);
+    }
+
+    public FeatureDomain getDomain(int i) {
+        return domains.get(i);
+    }
+
+    public Boolean getInput(int i) {
+        return inputs.get(i);
+    }
+
+    // list getters ====================================================================================================
+    public List<String> getNameAliases() {
+        return nameAliases;
+    }
+
+    public List<String> getCachedColumnNames() {
+        return cachedColumnNames;
+    }
+
+    public List<Type> getTypes() {
+        return types;
+    }
+
+    public List<Boolean> getConstrained() {
+        return constrained;
+    }
+
+    public List<FeatureDomain> getDomains() {
+        return domains;
+    }
+
+    public List<Boolean> getInputs() {
+        return inputs;
+    }
+
+    //setters ==========================================================================================================
+    public void setNameAlias(int i, String nameAlias) {
+        this.nameAliases.set(i, nameAlias);
+    }
+
+    public void setType(int i, Type type) {
+        this.types.set(i, type);
+    }
+
+    public void setConstrained(int i, Boolean constraint) {
+        this.constrained.set(i, constraint);
+    }
+
+    public void setDomain(int i, FeatureDomain domain) {
+        this.domains.set(i, domain);
+    }
+
+    public void setInput(int i, Boolean input) {
+        this.inputs.set(i, input);
+    }
+}

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/model/DataframeMetadata.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/model/DataframeMetadata.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.kie.trustyai.explainability.model.domain.EmptyFeatureDomain;
 import org.kie.trustyai.explainability.model.domain.FeatureDomain;
 
 public class DataframeMetadata {
@@ -15,6 +16,7 @@ public class DataframeMetadata {
     private List<FeatureDomain> domains;
     private final List<Boolean> inputs;
 
+    // constructors ====================================================================================================
     public DataframeMetadata() {
         this(new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
     }
@@ -30,26 +32,6 @@ public class DataframeMetadata {
         updateCachedColumnNames();
     }
 
-    public void remove(int column) {
-        names.remove(column);
-        nameAliases.remove(column);
-        types.remove(column);
-        constrained.remove(column);
-        domains.remove(column);
-        inputs.remove(column);
-        cachedColumnNames.remove(column);
-    }
-
-    public void add(String name, String nameAlias, Type type, Boolean constraint, FeatureDomain domain, Boolean input) {
-        this.names.add(name);
-        this.nameAliases.add(nameAlias);
-        this.types.add(type);
-        this.constrained.add(constraint);
-        this.domains.add(domain);
-        this.inputs.add(input);
-        this.cachedColumnNames.add(nameAlias == null ? name : nameAlias);
-    }
-
     public DataframeMetadata copy() {
         return new DataframeMetadata(
                 new ArrayList<>(this.names),
@@ -60,6 +42,48 @@ public class DataframeMetadata {
                 new ArrayList<>(this.inputs));
     }
 
+    public void remove(int column) {
+        names.remove(column);
+        nameAliases.remove(column);
+        types.remove(column);
+        constrained.remove(column);
+        domains.remove(column);
+        inputs.remove(column);
+        cachedColumnNames.remove(column);
+    }
+
+    // row adders ======================================================================================================
+    public void add(String name, String nameAlias, Type type, Boolean constraint, FeatureDomain domain, Boolean input) {
+        this.names.add(name);
+        this.nameAliases.add(nameAlias);
+        this.types.add(type);
+        this.constrained.add(constraint);
+        this.domains.add(domain);
+        this.inputs.add(input);
+        this.cachedColumnNames.add(nameAlias == null ? name : nameAlias);
+    }
+
+    public void add(Feature feature) {
+        add(
+                feature.getName(),
+                null,
+                feature.getType(),
+                feature.isConstrained(),
+                feature.getDomain(),
+                true);
+    }
+
+    public void add(Output output) {
+        add(
+                output.getName(),
+                null,
+                output.getType(),
+                true,
+                EmptyFeatureDomain.create(),
+                false);
+    }
+
+    // column name accessors ===========================================================================================
     private void updateCachedColumnNames() {
         List<String> newNames = new ArrayList<>();
         for (int i = 0; i < this.names.size(); i++) {

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/model/DataframeMetadataTest.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/model/DataframeMetadataTest.java
@@ -1,0 +1,31 @@
+package org.kie.trustyai.explainability.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DataframeMetadataTest {
+
+    @Test
+    void testColumnAdding() {
+        DataframeMetadata dfm = new DataframeMetadata();
+        for (int i = 0; i < 100; i++) {
+            if (i % 3 == 0) {
+                Feature f = FeatureFactory.newNumericalFeature(String.valueOf(i), i);
+                dfm.add(f);
+            } else if (i % 3 == 1) {
+                Output o = new Output(String.valueOf(i), Type.NUMBER, new Value(i), 1.0);
+                dfm.add(o);
+            } else {
+                dfm.add(String.valueOf(i), null, Type.CATEGORICAL, true, null, true);
+            }
+        }
+
+        // check alignment of cached column names
+        assertEquals(dfm.getNameAliases().size(), dfm.getNames().size());
+        assertEquals(dfm.getTypes().size(), dfm.getNames().size());
+        assertEquals(dfm.getConstrained().size(), dfm.getNames().size());
+        assertEquals(dfm.getDomains().size(), dfm.getNames().size());
+        assertEquals(dfm.getInputs().size(), dfm.getNames().size());
+    }
+}


### PR DESCRIPTION
This PR refactors the Dataframe metadata into its own class to more strictly control how its attributes are accessed and modified by `Dataframe`. Furthermore, this changes `Dataframe.getColumnNames()` from an O(n) to an O(1) operation, which should drastically speed up Metadata creation from logged inferences.


Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `FAI-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.3.x] FAI-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

