### PR TITLE
Downgrade CI's odh-model-controller

### DIFF
--- a/tests/setup/odh-core.yaml
+++ b/tests/setup/odh-core.yaml
@@ -28,6 +28,8 @@ spec:
       parameters:
         - name: deployment-namespace
           value: opendatahub
+        - name: odh-model-controller
+          value: 'quay.io/opendatahub/odh-model-controller:v0.11.0-alpha'
       repoRef:
         name: manifests
         path: modelmesh-monitoring

--- a/tests/setup/odh-core.yaml
+++ b/tests/setup/odh-core.yaml
@@ -20,6 +20,8 @@ spec:
       parameters:
         - name: monitoring-namespace
           value: opendatahub
+        - name: odh-model-controller
+          value: 'quay.io/opendatahub/odh-model-controller:v0.11.0-alpha'
       repoRef:
         name: manifests
         path: model-mesh
@@ -28,8 +30,6 @@ spec:
       parameters:
         - name: deployment-namespace
           value: opendatahub
-        - name: odh-model-controller
-          value: 'quay.io/opendatahub/odh-model-controller:v0.11.0-alpha'
       repoRef:
         name: manifests
         path: modelmesh-monitoring


### PR DESCRIPTION
TrustyAI CI not working with latest `odh-model-controller:v0.11.0`. Reverting to `odh-model-controller:v0.11.0-odh-model-controller:v0.11.0-alpha` temporarily.
