### PR TITLE
RHOAIENG-4701: Get tensor data based on non-empty contents, instead of data type.

### DIFF
--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/KServeV2GRPCPredictionProvider.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/KServeV2GRPCPredictionProvider.java
@@ -12,13 +12,13 @@ import org.kie.trustyai.connectors.utils.ListenableFutureUtils;
 import org.kie.trustyai.explainability.model.PredictionInput;
 import org.kie.trustyai.explainability.model.PredictionOutput;
 import org.kie.trustyai.explainability.model.PredictionProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.util.concurrent.ListenableFuture;
 
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Wraps a KServe v2-compatible model server as a TrustyAI {@link PredictionProvider}
@@ -137,7 +137,7 @@ public class KServeV2GRPCPredictionProvider implements PredictionProvider {
                         logger.error("Error during model inference: " + ex.getMessage());
                         // Shutdown the channel
                         localChannel.shutdown();
-                         throw new RuntimeException("Failed to get inference", ex);
+                        throw new RuntimeException("Failed to get inference", ex);
                     })
                     .whenComplete((response, throwable) -> {
                         if (!localChannel.isShutdown()) { // In case channel already closed in .exceptionally()

--- a/explainability-connectors/src/test/java/org/kie/trustyai/connectors/kserve/v2/KServeFormatsTest.java
+++ b/explainability-connectors/src/test/java/org/kie/trustyai/connectors/kserve/v2/KServeFormatsTest.java
@@ -9,7 +9,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.RepeatedTest;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.kie.trustyai.connectors.kserve.v2.grpc.InferTensorContents;

--- a/explainability-connectors/src/test/java/org/kie/trustyai/connectors/kserve/v2/KServeFormatsTest.java
+++ b/explainability-connectors/src/test/java/org/kie/trustyai/connectors/kserve/v2/KServeFormatsTest.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.kie.trustyai.connectors.kserve.v2.grpc.InferTensorContents;

--- a/explainability-connectors/src/test/java/org/kie/trustyai/connectors/kserve/v2/TensorConverterTest.java
+++ b/explainability-connectors/src/test/java/org/kie/trustyai/connectors/kserve/v2/TensorConverterTest.java
@@ -8,6 +8,7 @@ import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.kie.trustyai.connectors.kserve.v2.grpc.InferTensorContents;
 import org.kie.trustyai.connectors.kserve.v2.grpc.ModelInferRequest;
@@ -341,5 +342,19 @@ class TensorConverterTest {
                 assertTrue(Math.abs(o.getValue().asNumber()) < 3);
             }
         }
+    }
+
+    @Test
+    @DisplayName("Test mismatch between output tensor type and tensor data")
+    void testMismatchOutputTypeData() {
+        final String NAME = "output";
+        final ModelInferResponse.InferOutputTensor outputTensor = ModelInferResponse.InferOutputTensor.newBuilder()
+                .setDatatype("INT32")
+                .addShape(1).addShape(1).setContents(InferTensorContents.newBuilder().addFp64Contents(1.0)).build();
+        final Output output = TensorConverter.contentsToOutput(outputTensor, NAME, 0);
+        assertEquals(1.0, output.getValue().asNumber());
+        assertEquals(Double.class, output.getValue().getUnderlyingObject().getClass());
+        assertEquals(NAME, output.getName());
+        assertEquals(Type.NUMBER, output.getType());
     }
 }

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/model/Output.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/model/Output.java
@@ -22,6 +22,8 @@ import java.util.Objects;
  */
 public class Output {
 
+    public static final double DEFAULT_SCORE = 1.0;
+
     private final Value value;
     private final Type type;
     private final double score;


### PR DESCRIPTION
## PR Summary

### Issue Description

I've encountered a parsing issue with the `PredictionOutput` in models, particularly with the KServe v2 format. This format specifies a data type flag (`FP64`, `INT32`, `BOOL`, `INT32`), but the actual tensor data is stored in a separate container. To access this data, we need to know the exact type; for instance, `content.getFP64Contents()` for `FP64`. However, the protocol doesn't guarantee that the declared data type matches the actual stored data, which can lead to mismatches.

### Problem

In some cases, models—over which we have no control—may declare a data type (e.g., `INT32`) that does not match the actual data (e.g., `contents.getFP64Contents()` contains the data, but `contents.getINT32Contents()` will be null). The previous parsing logic, which took the declared data type as the source of truth, failed in these situations.

### Implemented Solution

To resolve this issue, now, instead of relying on the declared data type, we check for the actual presence of data. This method involves assessing the content count for each data type and choosing the non-empty option accordingly. Below is a pseudocode representation of this new logic:

Before:
```pseudocode
if (type == F64) {
   data = contents.getFP64Contents(); // <- data is here
} else if (type == INT32) { // <- advertised type
   data = contents.getINT32Contents(); // <- null
}
```

Now:
```pseudocode
if (content.getF64ContentCount() != 0) {
   data = contents.getFP64Contents();
} else if (content.getINT32ContentCount() != 0) {
   data = contents.getINT32Contents();
}
```