### PR TITLE
Refactor name mapping retrieval in schema

### DIFF
--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/CSVUtils.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/CSVUtils.java
@@ -26,7 +26,7 @@ public class CSVUtils {
 
     private static List<Output> getOutputs(List<String> outputNames, Metadata metadata, CSVRecord entry) {
         return outputNames.stream().map(colName -> {
-            final SchemaItem schemaItem = metadata.getOutputSchema().retrieveNameMappedItems().get(colName);
+            final SchemaItem schemaItem = metadata.getOutputSchema().getNameMappedItems().get(colName);
             final int inputIndex = schemaItem.getIndex();
             final String name = schemaItem.getName();
             final DataType vtypes = schemaItem.getType();
@@ -57,12 +57,12 @@ public class CSVUtils {
     public static List<Prediction> parse(String in, Metadata metadata, boolean header) throws IOException {
         CSVParser parser = CSVFormat.DEFAULT.parse(new StringReader(in));
 
-        final List<String> inputNames = metadata.getInputSchema().retrieveNameMappedItems().entrySet()
+        final List<String> inputNames = metadata.getInputSchema().getNameMappedItems().entrySet()
                 .stream()
                 .sorted(Comparator.comparingInt(e -> e.getValue().getIndex()))
                 .map(Map.Entry::getKey)
                 .collect(Collectors.toList());
-        final List<String> outputNames = metadata.getOutputSchema().retrieveNameMappedItems().entrySet()
+        final List<String> outputNames = metadata.getOutputSchema().getNameMappedItems().entrySet()
                 .stream()
                 .sorted(Comparator.comparingInt(e -> e.getValue().getIndex()))
                 .map(Map.Entry::getKey)
@@ -73,7 +73,7 @@ public class CSVUtils {
         parser.stream().forEach(entry -> {
             if (!header || idx.get() > 0) {
                 final List<Feature> inputFeatures = inputNames.stream().map(colName -> {
-                    final SchemaItem schemaItem = metadata.getInputSchema().retrieveNameMappedItems().get(colName);
+                    final SchemaItem schemaItem = metadata.getInputSchema().getNameMappedItems().get(colName);
                     final int inputIndex = schemaItem.getIndex();
                     final String name = schemaItem.getName();
                     final String valueString = entry.get(inputIndex);

--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/metrics/RequestReconciler.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/metrics/RequestReconciler.java
@@ -47,7 +47,7 @@ public class RequestReconciler {
                     throw new IllegalArgumentException("Method " + f.getName() + "was declared as the name source of the reconciled feature, but returns exception:" + e);
                 }
 
-                DataType fieldDataType = metadata.getInputSchema().retrieveNameMappedItems().get(name).getType();
+                DataType fieldDataType = metadata.getInputSchema().getNameMappedItems().get(name).getType();
                 TypedValue tv = new TypedValue();
                 tv.setType(fieldDataType);
                 tv.setValue(fieldValue.getRawValueNode());
@@ -81,7 +81,7 @@ public class RequestReconciler {
                     throw new IllegalArgumentException("Method " + f.getName() + "was declared as the name source of the reconciled output, but returns exception:" + e);
                 }
 
-                DataType fieldDataType = metadata.getOutputSchema().retrieveNameMappedItems().get(name).getType();
+                DataType fieldDataType = metadata.getOutputSchema().getNameMappedItems().get(name).getType();
                 TypedValue tv = new TypedValue();
                 tv.setType(fieldDataType);
                 tv.setValue(fieldValue.getRawValueNode());

--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/service/Schema.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/service/Schema.java
@@ -8,18 +8,22 @@ import java.util.concurrent.ConcurrentHashMap;
 public class Schema {
     private final Map<String, SchemaItem> items;
     private Map<String, String> nameMapping = new HashMap<>();
+    private Map<String, SchemaItem> mappedItems = new HashMap<>();
 
     public Schema() {
         this.items = new ConcurrentHashMap<>();
+        calculateNameMappedItems();
     }
 
     public Schema(Map<String, SchemaItem> items) {
         this.items = items;
+        calculateNameMappedItems();
     }
 
     public Schema(Map<String, SchemaItem> items, Map<String, String> nameMapping) {
         this.items = items;
         this.nameMapping = nameMapping;
+        calculateNameMappedItems();
     }
 
     public static Schema from(Map<String, SchemaItem> items) {
@@ -31,16 +35,15 @@ public class Schema {
     }
 
     //@CacheResult(cacheName = "schema-name-mapped-items", keyGenerator = SchemaNameMappingCacheKeyGen.class)
-    public Map<String, SchemaItem> retrieveNameMappedItems() {
-        Map<String, SchemaItem> returnMap = new HashMap<>();
-        for (Map.Entry<String, SchemaItem> entry : items.entrySet()) {
-            if (nameMapping.containsKey(entry.getKey())) {
-                returnMap.put(nameMapping.get(entry.getKey()), entry.getValue());
-            } else {
-                returnMap.put(entry.getKey(), entry.getValue());
+    private void calculateNameMappedItems() {
+        this.mappedItems = new HashMap<>(items);
+        if (!nameMapping.isEmpty()) {
+            for (Map.Entry<String, String> mapping : nameMapping.entrySet()) {
+                if (items.containsKey(mapping.getKey())) {
+                    this.mappedItems.put(mapping.getKey(), items.get(mapping.getKey()));
+                }
             }
         }
-        return returnMap;
     }
 
     public Map<String, String> getNameMapping() {
@@ -49,6 +52,11 @@ public class Schema {
 
     public void setNameMapping(Map<String, String> nameMapping) {
         this.nameMapping = nameMapping;
+        calculateNameMappedItems();
+    }
+
+    public Map<String, SchemaItem> getNameMappedItems() {
+        return mappedItems;
     }
 
     @Override

--- a/explainability-service/src/main/java/org/kie/trustyai/service/validators/generic/GenericValidationUtils.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/validators/generic/GenericValidationUtils.java
@@ -27,7 +27,7 @@ public class GenericValidationUtils {
     }
 
     public static boolean validateFeatureColumnName(ConstraintValidatorContext context, Metadata metadata, String modelId, String columnName, String objectName) {
-        if (!metadata.getInputSchema().retrieveNameMappedItems().containsKey(columnName)) {
+        if (!metadata.getInputSchema().getNameMappedItems().containsKey(columnName)) {
             context.buildConstraintViolationWithTemplate("No " + objectName + " found with name=" + columnName)
                     .addPropertyNode(modelId)
                     .addPropertyNode(columnName)
@@ -42,7 +42,7 @@ public class GenericValidationUtils {
     }
 
     public static boolean validateOutputColumnName(ConstraintValidatorContext context, Metadata metadata, String modelId, String columnName, String objectName) {
-        if (!metadata.getOutputSchema().retrieveNameMappedItems().containsKey(columnName)) {
+        if (!metadata.getOutputSchema().getNameMappedItems().containsKey(columnName)) {
             context.buildConstraintViolationWithTemplate("No " + objectName + " found with name=" + columnName)
                     .addPropertyNode(modelId)
                     .addPropertyNode(columnName)
@@ -57,7 +57,7 @@ public class GenericValidationUtils {
     }
 
     public static boolean validateColumnName(ConstraintValidatorContext context, Metadata metadata, String modelId, String columnName) {
-        if (!metadata.getOutputSchema().retrieveNameMappedItems().containsKey(columnName) && !metadata.getInputSchema().retrieveNameMappedItems().containsKey(columnName)) {
+        if (!metadata.getOutputSchema().getNameMappedItems().containsKey(columnName) && !metadata.getInputSchema().getNameMappedItems().containsKey(columnName)) {
             context.buildConstraintViolationWithTemplate("No feature or output found with name=" + columnName)
                     .addPropertyNode(modelId)
                     .addPropertyNode(columnName)
@@ -70,7 +70,7 @@ public class GenericValidationUtils {
     // check to see if the provided output value has a compatible type
     public static boolean validateOutputColumnType(ConstraintValidatorContext context, Metadata metadata, String modelId, String columnName, ValueNode valueNode, String objectName) {
         // Output name guaranteed to exist
-        final SchemaItem outcomeSchema = metadata.getOutputSchema().retrieveNameMappedItems().get(columnName);
+        final SchemaItem outcomeSchema = metadata.getOutputSchema().getNameMappedItems().get(columnName);
         if (!PayloadConverter.checkValueType(outcomeSchema.getType(), valueNode)) {
             context.buildConstraintViolationWithTemplate(
                     String.format(
@@ -94,7 +94,7 @@ public class GenericValidationUtils {
     // check to see if the provided attribute values have a compatible type
     public static boolean validateFeatureColumnType(ConstraintValidatorContext context, Metadata metadata, String modelId, String columnName, ValueNode valueNode, String objectName) {
         // Protected attribute guaranteed to exist
-        final SchemaItem protectedAttrSchema = metadata.getInputSchema().retrieveNameMappedItems().get(columnName);
+        final SchemaItem protectedAttrSchema = metadata.getInputSchema().getNameMappedItems().get(columnName);
         boolean result = true;
         if (!PayloadConverter.checkValueType(protectedAttrSchema.getType(), valueNode)) {
             context.buildConstraintViolationWithTemplate(

--- a/explainability-service/src/test/java/org/kie/trustyai/service/data/parsers/CSVParserTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/data/parsers/CSVParserTest.java
@@ -32,4 +32,24 @@ class CSVParserTest {
         }
     }
 
+    @Test
+    void testRestoringLargeDataframeFromByteBuffers() {
+        // tests to make sure runtime is reasonable for very large-columned dfs
+
+        CSVParser csvParser = new CSVParser();
+        Dataframe dataframe = new MockDatasource().generateRandomNColumnDataframe(10, 100_000);
+        ByteBuffer[] byteBuffers = csvParser.toByteBuffers(dataframe, false);
+        assertNotNull(byteBuffers);
+        assertEquals(2, byteBuffers.length);
+        Metadata metadata = new Metadata();
+        metadata.setInputSchema(MetadataUtils.getInputSchema(dataframe));
+        metadata.setOutputSchema(MetadataUtils.getOutputSchema(dataframe));
+        metadata.setObservations(dataframe.getRowDimension());
+        Dataframe restoredDataframe = csvParser.toDataframe(byteBuffers[0], byteBuffers[1], metadata);
+        assertNotNull(restoredDataframe);
+        assertEquals(10, dataframe.getRowDimension());
+        for (int i = 0; i < dataframe.getRowDimension(); i++) {
+            assertEquals(dataframe.getRow(i), restoredDataframe.getRow(i));
+        }
+    }
 }

--- a/explainability-service/src/test/java/org/kie/trustyai/service/mocks/MockDatasource.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/mocks/MockDatasource.java
@@ -3,6 +3,8 @@ package org.kie.trustyai.service.mocks;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.kie.trustyai.explainability.model.*;
 import org.kie.trustyai.service.data.DataSource;
@@ -78,6 +80,23 @@ public class MockDatasource extends DataSource {
 
     public Dataframe generateRandomDataframeDrifted(int observations) {
         return generateRandomDataframeDrifted(observations, 100);
+    }
+
+    public Dataframe generateRandomNColumnDataframe(int observations, int columns) {
+        final List<Prediction> predictions = new ArrayList<>();
+        final Random random = new Random(0);
+        for (int i = 0; i < observations; i++) {
+            final List<Feature> featureList = IntStream.range(0, columns)
+                    .mapToObj(idx -> FeatureFactory.newNumericalFeature("f" + idx, idx))
+                    .collect(Collectors.toList());
+            final PredictionInput predictionInput = new PredictionInput(featureList);
+
+            final List<Output> outputList = List.of(
+                    new Output("income", Type.NUMBER, new Value(random.nextBoolean() ? 1 : 0), 1.0));
+            final PredictionOutput predictionOutput = new PredictionOutput(outputList);
+            predictions.add(new SimplePrediction(predictionInput, predictionOutput));
+        }
+        return Dataframe.createFrom(predictions);
     }
 
     public Dataframe generateRandomDataframeDrifted(int observations, int featureDiversity) {


### PR DESCRIPTION
Addresses https://github.com/trustyai-explainability/trustyai-explainability/issues/418

Namely, this PR adjusts the `Schema.retrieveNameMappedItems()` logic, both making the function itself more efficient as well as only computing the result on changes to the `nameMapping` map, rather than on every call. 

Additionally, the function is renamed from `retrieveNameMappedItems()` to `getNameMappedItems` to reflect its new nature as a true attribute getter.







Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `FAI-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.3.x] FAI-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

