### PR TITLE
RHOAIENG-4483: Persist synthetic tag when tensor parameter present

### DIFF
--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/KServeV2GRPCPredictionProvider.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/KServeV2GRPCPredictionProvider.java
@@ -63,7 +63,7 @@ public class KServeV2GRPCPredictionProvider implements PredictionProvider {
      * @return A {@link PredictionProvider}
      */
     public static KServeV2GRPCPredictionProvider forTarget(KServeConfig kServeConfig, String inputName, List<String> outputNames, Map<String, String> optionalParameters) {
-        return new KServeV2GRPCPredictionProvider(kServeConfig, inputName, outputNames, null);
+        return new KServeV2GRPCPredictionProvider(kServeConfig, inputName, outputNames, optionalParameters);
     }
 
     /**
@@ -131,6 +131,7 @@ public class KServeV2GRPCPredictionProvider implements PredictionProvider {
 
         final CompletableFuture<ModelInferResponse> futureResponse = ListenableFutureUtils.asCompletableFuture(listenableResponse);
 
-        return futureResponse.thenApply(response -> TensorConverter.parseKserveModelInferResponse(response, inputs.size(), Objects.isNull(this.outputNames) ? Optional.empty() : Optional.of(this.outputNames)));
+        return futureResponse
+                .thenApply(response -> TensorConverter.parseKserveModelInferResponse(response, inputs.size(), Objects.isNull(this.outputNames) ? Optional.empty() : Optional.of(this.outputNames)));
     }
 }

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/model/PredictionMetadata.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/model/PredictionMetadata.java
@@ -1,6 +1,7 @@
 package org.kie.trustyai.explainability.model;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 public class PredictionMetadata {
 
@@ -32,5 +33,17 @@ public class PredictionMetadata {
 
     public String getDataPointTag() {
         return datapointTag;
+    }
+
+    /**
+     * Create a {@link PredictionMetadata} with a random {@link UUID}, current {@link LocalDateTime} and
+     * the specified tag.
+     *
+     * @param datapointTag A {@link String} containing the tag
+     * @return A {@link PredictionMetadata}
+     */
+    public static PredictionMetadata fromTag(String datapointTag) {
+        return new PredictionMetadata(UUID.randomUUID().toString(),
+                LocalDateTime.now(), datapointTag);
     }
 }

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/ModelMeshInferencePayloadReconciler.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/ModelMeshInferencePayloadReconciler.java
@@ -1,9 +1,7 @@
 package org.kie.trustyai.service.data.utils;
 
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.List;
-import java.util.Map;
+import java.time.LocalDateTime;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -15,6 +13,7 @@ import org.kie.trustyai.explainability.model.*;
 import org.kie.trustyai.service.data.DataSource;
 import org.kie.trustyai.service.data.exceptions.DataframeCreateException;
 import org.kie.trustyai.service.data.exceptions.InvalidSchemaException;
