### PR TITLE
Add support for KServe's "inputs" format

### DIFF
--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/KServeInferencePayloadReconciler.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/KServeInferencePayloadReconciler.java
@@ -10,11 +10,13 @@ import org.kie.trustyai.explainability.model.*;
 import org.kie.trustyai.service.data.DataSource;
 import org.kie.trustyai.service.data.exceptions.DataframeCreateException;
 import org.kie.trustyai.service.data.exceptions.InvalidSchemaException;
+import org.kie.trustyai.service.payloads.consumer.InferenceLoggerGeneral;
 import org.kie.trustyai.service.payloads.consumer.InferenceLoggerInput;
 import org.kie.trustyai.service.payloads.consumer.KServeInputPayload;
 import org.kie.trustyai.service.payloads.consumer.KServeOutputPayload;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -55,17 +57,33 @@ public class KServeInferencePayloadReconciler extends InferencePayloadReconciler
 
     public List<Prediction> payloadToPrediction(KServeInputPayload inputs, KServeOutputPayload outputs, String id, Map<String, String> metadata) throws DataframeCreateException {
 
-        final InferenceLoggerInput inferenceLoggerInput;
+        final ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode rootNode;
+        List<Double> instanceData = null;
+
         try {
-            inferenceLoggerInput = objectMapper.readValue(inputs.getData(), InferenceLoggerInput.class);
+            rootNode = objectMapper.readTree(inputs.getData());
+
+            if (rootNode.has("instances")) {
+                // Handle the instances format
+                InferenceLoggerInput originalFormat = objectMapper.treeToValue(rootNode, InferenceLoggerInput.class);
+                instanceData = originalFormat.getInstances().get(0);
+            } else if (rootNode.has("inputs")) {
+                // Handle the inputs format
+                InferenceLoggerGeneral newFormat = objectMapper.treeToValue(rootNode, InferenceLoggerGeneral.class);
+                instanceData = newFormat.getInputs().get(0).getInputData().get(0);
+            } else {
+                throw new DataframeCreateException("Unknown input format");
+            }
         } catch (JsonProcessingException e) {
-            final String message = "Could not parse input data";
+            final String message = "Could not parse input data: " + e.getMessage();
             LOG.error(message);
             throw new DataframeCreateException(message);
         }
 
-        final PredictionInput predictionInput = new PredictionInput(IntStream.range(0, inferenceLoggerInput.getInstances().get(0).size()).mapToObj(i -> {
-            return FeatureFactory.newNumericalFeature("feature-" + i, inferenceLoggerInput.getInstances().get(0).get(i));
+        final List<Double> data = instanceData;
+        final PredictionInput predictionInput = new PredictionInput(IntStream.range(0, instanceData.size()).mapToObj(i -> {
+            return FeatureFactory.newNumericalFeature("feature-" + i, data.get(i));
         }).collect(Collectors.toList()));
 
         final PredictionOutput predictionOutput = new PredictionOutput(IntStream.range(0, outputs.getData().getPredictions().size()).mapToObj(i -> {
@@ -73,8 +91,6 @@ public class KServeInferencePayloadReconciler extends InferencePayloadReconciler
         }).collect(Collectors.toList()));
 
         final List<Prediction> predictions = List.of(new SimplePrediction(predictionInput, predictionOutput));
-
-        LOG.info(predictions.get(0));
 
         return predictions;
     }

--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/consumer/InferenceLoggerGeneral.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/consumer/InferenceLoggerGeneral.java
@@ -1,0 +1,26 @@
+package org.kie.trustyai.service.payloads.consumer;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class InferenceLoggerGeneral {
+
+    @JsonProperty("inputs")
+    private List<InferenceLoggerInputV2> inputs;
+
+    public InferenceLoggerGeneral(List<InferenceLoggerInputV2> inputs) {
+        this.inputs = inputs;
+    }
+
+    public List<InferenceLoggerInputV2> getInputs() {
+        return inputs;
+    }
+
+    public void setInputs(List<InferenceLoggerInputV2> inputs) {
+        this.inputs = inputs;
+    }
+
+    public InferenceLoggerGeneral() {
+    }
+}

--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/consumer/InferenceLoggerInputV2.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/consumer/InferenceLoggerInputV2.java
@@ -1,0 +1,47 @@
+package org.kie.trustyai.service.payloads.consumer;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class InferenceLoggerInputV2 {
+
+    private String name;
+    private List<Integer> shape;
+    private String datatype;
+
+    @JsonProperty("data")
+    private List<List<Double>> inputData;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<Integer> getShape() {
+        return shape;
+    }
+
+    public void setShape(List<Integer> shape) {
+        this.shape = shape;
+    }
+
+    public String getDatatype() {
+        return datatype;
+    }
+
+    public void setDatatype(String datatype) {
+        this.datatype = datatype;
+    }
+
+    public List<List<Double>> getInputData() {
+        return inputData;
+    }
+
+    public void setInputData(List<List<Double>> inputData) {
+        this.inputData = inputData;
+    }
+}

--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/consumer/InferenceLoggerOutput.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/consumer/InferenceLoggerOutput.java
@@ -2,14 +2,65 @@ package org.kie.trustyai.service.payloads.consumer;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class InferenceLoggerOutput {
-    @JsonProperty("predictions")
+    // Match the old "predictions" format
+    @JsonAlias({ "predictions" })
     private List<Double> predictions;
 
+    // Match the "outputs" format
+    @JsonProperty("outputs")
+    private List<Output> outputs;
+
+    public static class Output {
+        private String name;
+
+        public List<Integer> getShape() {
+            return shape;
+        }
+
+        public void setShape(List<Integer> shape) {
+            this.shape = shape;
+        }
+
+        public String getDatatype() {
+            return datatype;
+        }
+
+        public void setDatatype(String datatype) {
+            this.datatype = datatype;
+        }
+
+        public List<Double> getData() {
+            return data;
+        }
+
+        public void setData(List<Double> data) {
+            this.data = data;
+        }
+
+        private List<Integer> shape;
+        private String datatype;
+        private List<Double> data;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
     public List<Double> getPredictions() {
-        return predictions;
+        if (predictions != null) {
+            return predictions;
+        } else if (outputs != null && !outputs.isEmpty()) {
+            return outputs.get(0).data;
+        }
+        return null;
     }
 
     public void setPredictions(List<Double> predictions) {

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/consumer/CloudEventConsumerTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/consumer/CloudEventConsumerTest.java
@@ -97,7 +97,8 @@ public class CloudEventConsumerTest {
             consumer.get().consumeKubeflowResponse(mockOutput);
         });
 
-        assertEquals("Could not parse input data", exception.getMessage());
+        assertEquals("Could not parse input data: Unrecognized token 'foo': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')\n" +
+                " at [Source: (String)\"foo\"; line: 1, column: 4]", exception.getMessage());
     }
 
     @Test


### PR DESCRIPTION
Add support for the KServe "inputs" format.

## Example:

Input:

```json
{
    "inputs": [
      {
        "name": "input-0",
        "shape": [1, 4],
        "datatype": "FP32",
        "data": [
          [32, 0, 1, 2]
        ]
      }
    ]
  }
```

Output:

```json
{"model_name":"example-isvc","id":"04f66a85-a54d-4a9c-aa5e-5f4514cb4def","parameters":{},"outputs":[{"name":"predict","shape":[1,1],"datatype":"INT64","data":[0]}]}
```