### PR TITLE
Expand missing metadata error message during metric creation.

### DIFF
--- a/explainability-service/src/main/java/org/kie/trustyai/service/validators/generic/GenericValidationUtils.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/validators/generic/GenericValidationUtils.java
@@ -19,7 +19,7 @@ import jakarta.validation.ConstraintValidatorContext;
 public class GenericValidationUtils {
     public static boolean validateModelId(ConstraintValidatorContext context, Instance<DataSource> dataSource, String modelId) {
         if (!dataSource.get().hasMetadata(modelId)) {
-            context.buildConstraintViolationWithTemplate("No metadata found for model=" + modelId)
+            context.buildConstraintViolationWithTemplate("No metadata found for model=" + modelId + ". This can happen if TrustyAI has not yet logged any inferences from this model.")
                     .addPropertyNode(modelId)
                     .addConstraintViolation();
             return false;


### PR DESCRIPTION
When models had no data, the error was:
`No metadata found for model=x`

It is now:
`No metadata found for model=" + modelId + ". This can happen if TrustyAI has not yet logged any inferences from this model.`

Addresses https://issues.redhat.com/browse/RHOAIENG-1974

Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `FAI-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.3.x] FAI-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

