### PR TITLE
Rearrange maven repo ordering

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -338,11 +338,19 @@
 
     <repositories>
         <repository>
+            <id>central</id>
+            <url>https://repo.maven.apache.org/maven2/</url>
+        </repository>
+        <repository>
             <id>red-hat-ga</id>
             <url>https://maven.repository.redhat.com/ga/</url>
         </repository>
     </repositories>
     <pluginRepositories>
+        <pluginRepository>
+            <id>central</id>
+            <url>https://repo.maven.apache.org/maven2/</url>
+        </pluginRepository>
         <pluginRepository>
             <id>red-hat-ga</id>
             <url>https://maven.repository.redhat.com/ga/</url>


### PR DESCRIPTION
Previously, the repo resolve order went:
1) red-hat-ga
2) maven central

Which meant the majority of dependencies checked RH first, then maven-central, effectively doubling the resolvement time.

Now, it checks:
1) Maven central
2) red-hat-ga

Which means only the dependencies not in maven central (quarkus) get pulled from red-hat-ga


Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `FAI-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.3.x] FAI-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

