### PR TITLE
Upgrade Quarkus base version to 2.16.12.Final

### DIFF
--- a/explainability-service/pom.xml
+++ b/explainability-service/pom.xml
@@ -18,7 +18,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>2.13.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.16.12.Final</quarkus.platform.version>
         <apache.commons.collections.version>4.4</apache.commons.collections.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>


### PR DESCRIPTION
Following the release of Quarkus 2.16.12.Final and Red Hat Build of Quarkus 2.13.8 on the 20th October[^1], upgrade to Quarkus 2.16.12.Final.

[^1]: https://quarkus.io/blog/cve-2023-44487/