### PR TITLE
Increase async timeout for CI tests

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -13,8 +13,7 @@ jobs:
       matrix:
         # configure with [ 'ubuntu-latest', 'windows-latest' ] to enable Windows builds
         include:
-          - { os: ubuntu-latest, shell: bash }
-        #  - {os: windows-latest, shell: cmd }
+          - { os: ubuntu-22.04, shell: bash } # Pinned to Ubuntu 22.04 LTS. Change if necessary.
         java-version: [ 11, 17 ]
         # Maven maintained core versions, https://maven.apache.org/docs/history.html
         maven-version: [ '3.6.3', '3.8.8', '3.9.2' ]
@@ -49,7 +48,7 @@ jobs:
         run: git config --system core.longpaths true
       - name: Set up JDK + Maven version
         # include actions/checkout, actions/setup-java, actions/cache, see https://github.com/s4u/setup-maven-action/blob/main/action.yml
-        uses: s4u/setup-maven-action@v1.7.0
+        uses: s4u/setup-maven-action@v1.11.0
         with:
           java-version: ${{ matrix.java-version }}
           maven-version: ${{ matrix.maven-version }}

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/TestConfig.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/TestConfig.java
@@ -3,7 +3,7 @@ package org.kie.trustyai.explainability;
 import java.util.concurrent.TimeUnit;
 
 public class TestConfig {
-    public static final long DEFAULT_ASYNC_TIMEOUT = 120;
+    public static final long DEFAULT_ASYNC_TIMEOUT = 20;
     public static final TimeUnit DEFAULT_ASYNC_TIMEUNIT = TimeUnit.SECONDS;
 
 }

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/TestConfig.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/TestConfig.java
@@ -1,0 +1,9 @@
+package org.kie.trustyai.explainability;
+
+import java.util.concurrent.TimeUnit;
+
+public class TestConfig {
+    public static final long DEFAULT_ASYNC_TIMEOUT = 10;
+    public static final TimeUnit DEFAULT_ASYNC_TIMEUNIT = TimeUnit.SECONDS;
+
+}

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/TestConfig.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/TestConfig.java
@@ -3,7 +3,7 @@ package org.kie.trustyai.explainability;
 import java.util.concurrent.TimeUnit;
 
 public class TestConfig {
-    public static final long DEFAULT_ASYNC_TIMEOUT = 10;
+    public static final long DEFAULT_ASYNC_TIMEOUT = 120;
     public static final TimeUnit DEFAULT_ASYNC_TIMEUNIT = TimeUnit.SECONDS;
 
 }

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/utils/ValidationUtilsTest.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/utils/ValidationUtilsTest.java
@@ -24,17 +24,13 @@ import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.kie.trustyai.explainability.Config;
+import org.kie.trustyai.explainability.TestConfig;
 import org.kie.trustyai.explainability.local.lime.LimeConfig;
 import org.kie.trustyai.explainability.local.lime.LimeExplainer;
 import org.kie.trustyai.explainability.model.*;
 import org.kie.trustyai.explainability.utils.models.TestModels;
 
 class ValidationUtilsTest {
-
-    @BeforeEach
-    void setUp() {
-        Config.INSTANCE.setAsyncTimeout(10);
-    }
 
     @Test
     void testStableEval() throws ExecutionException, InterruptedException, TimeoutException, ValidationUtils.ValidationException {
@@ -49,7 +45,7 @@ class ValidationUtilsTest {
                 features.add(FeatureFactory.newNumericalFeature("f-" + i, Type.NUMBER.randomValue(perturbationContext).asNumber()));
             }
             PredictionInput input = new PredictionInput(features);
-            List<PredictionOutput> outputs = model.predictAsync(List.of(input)).get(Config.DEFAULT_ASYNC_TIMEOUT, Config.DEFAULT_ASYNC_TIMEUNIT);
+            List<PredictionOutput> outputs = model.predictAsync(List.of(input)).get(TestConfig.DEFAULT_ASYNC_TIMEOUT, TestConfig.DEFAULT_ASYNC_TIMEUNIT);
             Prediction prediction = new SimplePrediction(input, outputs.get(0));
             int topK = 1;
             double posScore = 0.6;

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/utils/ValidationUtilsTest.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/utils/ValidationUtilsTest.java
@@ -21,6 +21,7 @@ import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.kie.trustyai.explainability.Config;
 import org.kie.trustyai.explainability.local.lime.LimeConfig;
@@ -29,6 +30,11 @@ import org.kie.trustyai.explainability.model.*;
 import org.kie.trustyai.explainability.utils.models.TestModels;
 
 class ValidationUtilsTest {
+
+    @BeforeEach
+    void setUp() {
+        Config.INSTANCE.setAsyncTimeout(10);
+    }
 
     @Test
     void testStableEval() throws ExecutionException, InterruptedException, TimeoutException, ValidationUtils.ValidationException {


### PR DESCRIPTION
Unit tests CI seems to be taking longer recently, and it's generating `TimeOutExceptions`.
This PR: 
- increases the default timeout (for tests only) to 20s.
- Pins runner OS version to Ubuntu 22.04 LTS
- Updates Java/Maven install action to 1.11.0