### PR TITLE
When the mvn command fails for example due to lack of space, make sure the whole build fails.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ COPY ${SOURCE_CODE}/explainability-integrationtests ./explainability-integration
 COPY ${SOURCE_CODE}/pom.xml ./pom.xml
 
 # build and clean up everything we don't need
-RUN mvn -B clean package --file pom.xml -P service-minimal -DskipTests; rm -Rf explainability-core explainability-connectors explainability-arrow explainability-integrationtests
+RUN mvn -B clean package --file pom.xml -P service-minimal -DskipTests && rm -Rf explainability-core explainability-connectors explainability-arrow explainability-integrationtests
 
 ## Livebuilder CODE END ##
 


### PR DESCRIPTION
This comes from https://github.com/red-hat-data-services/trustyai-explainability/pull/6.

Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `FAI-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting main: `[0.3.x] FAI-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
