### PR TITLE
RHOAIENG-4584: Properly shutdown channel after prediction request.

### DIFF
--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/explainers/global/AggregatedLimeEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/explainers/global/AggregatedLimeEndpointTest.java
@@ -61,6 +61,6 @@ class AggregatedLimeEndpointTest {
         given().contentType(ContentType.JSON).body(payload)
                 .when().post()
                 .then()
-                .statusCode(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+                .statusCode(Response.Status.OK.getStatusCode());
     }
 }

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/explainers/local/CounterfactualEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/explainers/local/CounterfactualEndpointTest.java
@@ -73,6 +73,6 @@ class CounterfactualEndpointTest {
         given().contentType(ContentType.JSON).body(payload)
                 .when().post()
                 .then()
-                .statusCode(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+                .statusCode(Response.Status.NOT_FOUND.getStatusCode());
     }
 }

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/explainers/local/LimeEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/explainers/local/LimeEndpointTest.java
@@ -85,7 +85,7 @@ class LimeEndpointTest {
         given().contentType(ContentType.JSON).body(payload)
                 .when().post()
                 .then()
-                .statusCode(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+                .statusCode(Response.Status.NOT_FOUND.getStatusCode());
     }
 
     @Test

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/explainers/local/ShapEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/explainers/local/ShapEndpointTest.java
@@ -68,6 +68,6 @@ class ShapEndpointTest {
         given().contentType(ContentType.JSON).body(payload)
                 .when().post()
                 .then()
-                .statusCode(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+                .statusCode(Response.Status.NOT_FOUND.getStatusCode());
     }
 }


### PR DESCRIPTION
gRPC channel management is done from `predictAsync`, i.e. the channel is closed after the inference request is made.

