### PR TITLE
Change Maven scope of OpenNLP to compile

### DIFF
--- a/explainability-core/pom.xml
+++ b/explainability-core/pom.xml
@@ -83,7 +83,6 @@
     <dependency>
       <groupId>org.apache.opennlp</groupId>
       <artifactId>opennlp-tools</artifactId>
-      <scope>compile</scope>
     </dependency>
   </dependencies>
 

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/utils/ValidationUtilsTest.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/utils/ValidationUtilsTest.java
@@ -21,9 +21,7 @@ import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.kie.trustyai.explainability.Config;
 import org.kie.trustyai.explainability.TestConfig;
 import org.kie.trustyai.explainability.local.lime.LimeConfig;
 import org.kie.trustyai.explainability.local.lime.LimeExplainer;

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,6 @@
                 <groupId>org.apache.opennlp</groupId>
                 <artifactId>opennlp-tools</artifactId>
                 <version>${version.org.apache.opennlp}</version>
-                <scope>test</scope>
             </dependency>
 
         </dependencies>


### PR DESCRIPTION
The current scope is test, however this dependency is needed for the Python bindings language metrics.