+import org.kie.trustyai.service.endpoints.explainers.ExplainerEndpoint;
 import org.kie.trustyai.service.payloads.consumer.InferencePartialPayload;
 
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -60,6 +59,8 @@ public class ModelMeshInferencePayloadReconciler extends InferencePayloadReconci
 
     /**
      * Convert both input and output {@link InferencePartialPayload} to a TrustyAI {@link Prediction}.
+     * If the input tensor contains a {@link ExplainerEndpoint#BIAS_IGNORE_PARAM} set, then {@link PredictionMetadata}
+     * will be attached marking these inferences as synthetic.
      * 
      * @param inputPayload Input {@link InferencePartialPayload}
      * @param outputPayload Output {@link InferencePartialPayload}
@@ -77,35 +78,51 @@ public class ModelMeshInferencePayloadReconciler extends InferencePayloadReconci
         } catch (InvalidProtocolBufferException e) {
             throw new DataframeCreateException(e.getMessage());
         }
-        final List<PredictionInput> predictionInput;
+
+        // Construct record of synthetic data tags
+        List<Dataframe.InternalTags> tags = input.getInputsList().stream().map(inferInputTensor -> {
+            if (inferInputTensor.containsParameters(ExplainerEndpoint.BIAS_IGNORE_PARAM) && inferInputTensor.getParametersMap().get(ExplainerEndpoint.BIAS_IGNORE_PARAM).getStringParam().equals("true")) {
+                return Dataframe.InternalTags.SYNTHETIC;
+            } else {
+                return Dataframe.InternalTags.UNLABELED;
+            }
+        }).collect(Collectors.toList());
+        LOG.debug("Payload tags: " + tags);
+
+        final List<PredictionInput> predictionInputs;
         final int enforcedFirstDimension;
         try {
-            predictionInput = TensorConverter.parseKserveModelInferRequest(input);
-            enforcedFirstDimension = predictionInput.size();
+            predictionInputs = TensorConverter.parseKserveModelInferRequest(input);
+            enforcedFirstDimension = predictionInputs.size();
         } catch (IllegalArgumentException e) {
             throw new DataframeCreateException("Error parsing input payload: " + e.getMessage());
         }
-        LOG.debug("Prediction input: " + predictionInput);
+        LOG.debug("Prediction input: " + predictionInputs);
         final ModelInferResponse output;
         try {
             output = ModelInferResponse.parseFrom(outputBytes);
         } catch (InvalidProtocolBufferException e) {
             throw new DataframeCreateException(e.getMessage());
         }
-        final List<PredictionOutput> predictionOutput;
+        final List<PredictionOutput> predictionOutputs;
         try {
-            predictionOutput = TensorConverter.parseKserveModelInferResponse(output, enforcedFirstDimension);
+            predictionOutputs = TensorConverter.parseKserveModelInferResponse(output, enforcedFirstDimension);
         } catch (IllegalArgumentException e) {
             throw new DataframeCreateException("Error parsing output payload: " + e.getMessage());
         }
-        LOG.debug("Prediction output: " + predictionOutput);
+        LOG.debug("Prediction output: " + predictionOutputs);
 
         // Aggregate features and outputs
-        final int size = predictionInput.size();
+        final int size = predictionInputs.size();
+        // Use the tensor tag for a batch
+        // If no tags are recorded, use unlabelled by default
+        final String tag = tags.isEmpty() ? Dataframe.InternalTags.UNLABELED.get() : tags.get(0).get();
         final List<Prediction> predictions = IntStream.range(0, size).mapToObj(i -> {
-            final PredictionInput pi = predictionInput.get(i);
-            final PredictionOutput po = predictionOutput.get(i);
-            return new SimplePrediction(pi, po);
+            final PredictionInput pi = predictionInputs.get(i);
+            final PredictionOutput po = predictionOutputs.get(i);
+            final PredictionMetadata predictionMetadata = PredictionMetadata.fromTag(tag);
+            return (Prediction) new SimplePrediction(pi, po, predictionMetadata);
+
         }).collect(Collectors.toCollection(ArrayList::new));
 
         final Dataframe dataframe = Dataframe.createFrom(predictions);

--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/explainers/local/LocalExplainerEndpoint.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/explainers/local/LocalExplainerEndpoint.java
@@ -38,16 +38,16 @@ public abstract class LocalExplainerEndpoint extends ExplainerEndpoint {
             final PredictionProvider model = getModel(request.getModelConfig(), dataframe.getInputTensorName());
 
             Prediction predictionToExplain;
-            List<Prediction> predictions = dataframe.filterRowsById(request.getPredictionId()).asPredictions();
+            final List<Prediction> predictions = dataframe.filterRowsById(request.getPredictionId()).asPredictions();
             if (predictions.isEmpty()) {
                 return Response.status(Response.Status.NOT_FOUND).entity("No prediction found with id="
                         + request.getPredictionId()).build();
             } else if (predictions.size() == 1) {
                 predictionToExplain = predictions.get(0);
-                List<PredictionInput> testDataDistribution = dataframe.filterRowsById(request.getPredictionId(), true,
+                final List<PredictionInput> testDataDistribution = dataframe.filterRowsById(request.getPredictionId(), true,
                         serviceConfig.batchSize().orElse(100)).asPredictionInputs();
                 predictionToExplain = prepare(predictionToExplain, request, testDataDistribution);
-                BaseExplanationResponse entity = generateExplanation(model, predictionToExplain, testDataDistribution);
+                final BaseExplanationResponse entity = generateExplanation(model, predictionToExplain, testDataDistribution);
                 return Response.ok(entity).build();
             } else {
                 return Response.status(Response.Status.BAD_REQUEST).entity("Found " + predictions.size()

--- a/explainability-service/src/test/java/org/kie/trustyai/service/data/metadata/legacy/v1/LegacyMetadataTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/data/metadata/legacy/v1/LegacyMetadataTest.java
@@ -1,10 +1,13 @@
 package org.kie.trustyai.service.data.metadata.legacy.v1;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.TestProfile;
-import jakarta.enterprise.inject.Instance;
-import jakarta.inject.Inject;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.kie.trustyai.explainability.model.*;
@@ -13,13 +16,13 @@ import org.kie.trustyai.service.data.metadata.Metadata;
 import org.kie.trustyai.service.mocks.MockDatasource;
 import org.kie.trustyai.service.mocks.MockMemoryStorage;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
-import java.util.stream.Collectors;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -51,6 +54,7 @@ public class LegacyMetadataTest {
         }
 
     }
+
     private static ByteBuffer readFile(String filename) throws IOException {
         String resourcePath = "storage/data/v1/" + filename;
 
@@ -97,8 +101,6 @@ public class LegacyMetadataTest {
         // Old metadata not changed
         assertEquals(DataframeMetadata.DEFAULT_INPUT_TENSOR_NAME, loadedDataframe.getInputTensorName());
         assertEquals(DataframeMetadata.DEFAULT_OUTPUT_TENSOR_NAME, loadedDataframe.getOutputTensorName());
-
-
 
     }
 }

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/consumer/ConsumerEndpointRawTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/consumer/ConsumerEndpointRawTest.java
@@ -9,13 +9,16 @@ import java.util.stream.IntStream;
 
 import org.jboss.resteasy.reactive.RestResponse;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.kie.trustyai.connectors.kserve.v2.RawConverter;
+import org.kie.trustyai.connectors.kserve.v2.grpc.InferParameter;
 import org.kie.trustyai.connectors.kserve.v2.grpc.ModelInferRequest;
 import org.kie.trustyai.connectors.kserve.v2.grpc.ModelInferResponse;
 import org.kie.trustyai.explainability.model.Dataframe;
 import org.kie.trustyai.service.BaseTestProfile;
 import org.kie.trustyai.service.data.exceptions.DataframeCreateException;
+import org.kie.trustyai.service.endpoints.explainers.ExplainerEndpoint;
 import org.kie.trustyai.service.mocks.MockDatasource;
 import org.kie.trustyai.service.mocks.MockMemoryStorage;
 import org.kie.trustyai.service.payloads.consumer.InferencePartialPayload;
@@ -49,15 +52,35 @@ class ConsumerEndpointRawTest {
     @Inject
     Instance<MockMemoryStorage> storage;
 
+    /**
+     * Create an input partial payload with no synthetic flag
+     * @param id
+     * @return
+     */
     private static InferencePartialPayload createInputFP64(UUID id) {
+        return createInputFP64(id, false);
+    }
+
+    /**
+     * Create an input partial payload with the specified synthetic flag
+     * @param id
+     * @param synthetic
+     * @return
+     */
+    private static InferencePartialPayload createInputFP64(UUID id, boolean synthetic) {
         final Random random = new Random(0);
         final List<Double> values = List.of(random.nextDouble(), random.nextDouble(), random.nextDouble());
         ModelInferRequest.Builder builder = ModelInferRequest.newBuilder();
         builder.addRawInputContents(RawConverter.fromDouble(values));
-        ModelInferRequest.InferInputTensor tensor = ModelInferRequest.InferInputTensor.newBuilder()
+        ModelInferRequest.InferInputTensor.Builder tensorBuilder = ModelInferRequest.InferInputTensor.newBuilder()
                 .setDatatype("FP64")
-                .addShape(1).addShape(3)
-                .build();
+                .addShape(1).addShape(3);
+
+        if (synthetic) {
+            tensorBuilder.putParameters(ExplainerEndpoint.BIAS_IGNORE_PARAM, InferParameter.newBuilder().setStringParam("true").build());
+        }
+        ModelInferRequest.InferInputTensor tensor = tensorBuilder.build();
+
         builder.addInputs(tensor);
         builder.setModelName(MODEL_A_ID);
         builder.setModelVersion("1");
@@ -253,6 +276,51 @@ class ConsumerEndpointRawTest {
 
         final Dataframe dataframe = datasource.get().getDataframe(MODEL_A_ID);
         assertEquals(3, dataframe.getRowDimension());
+    }
+
+    @Test
+    @DisplayName("Synthetic payloads should be correctly tagged in the dataframe")
+    void consumePartialPostFP64Synthetic() {
+        final int N = 100;
+        final int syntheticN = N - new Random().nextInt(N);
+
+        final List<UUID> ids = IntStream.range(0, N).mapToObj(i -> UUID.randomUUID()).collect(Collectors.toList());
+        for (int i = 0; i < N - syntheticN; i++) {
+            final InferencePartialPayload payload = createInputFP64(ids.get(i), false);
+            given()
+                    .contentType(ContentType.JSON)
+                    .body(payload)
+                    .when().post()
+                    .then()
+                    .statusCode(RestResponse.StatusCode.OK)
+                    .body(is(""));
+        }
+        for (int i = N - syntheticN; i < N; i++) {
+            final InferencePartialPayload payload = createInputFP64(ids.get(i), true);
+            given()
+                    .contentType(ContentType.JSON)
+                    .body(payload)
+                    .when().post()
+                    .then()
+                    .statusCode(RestResponse.StatusCode.OK)
+                    .body(is(""));
+        }
+
+        for (int i = 0; i < N; i++) {
+            final InferencePartialPayload payload = createOutputF64(ids.get(i));
+            given()
+                    .contentType(ContentType.JSON)
+                    .body(payload)
+                    .when().post()
+                    .then()
+                    .statusCode(RestResponse.StatusCode.OK)
+                    .body(is(""));
+        }
+
+        final Dataframe dataframe = datasource.get().getDataframe(MODEL_A_ID);
+        assertEquals(N, dataframe.getRowDimension());
+        assertEquals(syntheticN, dataframe.filterRowsBySynthetic(true).getRowDimension());
+        assertEquals(N - syntheticN, dataframe.filterRowsBySynthetic(false).getRowDimension());
     }
 
     @Test


### PR DESCRIPTION
This PR allows the ModelMesh payload consumer to detect synthetic payload parameters and serialise the dataframe internal data accordingly.

Unit test for synthetic payloads are added.

