### PR TITLE
Fix upload of Nx1 tensors in upload endpoint

### DIFF
--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/UploadUtils.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/UploadUtils.java
@@ -22,6 +22,10 @@ import com.google.protobuf.ByteString;
 public class UploadUtils {
     private static final Logger LOG = Logger.getLogger(UploadUtils.class);
 
+    private static boolean shapeReversalCheck(List<Long> shape) {
+        return shape.get(0) != 1 && shape.get(shape.size() - 1) != 1;
+    }
+
     // fill a tensor builder based on provided datatype
     private static InferTensorContents.Builder getTensorBuilder(String datatype, Object[] data) {
 
@@ -97,7 +101,7 @@ public class UploadUtils {
 
         // the shapes are parsed in different directions in the kserve parser depending on codec
         List<Long> shape = Arrays.stream(input.getShape()).mapToLong(Number::longValue).boxed().collect(Collectors.toList());
-        if (shape.get(0) != 1) {
+        if (shapeReversalCheck(shape)) {
             Collections.reverse(shape);
         }
         inputBuilder.addAllShape(shape);
@@ -140,7 +144,7 @@ public class UploadUtils {
 
         // the shapes are parsed in different directions in the kserve parser depending on codec
         List<Long> shape = Arrays.stream(output.getShape()).mapToLong(Number::longValue).boxed().collect(Collectors.toList());
-        if (shape.get(0) != 1) {
+        if (shapeReversalCheck(shape)) {
             Collections.reverse(shape);
         }
         outputBuilder.addAllShape(shape);

--- a/explainability-service/src/test/java/org/kie/trustyai/service/utils/KserveRestPayloads.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/utils/KserveRestPayloads.java
@@ -35,11 +35,7 @@ public class KserveRestPayloads {
     public static TensorPayload generateTensor(int nRows, int nCols, String name, String datatype, int offset) {
         TensorPayload tensorPayload = new TensorPayload();
         tensorPayload.setName(name);
-        if (nCols == 1) {
-            tensorPayload.setShape(new Number[] { nRows });
-        } else {
-            tensorPayload.setShape(new Number[] { nRows, nCols });
-        }
+        tensorPayload.setShape(new Number[] { nRows, nCols });
         tensorPayload.setDatatype(datatype);
 
         if (nRows == 1) {


### PR DESCRIPTION
Remedies https://github.com/trustyai-explainability/trustyai-explainability/issues/430

MM can return an N element tensor as `[a, b, ..., n]` and mark its shape as `[n, 1]`. This case was not correctly supported, this PR ensures that the correct parsing codec is used.


Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `FAI-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.3.x] FAI-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

