### PR TITLE
Update Quarkus from 3.2.9.Final to 3.2.11.Final

### DIFF
--- a/explainability-core/src/main/java/org/kie/trustyai/metrics/language/rouge/ROUGE.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/metrics/language/rouge/ROUGE.java
@@ -5,11 +5,11 @@ import java.util.List;
 import java.util.Map;
 
 import org.kie.trustyai.metrics.language.AbstractNLPPerformanceMetric;
+import org.kie.trustyai.metrics.language.utils.F1Score;
 import org.kie.trustyai.metrics.language.utils.NGramUtils;
 import org.kie.trustyai.metrics.language.utils.SentenceUtils;
-import org.kie.trustyai.metrics.language.utils.F1Score;
 
-public class ROUGE extends AbstractNLPPerformanceMetric<Double, String>{
+public class ROUGE extends AbstractNLPPerformanceMetric<Double, String> {
 
     public enum RougeTypes {
         ROUGE_LSUM,
@@ -31,7 +31,7 @@ public class ROUGE extends AbstractNLPPerformanceMetric<Double, String>{
 
     private RougeTypes rougeType;
 
-    public ROUGE(RougeTypes rougeType){
+    public ROUGE(RougeTypes rougeType) {
         super();
         this.rougeType = rougeType;
     }
@@ -50,9 +50,9 @@ public class ROUGE extends AbstractNLPPerformanceMetric<Double, String>{
      * @return The ROUGE score.
      */
     public Double calculate(String reference, String hypothesis, RougeTypes rougeType) {
-        switch (rougeType){
-            case ROUGE_LSUM:{
-                 // Split the reference and hypothesis into sentences
+        switch (rougeType) {
+            case ROUGE_LSUM: {
+                // Split the reference and hypothesis into sentences
                 final String[] referenceSentences = SentenceUtils.splitSentences(reference);
                 final String[] hypothesisSentences = SentenceUtils.splitSentences(hypothesis);
                 return rougeLsum(referenceSentences, hypothesisSentences);
@@ -64,9 +64,9 @@ public class ROUGE extends AbstractNLPPerformanceMetric<Double, String>{
                 reference = reference.replaceAll("\\p{Punct}", "");
                 hypothesis = hypothesis.replaceAll("\\p{Punct}", "");
                 // Tokenize the reference and hypothesis
-                final List<String> referenceTokens =  Arrays.asList(this.getTokenizer().tokenize(reference));
+                final List<String> referenceTokens = Arrays.asList(this.getTokenizer().tokenize(reference));
                 final List<String> hypothesisTokens = Arrays.asList(this.getTokenizer().tokenize(hypothesis));
-                if (rougeType != rougeType.ROUGEL){
+                if (rougeType != rougeType.ROUGEL) {
                     // Get the ROUGE-N type and calculate the n-grams in the reference and hypothesis accordingly
                     final int n = rougeType.getN();
                     final Map<String, Integer> referenceNgramCount = NGramUtils.countNgrams(referenceTokens, n);
@@ -79,23 +79,24 @@ public class ROUGE extends AbstractNLPPerformanceMetric<Double, String>{
         }
     }
 
-     /**
+    /**
      * Calculate ROUGE-N score given the reference and hypothesis n-gram count
      *
      * @param referenceNgramCount N-grams for reference
      * @param hypothesisNgramCount N-grams for hypothesis
      * @return ROUGE-N score
      */
-    public Double rougeN(Map<String, Integer> referenceNgramCount,  Map<String, Integer> hypothesisNgramCount){
+    public Double rougeN(Map<String, Integer> referenceNgramCount, Map<String, Integer> hypothesisNgramCount) {
         // Initalize total match count between reference and hypothesis tokens
         int totalMatchCount = 0;
 
         // Get length of reference and hypothesis tokens
         int referenceTokensLength = referenceNgramCount.values().stream().mapToInt(Integer::intValue).sum();
-        int hypothesisTokensLength = hypothesisNgramCount.values().stream().mapToInt(Integer::intValue).sum();;
+        int hypothesisTokensLength = hypothesisNgramCount.values().stream().mapToInt(Integer::intValue).sum();
+        ;
 
         // Count matches between reference and hypothesis tokens
-        for (Map.Entry<String, Integer> entry : hypothesisNgramCount.entrySet()){
+        for (Map.Entry<String, Integer> entry : hypothesisNgramCount.entrySet()) {
             final String ngram = entry.getKey();
             final int count = entry.getValue();
             totalMatchCount += Math.min(count, referenceNgramCount.getOrDefault(ngram, 0));
@@ -115,7 +116,7 @@ public class ROUGE extends AbstractNLPPerformanceMetric<Double, String>{
      * @param hypothesisTokens Hypothesis tokens
      * @return ROUGE-L score
      */
-    public Double rougeL(List<String> referenceTokens,  List<String> hypothesisTokens){
+    public Double rougeL(List<String> referenceTokens, List<String> hypothesisTokens) {
         // Initialize matrix to store the number of consecutive token matches between
         // the reference and hypothesis
         int rows = referenceTokens.size();
@@ -124,12 +125,11 @@ public class ROUGE extends AbstractNLPPerformanceMetric<Double, String>{
 
         // Iterate through each reference-hypothesis token pair and add 1 to the previous
         // value of the diagonal if they are equal
-        for (int i=1; i <= rows; i++){
-            for (int j=1; j <= cols; j++){
-                if (referenceTokens.get(i - 1).equals(hypothesisTokens.get(j - 1))){
+        for (int i = 1; i <= rows; i++) {
+            for (int j = 1; j <= cols; j++) {
+                if (referenceTokens.get(i - 1).equals(hypothesisTokens.get(j - 1))) {
                     lcsTable[i][j] = lcsTable[i - 1][j - 1] + 1;
-                }
-                else {
+                } else {
                     lcsTable[i][j] = Math.max(lcsTable[i - 1][j], lcsTable[i][j - 1]);
                 }
             }
@@ -148,14 +148,14 @@ public class ROUGE extends AbstractNLPPerformanceMetric<Double, String>{
      * @param hypothesisSentences A list of hypothesis sentences
      * @return The ROUGE-LSum score
      */
-    public Double rougeLsum(String[] referenceSentences, String[] hypothesisSentences){
+    public Double rougeLsum(String[] referenceSentences, String[] hypothesisSentences) {
         // Initialize F1 score
         double fScore = 0;
 
         // Calculate and aggregate the ROUGE-L score for each reference-hypothesis sentence pair
-        for (int i=0; i < referenceSentences.length; i++){
+        for (int i = 0; i < referenceSentences.length; i++) {
             final List<String> hypothesisTokens = Arrays.asList(this.getTokenizer().tokenize(hypothesisSentences[i]));
-            final List<String> referenceTokens =  Arrays.asList(this.getTokenizer().tokenize(referenceSentences[i]));
+            final List<String> referenceTokens = Arrays.asList(this.getTokenizer().tokenize(referenceSentences[i]));
             fScore += rougeL(referenceTokens, hypothesisTokens);
         }
         // Average the F1 score over the number of reference sentences

--- a/explainability-core/src/main/java/org/kie/trustyai/metrics/language/utils/F1Score.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/metrics/language/utils/F1Score.java
@@ -5,6 +5,7 @@ public class F1Score {
     private F1Score() {
 
     }
+
     /**
      * Calculate F1 score given the precison and recall.
      *
@@ -12,8 +13,8 @@ public class F1Score {
      * @param recall
      * @return F1 score
      */
-    public static double calculate(double precision, double recall){
-        if (precision + recall > 0.0){
+    public static double calculate(double precision, double recall) {
+        if (precision + recall > 0.0) {
             return 2 * precision * recall / (precision + recall);
         } else {
             return 0.0;

--- a/explainability-core/src/main/java/org/kie/trustyai/metrics/language/utils/SentenceUtils.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/metrics/language/utils/SentenceUtils.java
@@ -11,8 +11,8 @@ public class SentenceUtils {
     private SentenceUtils() {
     }
 
-    public static String[] splitSentences(String text){
-          try (InputStream modelIn = new FileInputStream("/opennlp/models/en-token.bin")) {
+    public static String[] splitSentences(String text) {
+        try (InputStream modelIn = new FileInputStream("/opennlp/models/en-token.bin")) {
             SentenceDetectorME detector = new SentenceDetectorME(new SentenceModel(modelIn));
             return detector.sentDetect(text);
         } catch (IOException e) {

--- a/explainability-core/src/test/java/org/kie/trustyai/metrics/language/rouge/ROUGETest.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/metrics/language/rouge/ROUGETest.java
@@ -15,7 +15,7 @@ class ROUGETest {
 
     @Test
     @DisplayName("Test ROUGE1")
-    void validationROUGE1(){
+    void validationROUGE1() {
         final ROUGE rougeCalculator = new ROUGE(RougeTypes.ROUGE1);
         final double score = rougeCalculator.calculate("testing one two", "testing");
         assertEquals(0.5, score);
@@ -23,9 +23,9 @@ class ROUGETest {
 
     @Test
     @DisplayName("Test ROUGE scores for zero matches")
-    void validationEmpty(){
+    void validationEmpty() {
         final List<RougeTypes> rougeTypes = List.of(RougeTypes.ROUGE1, RougeTypes.ROUGE2, RougeTypes.ROUGEL, RougeTypes.ROUGE_LSUM);
-        for (RougeTypes rougeType: rougeTypes){
+        for (RougeTypes rougeType : rougeTypes) {
             final ROUGE rougeCalculator = new ROUGE(rougeType);
             final double score = rougeCalculator.calculate("testing one two", "");
             assertEquals(0, score);
@@ -34,7 +34,7 @@ class ROUGETest {
 
     @Test
     @DisplayName("Test ROUGE2")
-    void validationROUGE2(){
+    void validationROUGE2() {
         final ROUGE rougeCalculator = new ROUGE(RougeTypes.ROUGE2);
         final double score = rougeCalculator.calculate("testing one two", "testing one");
         assertEquals(0.66, score, 0.05);
@@ -42,7 +42,7 @@ class ROUGETest {
 
     @Test
     @DisplayName("Test ROUGEL for consecutive sentences")
-    void validationROUGELConsecutive(){
+    void validationROUGELConsecutive() {
         final ROUGE rougeCalculator = new ROUGE(RougeTypes.ROUGEL);
         final double score = rougeCalculator.calculate("testing one two", "testing one");
         assertEquals(0.8, score, 0.05);
@@ -50,7 +50,7 @@ class ROUGETest {
 
     @Test
     @DisplayName("Test ROUGEL for nonconsecutive sentences")
-    void validationROUGELNonConsecutive(){
+    void validationROUGELNonConsecutive() {
         final ROUGE rougeCalculator = new ROUGE(RougeTypes.ROUGEL);
         final double score = rougeCalculator.calculate("testing one two", "testing two");
         assertEquals(0.8, score, 0.05);
@@ -58,7 +58,7 @@ class ROUGETest {
 
     @Test
     @DisplayName("Test ROUGELSum")
-    void validationROUGELSum(){
+    void validationROUGELSum() {
         final ROUGE rougeCalculator = new ROUGE(RougeTypes.ROUGE_LSUM);
         final double score = rougeCalculator.calculate("w1 w2 w3 w4 w5", "w1 w2 w6 w7 w8\nw1 w3 w8 w9 w5");
         assertEquals(0.5, score, 0.05);
@@ -66,7 +66,7 @@ class ROUGETest {
 
     @Test
     @DisplayName("Test ROUGELSum for non-word hypothesis")
-    void validationROUGELSumNonWord(){
+    void validationROUGELSumNonWord() {
         final ROUGE rougeCalculator = new ROUGE(RougeTypes.ROUGE_LSUM);
         final double score = rougeCalculator.calculate("w1 w2 w3 w4 w5", "/");
         assertEquals(0, score);

--- a/explainability-service/pom.xml
+++ b/explainability-service/pom.xml
@@ -19,7 +19,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.bom-group-id>io.quarkus</quarkus.platform.bom-group-id>
-        <quarkus.platform.version>3.2.9.Final</quarkus.platform.version>
+        <quarkus.platform.version>3.2.11.Final</quarkus.platform.version>
         <apache.commons.collections.version>4.4</apache.commons.collections.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/ModelMeshInferencePayloadReconciler.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/ModelMeshInferencePayloadReconciler.java
@@ -1,6 +1,5 @@
 package org.kie.trustyai.service.data.utils;
 
-import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -81,7 +80,8 @@ public class ModelMeshInferencePayloadReconciler extends InferencePayloadReconci
 
         // Construct record of synthetic data tags
         List<Dataframe.InternalTags> tags = input.getInputsList().stream().map(inferInputTensor -> {
-            if (inferInputTensor.containsParameters(ExplainerEndpoint.BIAS_IGNORE_PARAM) && inferInputTensor.getParametersMap().get(ExplainerEndpoint.BIAS_IGNORE_PARAM).getStringParam().equals("true")) {
+            if (inferInputTensor.containsParameters(ExplainerEndpoint.BIAS_IGNORE_PARAM)
+                    && inferInputTensor.getParametersMap().get(ExplainerEndpoint.BIAS_IGNORE_PARAM).getStringParam().equals("true")) {
                 return Dataframe.InternalTags.SYNTHETIC;
             } else {
                 return Dataframe.InternalTags.UNLABELED;

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/consumer/ConsumerEndpointRawTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/consumer/ConsumerEndpointRawTest.java
@@ -54,6 +54,7 @@ class ConsumerEndpointRawTest {
 
     /**
      * Create an input partial payload with no synthetic flag
+     * 
      * @param id
      * @return
      */
@@ -63,6 +64,7 @@ class ConsumerEndpointRawTest {
 
     /**
      * Create an input partial payload with the specified synthetic flag
+     * 
      * @param id
      * @param synthetic
      * @return

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/explainers/local/LimeEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/explainers/local/LimeEndpointTest.java
@@ -1,7 +1,6 @@
 package org.kie.trustyai.service.endpoints.explainers.local;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Collectors;
 

--- a/explainability-service/src/test/java/org/kie/trustyai/service/mocks/MockInferenceServiceImpl.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/mocks/MockInferenceServiceImpl.java
@@ -7,9 +7,9 @@ import java.util.logging.Logger;
 import org.kie.trustyai.connectors.kserve.v2.TensorConverter;
 import org.kie.trustyai.connectors.kserve.v2.grpc.*;
 import org.kie.trustyai.explainability.model.*;
+import org.kie.trustyai.service.endpoints.explainers.ExplainerEndpoint;
 
 import io.grpc.stub.StreamObserver;
-import org.kie.trustyai.service.endpoints.explainers.ExplainerEndpoint;
 
 public class MockInferenceServiceImpl extends GRPCInferenceServiceGrpc.GRPCInferenceServiceImplBase {
     private static final Logger logger = Logger.getLogger(MockInferenceServiceImpl.class.getName());
@@ -42,7 +42,6 @@ public class MockInferenceServiceImpl extends GRPCInferenceServiceGrpc.GRPCInfer
             responseBuilder.putParameters(ExplainerEndpoint.BIAS_IGNORE_PARAM, syntheticParam);
         }
 
-
         responseBuilder.addOutputs(tensorBuilder);
 
         return responseBuilder.build();
@@ -56,7 +55,7 @@ public class MockInferenceServiceImpl extends GRPCInferenceServiceGrpc.GRPCInfer
             final List<PredictionOutput> outputs = predictionProvider.predictAsync(inputs).get();
             ModelInferResponse response;
             if (request.getInputsList().get(0).containsParameters(ExplainerEndpoint.BIAS_IGNORE_PARAM)) {
-                 response = convertToModelInferResponse(outputs, true);
+                response = convertToModelInferResponse(outputs, true);
             } else {
                 response = convertToModelInferResponse(outputs, false);
             }


### PR DESCRIPTION
Update Quarkus from 3.2.9.Final to 3.2.11.Final.
Fixes:

- [CVE-2024-25710](https://nvd.nist.gov/vuln/detail/CVE-2024-25710) Denial of service caused by an infinite loop for a corrupted DUMP file
- [CVE-2024-1597](https://nvd.nist.gov/vuln/detail/CVE-2024-1597) PostgreSQL JDBC Driver allows attacker to inject SQL if using PreferQueryMode=SIMPLE
- [CVE-2024-1023](https://access.redhat.com/security/cve/cve-2024-1023) memory leak due to the use of Netty FastThreadLocal data structures in Vertx
- [CVE-2024-1300](https://access.redhat.com/security/cve/CVE-2024-1300) memory leak when a TCP server is configured with TLS and SNI support
- [CVE-2024-1726](https://access.redhat.com/security/cve/CVE-2024-1726) security checks for some inherited endpoints performed after serialization in RESTEasy Reactive may trigger a denial of service

- Additionally, some formatting fixes