### PR TITLE
RHOAIENG-4756: Service data batches for metrics calculations should account for synthetic data in its size

### DIFF
--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/DataSource.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/DataSource.java
@@ -1,12 +1,10 @@
 package org.kie.trustyai.service.data;
 
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jboss.logging.Logger;
 import org.kie.trustyai.explainability.model.Dataframe;
@@ -21,12 +19,12 @@ import org.kie.trustyai.service.data.storage.Storage;
 import org.kie.trustyai.service.data.utils.MetadataUtils;
 import org.kie.trustyai.service.payloads.service.Schema;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import jakarta.enterprise.inject.Instance;
-import jakarta.inject.Inject;
-import jakarta.inject.Singleton;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 @Singleton
 public class DataSource {
@@ -42,6 +40,10 @@ public class DataSource {
     DataParser parser;
     @Inject
     ServiceConfig serviceConfig;
+
+    public static String getGroundTruthName(String modelId) {
+        return modelId + GROUND_TRUTH_SUFFIX;
+    }
 
     public Set<String> getKnownModels() {
         return knownModels;
@@ -116,7 +118,8 @@ public class DataSource {
 
     /**
      * Get a dataframe with the organic (non-synthetic) data and metadata for a given model
-     * @param modelId the model id
+     *
+     * @param modelId   the model id
      * @param batchSize the batch size
      * @return a dataframe with the organic data and metadata for a given model
      * @throws DataframeCreateException if the dataframe cannot be created
@@ -139,7 +142,7 @@ public class DataSource {
 
         Dataframe df;
         try {
-         df = parser.toDataframe(pair.getLeft(), pair.getRight(), metadata);
+            df = parser.toDataframe(pair.getLeft(), pair.getRight(), metadata);
         } catch (IllegalArgumentException e) {
             LOG.error(e.getMessage());
             throw new DataframeCreateException("Could not parse create dataframe: " + e.getMessage());
@@ -288,10 +291,6 @@ public class DataSource {
 
     public boolean hasMetadata(String modelId) {
         return storage.get().fileExists(modelId + "-" + METADATA_FILENAME);
-    }
-
-    public static String getGroundTruthName(String modelId) {
-        return modelId + GROUND_TRUTH_SUFFIX;
     }
 
     // ground truth access and settors

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/DataSource.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/DataSource.java
@@ -137,7 +137,14 @@ public class DataSource {
             throw new DataframeCreateException("Could not parse metadata: " + e.getMessage());
         }
 
-        Dataframe df = parser.toDataframe(pair.getLeft(), pair.getRight(), metadata);
+        Dataframe df;
+        try {
+         df = parser.toDataframe(pair.getLeft(), pair.getRight(), metadata);
+        } catch (IllegalArgumentException e) {
+            LOG.error(e.getMessage());
+            throw new DataframeCreateException("Could not parse create dataframe: " + e.getMessage());
+        }
+
         df.setColumnAliases(getJointNameAliases(metadata));
         df.setInputTensorName(metadata.getInputTensorName());
         df.setOutputTensorName(metadata.getOutputTensorName());
@@ -168,7 +175,14 @@ public class DataSource {
             throw new DataframeCreateException("Could not parse metadata: " + e.getMessage());
         }
 
-        Dataframe df = parser.toDataframe(pair.getLeft(), pair.getRight(), metadata);
+        Dataframe df;
+        try {
+            df = parser.toDataframe(pair.getLeft(), pair.getRight(), metadata);
+        } catch (IllegalArgumentException e) {
+            LOG.error(e.getMessage());
+            throw new DataframeCreateException("Could not parse create dataframe: " + e.getMessage());
+        }
+
         df.setColumnAliases(getJointNameAliases(metadata));
         df.setInputTensorName(metadata.getInputTensorName());
         df.setOutputTensorName(metadata.getOutputTensorName());

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/storage/BatchReader.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/storage/BatchReader.java
@@ -1,18 +1,18 @@
 package org.kie.trustyai.service.data.storage;
 
-import java.io.*;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Scanner;
-import java.util.Set;
-
 import org.apache.commons.collections4.queue.CircularFifoQueue;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 import org.apache.commons.lang3.tuple.Pair;
 import org.kie.trustyai.service.data.utils.CSVUtils;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Scanner;
+import java.util.Set;
 
 public class BatchReader {
 
@@ -62,8 +62,10 @@ public class BatchReader {
         }
         return Pair.of(new ArrayList<>(dataQueue), new ArrayList<>(metadataQueue));
     }
+
     /**
      * Returns an InputStream for the given filename
+     *
      * @param filename The filename to open
      * @return An {@link InputStream} for the given filename
      * @throws FileNotFoundException If the file does not exist

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/storage/BatchReader.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/storage/BatchReader.java
@@ -48,7 +48,7 @@ public class BatchReader {
                     String metadataLine = CSVUtils.recordToString(metadataRecord);
                     String metadataTag = metadataRecord.get(0); // Tag is the first column
 
-                    if (tags.contains(metadataTag)) { // TODO: Handle exception
+                    if (tags.contains(metadataTag)) {
                         dataQueue.add(dataLine);
                         metadataQueue.add(metadataLine);
                     }

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/storage/BatchReader.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/storage/BatchReader.java
@@ -1,15 +1,18 @@
 package org.kie.trustyai.service.data.storage;
 
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
+import java.util.Set;
 
 import org.apache.commons.collections4.queue.CircularFifoQueue;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.apache.commons.lang3.tuple.Pair;
+import org.kie.trustyai.service.data.utils.CSVUtils;
 
 public class BatchReader {
 
@@ -30,6 +33,35 @@ public class BatchReader {
         return new ArrayList<>(queue);
     }
 
+    public static Pair<List<String>, List<String>> readEntriesWithTags(InputStream dataStream, InputStream metadataStream, int batchSize, Set<String> tags) throws IOException {
+        final CircularFifoQueue<String> dataQueue = new CircularFifoQueue<>(batchSize);
+        final CircularFifoQueue<String> metadataQueue = new CircularFifoQueue<>(batchSize);
+
+        try (Scanner dataScanner = new Scanner(dataStream, StandardCharsets.UTF_8);
+             BufferedReader metadataReader = new BufferedReader(new InputStreamReader(metadataStream, StandardCharsets.UTF_8))) {
+
+            final CSVParser parser = new CSVParser(metadataReader, CSVFormat.DEFAULT.withSkipHeaderRecord());
+
+            for (CSVRecord metadataRecord : parser) {
+                if (dataScanner.hasNextLine()) {
+                    final String dataLine = dataScanner.nextLine();
+                    String metadataLine = CSVUtils.recordToString(metadataRecord);
+                    String metadataTag = metadataRecord.get(0); // Tag is the first column
+
+                    if (tags.contains(metadataTag)) { // TODO: Handle exception
+                        dataQueue.add(dataLine);
+                        metadataQueue.add(metadataLine);
+                    }
+                } else {
+                    break; // No corresponding data line
+                }
+            }
+            if (dataScanner.ioException() != null) {
+                throw dataScanner.ioException();
+            }
+        }
+        return Pair.of(new ArrayList<>(dataQueue), new ArrayList<>(metadataQueue));
+    }
     /**
      * Returns an InputStream for the given filename
      * @param filename The filename to open

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/storage/MemoryStorage.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/storage/MemoryStorage.java
@@ -1,14 +1,18 @@
 package org.kie.trustyai.service.data.storage;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.zip.CRC32;
 import java.util.zip.Checksum;
 
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.apache.commons.lang3.tuple.Pair;
 import org.jboss.logging.Logger;
 import org.kie.trustyai.service.config.ServiceConfig;
 import org.kie.trustyai.service.config.storage.StorageConfig;
@@ -18,6 +22,8 @@ import org.kie.trustyai.service.data.exceptions.StorageWriteException;
 import io.quarkus.arc.lookup.LookupIfProperty;
 
 import jakarta.enterprise.context.ApplicationScoped;
+
+import static org.kie.trustyai.service.data.DataSource.INTERNAL_DATA_FILENAME;
 
 @LookupIfProperty(name = "service.storage.format", stringValue = "MEMORY")
 @ApplicationScoped
@@ -57,6 +63,58 @@ public class MemoryStorage extends Storage {
             throw new StorageReadException("Data file '" + key + "' not found");
         }
     }
+
+    @Override
+    public Pair<ByteBuffer, ByteBuffer> readDataWithTags(String modelId, Set<String> tags) throws StorageReadException {
+        return readDataWithTags(modelId, this.batchSize, tags);
+    }
+
+    @Override
+    public Pair<ByteBuffer, ByteBuffer> readDataWithTags(String modelId, int batchSize, Set<String> tags) throws StorageReadException {
+            final List<String> dataLines = new ArrayList<>();
+            final List<String> metadataLines = new ArrayList<>();
+
+            final String dataKey = getDataFilename(modelId);
+            final String metadataKey = getInternalDataFilename(modelId);
+
+            if (data.containsKey(dataKey) && data.containsKey(metadataKey)) {
+                String dataContent = data.get(dataKey);
+                String metadataContent = data.get(metadataKey);
+                String[] dataContentLines = dataContent.split("\n");
+
+                try (CSVParser parser = CSVParser.parse(metadataContent, CSVFormat.DEFAULT.withTrim())) {
+                    int index = 0;
+                    for (CSVRecord record : parser) {
+                        if (index >= dataContentLines.length) {
+                            // Ensuring we do not go out of bounds if metadata lines are more than data lines
+                            break;
+                        }
+                        String metadataLine = record.get(0); // Assuming the tag is in the first column
+                        if (tags.contains(metadataLine)) {
+                            metadataLines.add(String.join(",", record));
+                            dataLines.add(dataContentLines[index]);
+                        }
+                        index++;
+                    }
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+
+                // Apply batch size limit
+                if (dataLines.size() > batchSize) {
+                    final String dataLinesString = String.join("\n", dataLines.subList(dataLines.size() - batchSize, dataLines.size()));
+                    final String metadataLinesString = String.join("\n", metadataLines.subList(metadataLines.size() - batchSize, metadataLines.size()));
+                    return Pair.of(ByteBuffer.wrap(dataLinesString.getBytes()), ByteBuffer.wrap(metadataLinesString.getBytes()));
+                } else {
+                    final String dataLinesString = String.join("\n", dataLines);
+                    final String metadataLinesString = String.join("\n", metadataLines);
+
+                    return Pair.of(ByteBuffer.wrap(dataLinesString.getBytes()), ByteBuffer.wrap(metadataLinesString.getBytes()));
+                }
+            } else {
+                throw new StorageReadException("Data or Metadata file not found for modelId: " + modelId);
+            }
+        }
 
     @Override
     public boolean dataExists(String modelId) throws StorageReadException {
@@ -138,8 +196,18 @@ public class MemoryStorage extends Storage {
     }
 
     @Override
+    public String getInternalDataFilename(String modelId) {
+        return modelId + "-" + INTERNAL_DATA_FILENAME;
+    }
+
+    @Override
     public Path buildDataPath(String modelId) {
         return Path.of(getDataFilename(modelId));
+    }
+
+    @Override
+    public Path buildInternalDataPath(String modelId) {
+        return Path.of(getInternalDataFilename(modelId));
     }
 
     @Override

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/storage/MinioStorage.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/storage/MinioStorage.java
@@ -10,8 +10,10 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.jboss.logging.Logger;
 import org.kie.trustyai.service.config.storage.MinioConfig;
 import org.kie.trustyai.service.config.storage.StorageConfig;
@@ -122,6 +124,16 @@ public class MinioStorage extends Storage {
         throw new StorageReadException("Batch size not supported for MinIO storage");
     }
 
+    @Override
+    public Pair<ByteBuffer, ByteBuffer> readDataWithTags(String modelId, int batchSize, Set<String> tags) throws StorageReadException {
+        throw new StorageReadException("Storage type not supported");
+    }
+
+    @Override
+    public Pair<ByteBuffer, ByteBuffer> readDataWithTags(String modelId, Set<String> tags) throws StorageReadException {
+        throw new StorageReadException("Storage type not supported");
+    }
+
     private void saveData(ByteBuffer byteBuffer, String bucketName, String filename) throws StorageWriteException, StorageReadException {
 
         try {
@@ -220,8 +232,18 @@ public class MinioStorage extends Storage {
     }
 
     @Override
+    public String getInternalDataFilename(String modelId) {
+        throw new StorageReadException("Storage type not supported");
+    }
+
+    @Override
     public Path buildDataPath(String modelId) {
         return Path.of(this.bucketName, getDataFilename(modelId));
+    }
+
+    @Override
+    public Path buildInternalDataPath(String modelId) {
+        throw new StorageReadException("Storage type not supported");
     }
 
     @Override

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/storage/MinioStorage.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/storage/MinioStorage.java
@@ -1,5 +1,16 @@
 package org.kie.trustyai.service.data.storage;
 
+import io.minio.*;
+import io.minio.errors.*;
+import io.quarkus.arc.lookup.LookupIfProperty;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.apache.commons.lang3.tuple.Pair;
+import org.jboss.logging.Logger;
+import org.kie.trustyai.service.config.storage.MinioConfig;
+import org.kie.trustyai.service.config.storage.StorageConfig;
+import org.kie.trustyai.service.data.exceptions.StorageReadException;
+import org.kie.trustyai.service.data.exceptions.StorageWriteException;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -12,19 +23,6 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
-
-import org.apache.commons.lang3.tuple.Pair;
-import org.jboss.logging.Logger;
-import org.kie.trustyai.service.config.storage.MinioConfig;
-import org.kie.trustyai.service.config.storage.StorageConfig;
-import org.kie.trustyai.service.data.exceptions.StorageReadException;
-import org.kie.trustyai.service.data.exceptions.StorageWriteException;
-
-import io.minio.*;
-import io.minio.errors.*;
-import io.quarkus.arc.lookup.LookupIfProperty;
-
-import jakarta.enterprise.context.ApplicationScoped;
 
 @LookupIfProperty(name = "service.storage.format", stringValue = "MINIO")
 @ApplicationScoped
@@ -92,8 +90,9 @@ public class MinioStorage extends Storage {
     private boolean bucketExists(String bucketName) throws StorageReadException {
         try {
             return minioClient.bucketExists(BucketExistsArgs.builder().bucket(bucketName).build());
-        } catch (ErrorResponseException | InsufficientDataException | InternalException | InvalidKeyException | InvalidResponseException | IOException | NoSuchAlgorithmException | ServerException
-                | XmlParserException e) {
+        } catch (ErrorResponseException | InsufficientDataException | InternalException | InvalidKeyException |
+                 InvalidResponseException | IOException | NoSuchAlgorithmException | ServerException
+                 | XmlParserException e) {
             throw new StorageReadException(e.getMessage());
         }
     }
@@ -101,10 +100,10 @@ public class MinioStorage extends Storage {
     private byte[] readFile(String bucketName, String filename)
             throws MinioException, IOException, NoSuchAlgorithmException, InvalidKeyException {
         return minioClient.getObject(
-                GetObjectArgs.builder()
-                        .bucket(bucketName)
-                        .object(filename)
-                        .build())
+                        GetObjectArgs.builder()
+                                .bucket(bucketName)
+                                .object(filename)
+                                .build())
                 .readAllBytes();
     }
 
@@ -166,8 +165,9 @@ public class MinioStorage extends Storage {
                     .sources(sources).build());
             // Delete temporary file
             minioClient.removeObject(RemoveObjectArgs.builder().bucket(bucketName).object(tempFilename).build());
-        } catch (StorageWriteException | StorageReadException | ServerException | InsufficientDataException | ErrorResponseException | IOException | NoSuchAlgorithmException | InvalidKeyException
-                | InvalidResponseException | XmlParserException | InternalException e) {
+        } catch (StorageWriteException | StorageReadException | ServerException | InsufficientDataException |
+                 ErrorResponseException | IOException | NoSuchAlgorithmException | InvalidKeyException
+                 | InvalidResponseException | XmlParserException | InternalException e) {
             throw new StorageWriteException(e.getMessage());
         }
     }

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/storage/PVCStorage.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/storage/PVCStorage.java
@@ -1,13 +1,7 @@
 package org.kie.trustyai.service.data.storage;
 
-import java.io.*;
-import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.List;
-import java.util.Set;
-
+import io.quarkus.arc.lookup.LookupIfProperty;
+import jakarta.enterprise.context.ApplicationScoped;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jboss.logging.Logger;
 import org.kie.trustyai.service.config.ServiceConfig;
@@ -16,9 +10,13 @@ import org.kie.trustyai.service.data.DataSource;
 import org.kie.trustyai.service.data.exceptions.StorageReadException;
 import org.kie.trustyai.service.data.exceptions.StorageWriteException;
 
-import io.quarkus.arc.lookup.LookupIfProperty;
-
-import jakarta.enterprise.context.ApplicationScoped;
+import java.io.*;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Set;
 
 import static org.kie.trustyai.service.data.DataSource.INTERNAL_DATA_FILENAME;
 
@@ -68,7 +66,8 @@ public class PVCStorage extends Storage {
 
     /**
      * Read data from the file system, for a given model id and batch size.
-     * @param modelId The model id
+     *
+     * @param modelId   The model id
      * @param batchSize The batch size
      * @return A {@link ByteBuffer} containing the data
      * @throws StorageReadException If an error occurs while reading the data
@@ -102,7 +101,7 @@ public class PVCStorage extends Storage {
 
     @Override
     public Pair<ByteBuffer, ByteBuffer> readDataWithTags(String modelId, Set<String> tags) throws StorageReadException {
-        return  readDataWithTags(modelId, this.batchSize, tags);
+        return readDataWithTags(modelId, this.batchSize, tags);
     }
 
     private boolean pathExists(Path path) {
@@ -153,6 +152,7 @@ public class PVCStorage extends Storage {
 
     /**
      * Read an entire file into a {@link ByteBuffer}.
+     *
      * @param filename The filename to read
      * @return A {@link ByteBuffer} containing the data
      * @throws StorageReadException If an error occurs while reading the data
@@ -175,8 +175,8 @@ public class PVCStorage extends Storage {
 
     /**
      * Read {@link ByteBuffer} from the file system, for a given filename and batch size.
-     * 
-     * @param filename The filename to read
+     *
+     * @param filename  The filename to read
      * @param batchSize The batch size
      * @return A {@link ByteBuffer} containing the data
      * @throws StorageReadException If an error occurs while reading the data
@@ -185,13 +185,13 @@ public class PVCStorage extends Storage {
     public ByteBuffer read(String filename, int batchSize) throws StorageReadException {
         final Path path = Paths.get(this.dataFolder.toString(), filename);
         final File file = path.toFile();
-        
+
         try {
             final InputStream stream = BatchReader.getFileInputStream(file.toString());
             return ByteBuffer.wrap(
                     BatchReader.linesToBytes(BatchReader.readEntries(stream, batchSize)));
         } catch (IOException e) {
-            LOG.error("Error reading file for " + file.toString());
+            LOG.error("Error reading file for " + file);
             throw new StorageReadException(e.getMessage());
         }
     }

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/storage/Storage.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/storage/Storage.java
@@ -8,6 +8,7 @@ public abstract class Storage implements StorageInterface {
 
     /**
      * Get the internal data filename for a given model ID.
+     *
      * @param modelId The model ID
      * @return The internal data filename
      */
@@ -17,6 +18,7 @@ public abstract class Storage implements StorageInterface {
 
     /**
      * Build the internal data path for a given model ID.
+     *
      * @param modelId The model ID
      * @return The internal data path
      */

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/storage/Storage.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/storage/Storage.java
@@ -6,6 +6,20 @@ public abstract class Storage implements StorageInterface {
 
     public abstract String getDataFilename(String modelId);
 
+    /**
+     * Get the internal data filename for a given model ID.
+     * @param modelId The model ID
+     * @return The internal data filename
+     */
+    public abstract String getInternalDataFilename(String modelId);
+
     public abstract Path buildDataPath(String modelId);
+
+    /**
+     * Build the internal data path for a given model ID.
+     * @param modelId The model ID
+     * @return The internal data path
+     */
+    public abstract Path buildInternalDataPath(String modelId);
 
 }

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/storage/StorageFormat.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/storage/StorageFormat.java
@@ -3,6 +3,6 @@ package org.kie.trustyai.service.data.storage;
 public enum StorageFormat {
     MEMORY,
     PVC,
-    MINIO;
+    MINIO
 
 }

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/storage/StorageInterface.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/storage/StorageInterface.java
@@ -1,7 +1,9 @@
 package org.kie.trustyai.service.data.storage;
 
 import java.nio.ByteBuffer;
+import java.util.Set;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.kie.trustyai.service.data.cache.DataCacheKeyGen;
 import org.kie.trustyai.service.data.exceptions.StorageReadException;
 import org.kie.trustyai.service.data.exceptions.StorageWriteException;
@@ -13,6 +15,26 @@ public interface StorageInterface {
     ByteBuffer readData(String modelId) throws StorageReadException;
 
     ByteBuffer readData(String modelId, int batchSize) throws StorageReadException;
+
+    /**
+     * Read data and metadata with the specified tags and batch size.
+     * @param modelId The model ID
+     * @param batchSize The batch size
+     * @param tags The tags
+     * @return A pair of {@link ByteBuffer} containing the data and metadata
+     * @throws StorageReadException If an error occurs while reading the data
+     */
+    Pair<ByteBuffer, ByteBuffer> readDataWithTags(String modelId, int batchSize, Set<String> tags) throws StorageReadException;
+
+    /**
+     * Read data and metadata with the specified tags and batch size.
+     * Since no batch size is specified, the default batch size is used.
+     * @param modelId The model ID
+     * @param tags The tags
+     * @return A pair of {@link ByteBuffer} containing the data and metadata
+     * @throws StorageReadException If an error occurs while reading the data
+     */
+    Pair<ByteBuffer, ByteBuffer> readDataWithTags(String modelId, Set<String> tags) throws StorageReadException;
 
     boolean dataExists(String modelId) throws StorageReadException;
 

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/storage/StorageInterface.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/storage/StorageInterface.java
@@ -1,14 +1,13 @@
 package org.kie.trustyai.service.data.storage;
 
-import java.nio.ByteBuffer;
-import java.util.Set;
-
+import io.quarkus.cache.CacheResult;
 import org.apache.commons.lang3.tuple.Pair;
 import org.kie.trustyai.service.data.cache.DataCacheKeyGen;
 import org.kie.trustyai.service.data.exceptions.StorageReadException;
 import org.kie.trustyai.service.data.exceptions.StorageWriteException;
 
-import io.quarkus.cache.CacheResult;
+import java.nio.ByteBuffer;
+import java.util.Set;
 
 public interface StorageInterface {
     @CacheResult(cacheName = "dataframe", keyGenerator = DataCacheKeyGen.class)
@@ -18,9 +17,10 @@ public interface StorageInterface {
 
     /**
      * Read data and metadata with the specified tags and batch size.
-     * @param modelId The model ID
+     *
+     * @param modelId   The model ID
      * @param batchSize The batch size
-     * @param tags The tags
+     * @param tags      The tags
      * @return A pair of {@link ByteBuffer} containing the data and metadata
      * @throws StorageReadException If an error occurs while reading the data
      */
@@ -29,8 +29,9 @@ public interface StorageInterface {
     /**
      * Read data and metadata with the specified tags and batch size.
      * Since no batch size is specified, the default batch size is used.
+     *
      * @param modelId The model ID
-     * @param tags The tags
+     * @param tags    The tags
      * @return A pair of {@link ByteBuffer} containing the data and metadata
      * @throws StorageReadException If an error occurs while reading the data
      */
@@ -49,7 +50,7 @@ public interface StorageInterface {
     /**
      * Read {@link ByteBuffer} from the file system, for a given filename and batch size.
      *
-     * @param location The filename to read
+     * @param location  The filename to read
      * @param batchSize The batch size
      * @return A {@link ByteBuffer} containing the data
      * @throws StorageReadException If an error occurs while reading the data

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/CSVUtils.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/CSVUtils.java
@@ -1,5 +1,15 @@
 package org.kie.trustyai.service.data.utils;
 
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.commons.csv.CSVRecord;
+import org.kie.trustyai.explainability.model.*;
+import org.kie.trustyai.service.data.metadata.Metadata;
+import org.kie.trustyai.service.payloads.PayloadConverter;
+import org.kie.trustyai.service.payloads.service.SchemaItem;
+import org.kie.trustyai.service.payloads.values.DataType;
+
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
@@ -11,16 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
-
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVParser;
-import org.apache.commons.csv.CSVPrinter;
-import org.apache.commons.csv.CSVRecord;
-import org.kie.trustyai.explainability.model.*;
-import org.kie.trustyai.service.data.metadata.Metadata;
-import org.kie.trustyai.service.payloads.PayloadConverter;
-import org.kie.trustyai.service.payloads.service.SchemaItem;
-import org.kie.trustyai.service.payloads.values.DataType;
 
 import static org.kie.trustyai.service.data.parsers.CSVParser.ZONE_OFFSET;
 

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/CSVUtils.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/CSVUtils.java
@@ -2,6 +2,7 @@ package org.kie.trustyai.service.data.utils;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.io.StringWriter;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -13,6 +14,7 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.csv.CSVRecord;
 import org.kie.trustyai.explainability.model.*;
 import org.kie.trustyai.service.data.metadata.Metadata;
@@ -129,5 +131,12 @@ public class CSVUtils {
     public static List<List<Value>> parseRaw(String in) throws IOException {
         CSVParser parser = CSVFormat.DEFAULT.parse(new StringReader(in));
         return parser.stream().map(entry -> entry.stream().map(Value::new).collect(Collectors.toList())).collect(Collectors.toList());
+    }
+
+    public static String recordToString(CSVRecord record) throws IOException {
+        final StringWriter writer = new StringWriter();
+        final CSVPrinter printer = new CSVPrinter(writer, CSVFormat.DEFAULT);
+        printer.printRecord(record);
+        return writer.toString().trim();
     }
 }

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/DownloadUtils.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/DownloadUtils.java
@@ -1,16 +1,15 @@
 package org.kie.trustyai.service.data.utils;
 
-import java.time.LocalDateTime;
-import java.util.Set;
-import java.util.stream.Collectors;
-
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ValueNode;
 import org.kie.trustyai.explainability.model.Dataframe;
 import org.kie.trustyai.service.data.metadata.Metadata;
 import org.kie.trustyai.service.payloads.data.download.RowMatcher;
 import org.kie.trustyai.service.payloads.values.DataType;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ValueNode;
+import java.time.LocalDateTime;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class DownloadUtils {
 

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/InferencePayloadReconciler.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/InferencePayloadReconciler.java
@@ -1,13 +1,13 @@
 package org.kie.trustyai.service.data.utils;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
 import org.kie.trustyai.explainability.model.Dataframe;
 import org.kie.trustyai.service.data.exceptions.DataframeCreateException;
 import org.kie.trustyai.service.data.exceptions.InvalidSchemaException;
 import org.kie.trustyai.service.payloads.consumer.InferencePartialPayload;
 import org.kie.trustyai.service.payloads.consumer.PartialPayload;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public abstract class InferencePayloadReconciler<T extends PartialPayload, U extends PartialPayload> {
 
@@ -33,7 +33,7 @@ public abstract class InferencePayloadReconciler<T extends PartialPayload, U ext
      * Add a {@link InferencePartialPayload} output to the (yet) unreconciled mapping.
      * If there is a corresponding (based on unique id) input {@link InferencePartialPayload},
      * both are saved to storage and removed from the unreconciled mapping.
-     * 
+     *
      * @param output
      */
     public synchronized void addUnreconciledOutput(U output) throws InvalidSchemaException, DataframeCreateException {

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/KServeInferencePayloadReconciler.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/KServeInferencePayloadReconciler.java
@@ -1,10 +1,11 @@
 package org.kie.trustyai.service.data.utils;
 
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 import org.kie.trustyai.explainability.model.*;
 import org.kie.trustyai.service.data.DataSource;
@@ -15,13 +16,10 @@ import org.kie.trustyai.service.payloads.consumer.InferenceLoggerInput;
 import org.kie.trustyai.service.payloads.consumer.KServeInputPayload;
 import org.kie.trustyai.service.payloads.consumer.KServeOutputPayload;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.inject.Instance;
-import jakarta.inject.Inject;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * Reconcile partial input and output inference payloads in the KServe v2 protobuf format.

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/MetadataUtils.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/MetadataUtils.java
@@ -1,15 +1,15 @@
 package org.kie.trustyai.service.data.utils;
 
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
 import org.kie.trustyai.explainability.model.Dataframe;
 import org.kie.trustyai.explainability.model.Value;
 import org.kie.trustyai.service.payloads.service.Schema;
 import org.kie.trustyai.service.payloads.service.SchemaItem;
 import org.kie.trustyai.service.payloads.values.DataType;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class MetadataUtils {
 

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/ModelMeshInferencePayloadReconciler.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/ModelMeshInferencePayloadReconciler.java
@@ -1,9 +1,9 @@
 package org.kie.trustyai.service.data.utils;
 
-import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
+import com.google.protobuf.InvalidProtocolBufferException;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import org.jboss.logging.Logger;
 import org.kie.trustyai.connectors.kserve.v2.TensorConverter;
 import org.kie.trustyai.connectors.kserve.v2.grpc.ModelInferRequest;
@@ -15,23 +15,22 @@ import org.kie.trustyai.service.data.exceptions.InvalidSchemaException;
 import org.kie.trustyai.service.endpoints.explainers.ExplainerEndpoint;
 import org.kie.trustyai.service.payloads.consumer.InferencePartialPayload;
 
-import com.google.protobuf.InvalidProtocolBufferException;
-
-import jakarta.enterprise.inject.Instance;
-import jakarta.inject.Inject;
-import jakarta.inject.Singleton;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * Reconcile partial input and output inference payloads in the KServe v2 protobuf format.
  */
 @Singleton
 public class ModelMeshInferencePayloadReconciler extends InferencePayloadReconciler<InferencePartialPayload, InferencePartialPayload> {
+    protected static final String MM_MODEL_SUFFIX = "__isvc";
     private static final Logger LOG = Logger.getLogger(ModelMeshInferencePayloadReconciler.class);
-
     @Inject
     Instance<DataSource> datasource;
-
-    protected static final String MM_MODEL_SUFFIX = "__isvc";
 
     protected static String standardizeModelId(String inboundModelId) {
         if (inboundModelId != null && inboundModelId.contains(MM_MODEL_SUFFIX)) {
@@ -60,10 +59,10 @@ public class ModelMeshInferencePayloadReconciler extends InferencePayloadReconci
      * Convert both input and output {@link InferencePartialPayload} to a TrustyAI {@link Prediction}.
      * If the input tensor contains a {@link ExplainerEndpoint#BIAS_IGNORE_PARAM} set, then {@link PredictionMetadata}
      * will be attached marking these inferences as synthetic.
-     * 
-     * @param inputPayload Input {@link InferencePartialPayload}
+     *
+     * @param inputPayload  Input {@link InferencePartialPayload}
      * @param outputPayload Output {@link InferencePartialPayload}
-     * @param id The unique id of the payload
+     * @param id            The unique id of the payload
      * @return A {@link Prediction}
      * @throws DataframeCreateException
      */

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/UploadUtils.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/UploadUtils.java
@@ -1,13 +1,6 @@
 package org.kie.trustyai.service.data.utils;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
+import com.google.protobuf.ByteString;
 import org.jboss.logging.Logger;
 import org.kie.trustyai.connectors.kserve.v2.grpc.InferParameter;
 import org.kie.trustyai.connectors.kserve.v2.grpc.InferTensorContents;
@@ -17,7 +10,8 @@ import org.kie.trustyai.service.payloads.data.upload.ModelInferRequestPayload;
 import org.kie.trustyai.service.payloads.data.upload.ModelInferResponsePayload;
 import org.kie.trustyai.service.payloads.data.upload.TensorPayload;
 
-import com.google.protobuf.ByteString;
+import java.util.*;
+import java.util.stream.Collectors;
 
 public class UploadUtils {
     private static final Logger LOG = Logger.getLogger(UploadUtils.class);

--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/DisparateImpactRatioEndpoint.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/DisparateImpactRatioEndpoint.java
@@ -1,8 +1,8 @@
 package org.kie.trustyai.service.endpoints.metrics.fairness.group;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
+import io.quarkus.cache.CacheResult;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.Path;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.kie.trustyai.explainability.model.Dataframe;
 import org.kie.trustyai.explainability.model.Output;
@@ -20,10 +20,8 @@ import org.kie.trustyai.service.prometheus.MetricValueCarrier;
 import org.kie.trustyai.service.validators.metrics.ValidReconciledMetricRequest;
 import org.kie.trustyai.service.validators.metrics.fairness.group.ValidGroupMetricRequest;
 
-import io.quarkus.cache.CacheResult;
-
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.ws.rs.Path;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @ApplicationScoped
 @Tag(name = "Disparate Impact Ratio Endpoint", description = "Disparate Impact Ratio (DIR) measures imbalances in " +
@@ -31,6 +29,10 @@ import jakarta.ws.rs.Path;
         " a particular outcome.")
 @Path("/metrics/group/fairness/dir")
 public class DisparateImpactRatioEndpoint extends GroupEndpoint {
+    public DisparateImpactRatioEndpoint() {
+        super("DIR");
+    }
+
     @Override
     public MetricThreshold thresholdFunction(Number delta, MetricValueCarrier metricValue) {
         if (delta == null) {
@@ -48,7 +50,7 @@ public class DisparateImpactRatioEndpoint extends GroupEndpoint {
 
     @Override
     public String specificDefinitionFunction(String outcomeName, List<Value> favorableOutcomeAttr, String protectedAttribute, List<String> privileged, List<String> unprivileged,
-            MetricValueCarrier metricValue) {
+                                             MetricValueCarrier metricValue) {
         return FairnessDefinitions.defineGroupDisparateImpactRatio(
                 protectedAttribute,
                 privileged,
@@ -89,9 +91,5 @@ public class DisparateImpactRatioEndpoint extends GroupEndpoint {
     @Override
     public String getGeneralDefinition() {
         return FairnessDefinitions.defineGroupDisparateImpactRatio();
-    }
-
-    public DisparateImpactRatioEndpoint() {
-        super("DIR");
     }
 }

--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupEndpoint.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupEndpoint.java
@@ -70,7 +70,7 @@ public abstract class GroupEndpoint extends BaseEndpoint<GroupMetricRequest> {
                 LOG.warn("Request batch size is empty. Using the default value of " + defaultBatchSize);
                 request.setBatchSize(defaultBatchSize);
             }
-            dataframe = super.dataSource.get().getDataframe(request.getModelId(), request.getBatchSize()).filterRowsBySynthetic(false);
+            dataframe = super.dataSource.get().getOrganicDataframe(request.getModelId(), request.getBatchSize());
             metadata = dataSource.get().getMetadata(request.getModelId());
         } catch (DataframeCreateException e) {
             LOG.error("No data available for model " + request.getModelId() + ": " + e.getMessage(), e);

--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupEndpoint.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupEndpoint.java
@@ -1,9 +1,8 @@
 package org.kie.trustyai.service.endpoints.metrics.fairness.group;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
-
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.kie.trustyai.explainability.model.Dataframe;
 import org.kie.trustyai.explainability.model.Value;
 import org.kie.trustyai.service.data.exceptions.DataframeCreateException;
@@ -20,13 +19,9 @@ import org.kie.trustyai.service.prometheus.MetricValueCarrier;
 import org.kie.trustyai.service.validators.metrics.ValidReconciledMetricRequest;
 import org.kie.trustyai.service.validators.metrics.fairness.group.ValidGroupMetricRequest;
 
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.POST;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 public abstract class GroupEndpoint extends BaseEndpoint<GroupMetricRequest> {
     protected GroupEndpoint(String name) {
@@ -36,7 +31,7 @@ public abstract class GroupEndpoint extends BaseEndpoint<GroupMetricRequest> {
     public abstract MetricThreshold thresholdFunction(Number delta, MetricValueCarrier metricValue);
 
     public abstract String specificDefinitionFunction(String outcomeName, List<Value> favorableOutcomeAttr, String protectedAttribute, List<String> privileged, List<String> unprivileged,
-            MetricValueCarrier metricvalue);
+                                                      MetricValueCarrier metricvalue);
 
     public abstract String getGeneralDefinition();
 
@@ -55,7 +50,7 @@ public abstract class GroupEndpoint extends BaseEndpoint<GroupMetricRequest> {
                 .map(Value::toString)
                 .collect(Collectors.toList());
         return specificDefinitionFunction(outcomeName, favorableOutcomeAttrs, protectedAttribute, privilegeds, unprivilegeds, metricValue);
-    };
+    }
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)

--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupStatisticalParityDifferenceEndpoint.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupStatisticalParityDifferenceEndpoint.java
@@ -1,8 +1,8 @@
 package org.kie.trustyai.service.endpoints.metrics.fairness.group;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
+import io.quarkus.cache.CacheResult;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.Path;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.kie.trustyai.explainability.model.Dataframe;
 import org.kie.trustyai.explainability.model.Output;
@@ -20,16 +20,18 @@ import org.kie.trustyai.service.prometheus.MetricValueCarrier;
 import org.kie.trustyai.service.validators.metrics.ValidReconciledMetricRequest;
 import org.kie.trustyai.service.validators.metrics.fairness.group.ValidGroupMetricRequest;
 
-import io.quarkus.cache.CacheResult;
-
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.ws.rs.*;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @ApplicationScoped
 @Tag(name = "Statistical Parity Difference Endpoint", description = "Statistical Parity Difference (SPD) measures imbalances in classifications by calculating the " +
         "difference between the proportion of the majority and protected classes getting a particular outcome.")
 @Path("/metrics/group/fairness/spd")
 public class GroupStatisticalParityDifferenceEndpoint extends GroupEndpoint {
+    public GroupStatisticalParityDifferenceEndpoint() {
+        super("SPD");
+    }
+
     @Override
     public MetricThreshold thresholdFunction(Number delta, MetricValueCarrier metricValue) {
         if (delta == null) {
@@ -47,7 +49,7 @@ public class GroupStatisticalParityDifferenceEndpoint extends GroupEndpoint {
 
     @Override
     public String specificDefinitionFunction(String outcomeName, List<Value> favorableOutcomeAttr, String protectedAttribute, List<String> privileged, List<String> unprivileged,
-            MetricValueCarrier metricValue) {
+                                             MetricValueCarrier metricValue) {
         return FairnessDefinitions.defineGroupStatisticalParityDifference(
                 protectedAttribute,
                 privileged,
@@ -55,7 +57,7 @@ public class GroupStatisticalParityDifferenceEndpoint extends GroupEndpoint {
                 outcomeName,
                 favorableOutcomeAttr,
                 metricValue.getValue());
-    };
+    }
 
     @Override
     @CacheResult(cacheName = "metrics-calculator-spd", keyGenerator = MetricCalculationCacheKeyGen.class)
@@ -88,10 +90,6 @@ public class GroupStatisticalParityDifferenceEndpoint extends GroupEndpoint {
     @Override
     public String getGeneralDefinition() {
         return FairnessDefinitions.defineGroupStatisticalParityDifference();
-    }
-
-    public GroupStatisticalParityDifferenceEndpoint() {
-        super("SPD");
     }
 
 }

--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/legacy/DisparateImpactRatioEndpointLegacy.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/legacy/DisparateImpactRatioEndpointLegacy.java
@@ -1,10 +1,9 @@
 package org.kie.trustyai.service.endpoints.metrics.fairness.group.legacy;
 
-import org.eclipse.microprofile.openapi.annotations.tags.Tag;
-import org.kie.trustyai.service.endpoints.metrics.fairness.group.DisparateImpactRatioEndpoint;
-
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.Path;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.kie.trustyai.service.endpoints.metrics.fairness.group.DisparateImpactRatioEndpoint;
 
 @ApplicationScoped
 @Tag(name = "Disparate Impact Ratio Endpoint (Legacy)", description = "Disparate Impact Ratio (DIR) measures imbalances in " +

--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/legacy/GroupStatisticalParityDifferenceEndpointLegacy.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/legacy/GroupStatisticalParityDifferenceEndpointLegacy.java
@@ -1,10 +1,9 @@
 package org.kie.trustyai.service.endpoints.metrics.fairness.group.legacy;
 
-import org.eclipse.microprofile.openapi.annotations.tags.Tag;
-import org.kie.trustyai.service.endpoints.metrics.fairness.group.GroupStatisticalParityDifferenceEndpoint;
-
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.Path;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.kie.trustyai.service.endpoints.metrics.fairness.group.GroupStatisticalParityDifferenceEndpoint;
 
 @ApplicationScoped
 @Tag(name = "Statistical Parity Difference Endpoint (Legacy)", description = "Statistical Parity Difference (SPD) measures imbalances in classifications by calculating the " +

--- a/explainability-service/src/main/java/org/kie/trustyai/service/prometheus/PrometheusScheduler.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/prometheus/PrometheusScheduler.java
@@ -1,12 +1,9 @@
 package org.kie.trustyai.service.prometheus;
 
-import java.nio.charset.StandardCharsets;
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
+import io.quarkus.scheduler.Scheduled;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import org.jboss.logging.Logger;
 import org.kie.trustyai.explainability.model.Dataframe;
 import org.kie.trustyai.service.config.ServiceConfig;
@@ -16,26 +13,25 @@ import org.kie.trustyai.service.endpoints.metrics.MetricsDirectory;
 import org.kie.trustyai.service.payloads.metrics.BaseMetricRequest;
 import org.kie.trustyai.service.payloads.metrics.RequestReconciler;
 
-import io.quarkus.scheduler.Scheduled;
-
-import jakarta.enterprise.inject.Instance;
-import jakarta.inject.Inject;
-import jakarta.inject.Singleton;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Singleton
 public class PrometheusScheduler {
 
     private static final Logger LOG = Logger.getLogger(PrometheusScheduler.class);
     private final ConcurrentHashMap<String, ConcurrentHashMap<UUID, BaseMetricRequest>> requests = new ConcurrentHashMap<>();
+    private final MetricsDirectory metricsDirectory = new MetricsDirectory();
+    @Inject
+    protected PrometheusPublisher publisher;
     @Inject
     Instance<DataSource> dataSource;
     @Inject
-    protected PrometheusPublisher publisher;
-
-    @Inject
     ServiceConfig serviceConfig;
-
-    private final MetricsDirectory metricsDirectory = new MetricsDirectory();
 
     public MetricsDirectory getMetricsDirectory() {
         return metricsDirectory;
@@ -121,7 +117,7 @@ public class PrometheusScheduler {
 
     /**
      * Get unique model ids with registered Prometheus metrics
-     * 
+     *
      * @return Unique models ids
      */
     public Set<String> getModelIds() {

--- a/explainability-service/src/main/java/org/kie/trustyai/service/prometheus/PrometheusScheduler.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/prometheus/PrometheusScheduler.java
@@ -78,7 +78,7 @@ public class PrometheusScheduler {
                     final int maxBatchSize = requestsSet.stream()
                             .mapToInt(entry -> entry.getValue().getBatchSize()).max()
                             .orElse(serviceConfig.batchSize().getAsInt());
-                    final Dataframe df = ds.getDataframe(modelId, maxBatchSize);
+                    final Dataframe df = ds.getOrganicDataframe(modelId, maxBatchSize);
 
                     requestsSet.forEach(entry -> {
                         // entry value: BaseMetricRequest

--- a/explainability-service/src/test/java/org/kie/trustyai/service/data/DataSourceBaseTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/data/DataSourceBaseTest.java
@@ -1,13 +1,13 @@
 package org.kie.trustyai.service.data;
 
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.kie.trustyai.explainability.model.*;
 import org.kie.trustyai.service.data.exceptions.DataframeCreateException;
 import org.kie.trustyai.service.mocks.MockDatasource;
 
-import jakarta.enterprise.inject.Instance;
-import jakarta.inject.Inject;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -17,10 +17,9 @@ import static org.junit.jupiter.api.Assertions.*;
 
 abstract class DataSourceBaseTest {
 
+    public static final String MODEL_ID = "fake-model";
     @Inject
     Instance<MockDatasource> datasource;
-
-    public static final String MODEL_ID = "fake-model";
 
     @Test
     void testSavingAndReadingDataframe() {
@@ -41,7 +40,7 @@ abstract class DataSourceBaseTest {
         final Random random = new Random();
         final List<String> ids = new ArrayList<>();
         final List<Prediction> predictions = new ArrayList<>();
-        for (int i = 0 ; i < N ; i++) {
+        for (int i = 0; i < N; i++) {
             final PredictionInput input = new PredictionInput(List.of(FeatureFactory.newNumericalFeature("a", random.nextDouble())));
             final PredictionOutput output = new PredictionOutput(List.of(new Output("b", Type.NUMBER, new Value(random.nextDouble()), 1.0)));
             final String id = UUID.randomUUID().toString();
@@ -72,7 +71,7 @@ abstract class DataSourceBaseTest {
         final Random random = new Random();
         final List<String> ids = new ArrayList<>();
         final List<Prediction> predictions = new ArrayList<>();
-        for (int i = 0 ; i < N ; i++) {
+        for (int i = 0; i < N; i++) {
             final PredictionInput input = new PredictionInput(List.of(FeatureFactory.newNumericalFeature("a", random.nextDouble())));
             final PredictionOutput output = new PredictionOutput(List.of(new Output("b", Type.NUMBER, new Value(random.nextDouble()), 1.0)));
             final String id = UUID.randomUUID().toString();
@@ -106,7 +105,7 @@ abstract class DataSourceBaseTest {
         final List<String> organicIds = new ArrayList<>();
         final List<String> syntheticIds = new ArrayList<>();
         final List<Prediction> predictions = new ArrayList<>();
-        for (int i = 0 ; i < N1 ; i++) {
+        for (int i = 0; i < N1; i++) {
             final PredictionInput input = new PredictionInput(List.of(FeatureFactory.newNumericalFeature("a", random.nextDouble())));
             final PredictionOutput output = new PredictionOutput(List.of(new Output("b", Type.NUMBER, new Value(random.nextDouble()), 1.0)));
             final String id = UUID.randomUUID().toString();
@@ -115,7 +114,7 @@ abstract class DataSourceBaseTest {
             final Prediction prediction = new SimplePrediction(input, output, metadata);
             predictions.add(prediction);
         }
-        for (int i = 0 ; i < N2 ; i++) {
+        for (int i = 0; i < N2; i++) {
             final PredictionInput input = new PredictionInput(List.of(FeatureFactory.newNumericalFeature("a", random.nextDouble())));
             final PredictionOutput output = new PredictionOutput(List.of(new Output("b", Type.NUMBER, new Value(random.nextDouble()), 1.0)));
             final String id = UUID.randomUUID().toString();
@@ -124,7 +123,7 @@ abstract class DataSourceBaseTest {
             final Prediction prediction = new SimplePrediction(input, output, metadata);
             predictions.add(prediction);
         }
-        for (int i = 0 ; i < N3 ; i++) {
+        for (int i = 0; i < N3; i++) {
             final PredictionInput input = new PredictionInput(List.of(FeatureFactory.newNumericalFeature("a", random.nextDouble())));
             final PredictionOutput output = new PredictionOutput(List.of(new Output("b", Type.NUMBER, new Value(random.nextDouble()), 1.0)));
             final String id = UUID.randomUUID().toString();
@@ -157,7 +156,7 @@ abstract class DataSourceBaseTest {
         final int N1 = random.nextInt(300) + 100;
         final List<String> syntheticIds = new ArrayList<>();
         final List<Prediction> predictions = new ArrayList<>();
-        for (int i = 0 ; i < N1 ; i++) {
+        for (int i = 0; i < N1; i++) {
             final PredictionInput input = new PredictionInput(List.of(FeatureFactory.newNumericalFeature("a", random.nextDouble())));
             final PredictionOutput output = new PredictionOutput(List.of(new Output("b", Type.NUMBER, new Value(random.nextDouble()), 1.0)));
             final String id = UUID.randomUUID().toString();
@@ -185,7 +184,7 @@ abstract class DataSourceBaseTest {
         final int N1 = random.nextInt(300) + 100;
         final List<String> organicIds = new ArrayList<>();
         final List<Prediction> predictions = new ArrayList<>();
-        for (int i = 0 ; i < N1 ; i++) {
+        for (int i = 0; i < N1; i++) {
             final PredictionInput input = new PredictionInput(List.of(FeatureFactory.newNumericalFeature("a", random.nextDouble())));
             final PredictionOutput output = new PredictionOutput(List.of(new Output("b", Type.NUMBER, new Value(random.nextDouble()), 1.0)));
             final String id = UUID.randomUUID().toString();

--- a/explainability-service/src/test/java/org/kie/trustyai/service/data/DataSourceBaseTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/data/DataSourceBaseTest.java
@@ -8,13 +8,10 @@ import org.kie.trustyai.service.mocks.MockDatasource;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
-import java.util.UUID;
+import java.util.*;
+import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 abstract class DataSourceBaseTest {
@@ -97,5 +94,121 @@ abstract class DataSourceBaseTest {
         final List<String> originalIds = ids.subList(ids.size() - N, ids.size());
         assertEquals(originalIds, readIds);
     }
+
+    @Test
+    @DisplayName("Reading an organic batch should account for synthetic data")
+    void testReadingBatchMixSyntheticOrganic() {
+        final Random random = new Random();
+        final int N1 = random.nextInt(300) + 100;
+        final int N2 = random.nextInt(400);
+        final int N3 = random.nextInt(100);
+        final List<String> organicIds = new ArrayList<>();
+        final List<String> syntheticIds = new ArrayList<>();
+        final List<Prediction> predictions = new ArrayList<>();
+        for (int i = 0 ; i < N1 ; i++) {
+            final PredictionInput input = new PredictionInput(List.of(FeatureFactory.newNumericalFeature("a", random.nextDouble())));
+            final PredictionOutput output = new PredictionOutput(List.of(new Output("b", Type.NUMBER, new Value(random.nextDouble()), 1.0)));
+            final String id = UUID.randomUUID().toString();
+            organicIds.add(id);
+            final PredictionMetadata metadata = new PredictionMetadata(id, LocalDateTime.now(), Dataframe.InternalTags.UNLABELED.get());
+            final Prediction prediction = new SimplePrediction(input, output, metadata);
+            predictions.add(prediction);
+        }
+        for (int i = 0 ; i < N2 ; i++) {
+            final PredictionInput input = new PredictionInput(List.of(FeatureFactory.newNumericalFeature("a", random.nextDouble())));
+            final PredictionOutput output = new PredictionOutput(List.of(new Output("b", Type.NUMBER, new Value(random.nextDouble()), 1.0)));
+            final String id = UUID.randomUUID().toString();
+            syntheticIds.add(id);
+            final PredictionMetadata metadata = new PredictionMetadata(id, LocalDateTime.now(), Dataframe.InternalTags.SYNTHETIC.get());
+            final Prediction prediction = new SimplePrediction(input, output, metadata);
+            predictions.add(prediction);
+        }
+        for (int i = 0 ; i < N3 ; i++) {
+            final PredictionInput input = new PredictionInput(List.of(FeatureFactory.newNumericalFeature("a", random.nextDouble())));
+            final PredictionOutput output = new PredictionOutput(List.of(new Output("b", Type.NUMBER, new Value(random.nextDouble()), 1.0)));
+            final String id = UUID.randomUUID().toString();
+            organicIds.add(id);
+            final PredictionMetadata metadata = new PredictionMetadata(id, LocalDateTime.now(), Dataframe.InternalTags.UNLABELED.get());
+            final Prediction prediction = new SimplePrediction(input, output, metadata);
+            predictions.add(prediction);
+        }
+        final Dataframe dataframe = Dataframe.createFrom(predictions);
+        datasource.get().saveDataframe(dataframe, MODEL_ID);
+
+        // Get a batch slightly larger than N3. This forces the batch to include data from N1, since N2 is synthetic
+        final int BATCH_SIZE = N3 + 10;
+
+        final Dataframe readDataframe = datasource.get().getOrganicDataframe("fake-model", BATCH_SIZE);
+        assertNotNull(readDataframe);
+
+
+        assertEquals(BATCH_SIZE, readDataframe.getRowDimension());
+        final Set<String> tags = readDataframe.getTags().stream().collect(Collectors.toUnmodifiableSet());
+        assertEquals(1, tags.size());
+        assertEquals(Dataframe.InternalTags.UNLABELED.get(), tags.iterator().next());
+        assertEquals(organicIds.subList(organicIds.size() - BATCH_SIZE, organicIds.size()), readDataframe.getIds());
+    }
+
+    @Test
+    @DisplayName("Reading an organic batch should account for synthetic data (no organic data)")
+    void testReadingBatchMixSyntheticOrganicNoOrganic() {
+        final Random random = new Random();
+        final int N1 = random.nextInt(300) + 100;
+        final List<String> syntheticIds = new ArrayList<>();
+        final List<Prediction> predictions = new ArrayList<>();
+        for (int i = 0 ; i < N1 ; i++) {
+            final PredictionInput input = new PredictionInput(List.of(FeatureFactory.newNumericalFeature("a", random.nextDouble())));
+            final PredictionOutput output = new PredictionOutput(List.of(new Output("b", Type.NUMBER, new Value(random.nextDouble()), 1.0)));
+            final String id = UUID.randomUUID().toString();
+            syntheticIds.add(id);
+            final PredictionMetadata metadata = new PredictionMetadata(id, LocalDateTime.now(), Dataframe.InternalTags.SYNTHETIC.get());
+            final Prediction prediction = new SimplePrediction(input, output, metadata);
+            predictions.add(prediction);
+        }
+
+        final Dataframe dataframe = Dataframe.createFrom(predictions);
+        datasource.get().saveDataframe(dataframe, MODEL_ID);
+
+        // Get a batch slightly smaller than N3 (guaranteed positive)
+        final int BATCH_SIZE = N1 - 10;
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            datasource.get().getOrganicDataframe("fake-model", BATCH_SIZE);
+        }, "Cannot create a dataframe from an empty list of predictions.");
+    }
+
+    @Test
+    @DisplayName("Reading an organic batch should account for synthetic data (no synthetic data)")
+    void testReadingBatchMixSyntheticOrganicNoSynthetic() {
+        final Random random = new Random();
+        final int N1 = random.nextInt(300) + 100;
+        final List<String> organicIds = new ArrayList<>();
+        final List<Prediction> predictions = new ArrayList<>();
+        for (int i = 0 ; i < N1 ; i++) {
+            final PredictionInput input = new PredictionInput(List.of(FeatureFactory.newNumericalFeature("a", random.nextDouble())));
+            final PredictionOutput output = new PredictionOutput(List.of(new Output("b", Type.NUMBER, new Value(random.nextDouble()), 1.0)));
+            final String id = UUID.randomUUID().toString();
+            organicIds.add(id);
+            final PredictionMetadata metadata = new PredictionMetadata(id, LocalDateTime.now(), Dataframe.InternalTags.UNLABELED.get());
+            final Prediction prediction = new SimplePrediction(input, output, metadata);
+            predictions.add(prediction);
+        }
+
+        final Dataframe dataframe = Dataframe.createFrom(predictions);
+        datasource.get().saveDataframe(dataframe, MODEL_ID);
+
+        // Get a batch slightly smaller than N3 (guaranteed positive)
+        final int BATCH_SIZE = N1 - 10;
+
+        final Dataframe readDataframe = datasource.get().getOrganicDataframe("fake-model", BATCH_SIZE);
+        assertNotNull(readDataframe);
+
+        assertEquals(BATCH_SIZE, readDataframe.getRowDimension());
+        final Set<String> tags = readDataframe.getTags().stream().collect(Collectors.toUnmodifiableSet());
+        assertEquals(1, tags.size());
+        assertEquals(Dataframe.InternalTags.UNLABELED.get(), tags.iterator().next());
+        assertEquals(organicIds.subList(organicIds.size() - BATCH_SIZE, organicIds.size()), readDataframe.getIds());
+    }
+
 
 }

--- a/explainability-service/src/test/java/org/kie/trustyai/service/data/DataSourceBaseTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/data/DataSourceBaseTest.java
@@ -3,6 +3,7 @@ package org.kie.trustyai.service.data;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.kie.trustyai.explainability.model.*;
+import org.kie.trustyai.service.data.exceptions.DataframeCreateException;
 import org.kie.trustyai.service.mocks.MockDatasource;
 
 import jakarta.enterprise.inject.Instance;
@@ -172,7 +173,7 @@ abstract class DataSourceBaseTest {
         // Get a batch slightly smaller than N3 (guaranteed positive)
         final int BATCH_SIZE = N1 - 10;
 
-        assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(DataframeCreateException.class, () -> {
             datasource.get().getOrganicDataframe("fake-model", BATCH_SIZE);
         }, "Cannot create a dataframe from an empty list of predictions.");
     }

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/consumer/CloudEventConsumerTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/consumer/CloudEventConsumerTest.java
@@ -8,6 +8,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -43,8 +44,8 @@ public class CloudEventConsumerTest {
     Instance<MockMemoryStorage> storage;
 
     @BeforeEach
-    void emptyStorage() {
-        datasource.get().empty();
+    void emptyStorage() throws JsonProcessingException {
+        datasource.get().reset();
         storage.get().emptyStorage();
     }
 

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/consumer/CloudEventConsumerTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/consumer/CloudEventConsumerTest.java
@@ -1,5 +1,23 @@
 package org.kie.trustyai.service.endpoints.consumer;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.quarkus.funqy.knative.events.CloudEvent;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.kie.trustyai.explainability.model.Dataframe;
+import org.kie.trustyai.service.data.exceptions.DataframeCreateException;
+import org.kie.trustyai.service.mocks.MockDatasource;
+import org.kie.trustyai.service.mocks.MockKServeInputPayload;
+import org.kie.trustyai.service.mocks.MockKServeOutputPayload;
+import org.kie.trustyai.service.mocks.MockMemoryStorage;
+import org.kie.trustyai.service.payloads.consumer.InferenceLoggerOutput;
+import org.kie.trustyai.service.profiles.MemoryTestProfile;
+
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.UUID;
@@ -7,26 +25,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.kie.trustyai.explainability.model.Dataframe;
-import org.kie.trustyai.service.profiles.MemoryTestProfile;
-import org.kie.trustyai.service.data.exceptions.DataframeCreateException;
-import org.kie.trustyai.service.mocks.MockDatasource;
-import org.kie.trustyai.service.mocks.MockKServeInputPayload;
-import org.kie.trustyai.service.mocks.MockKServeOutputPayload;
-import org.kie.trustyai.service.mocks.MockMemoryStorage;
-import org.kie.trustyai.service.payloads.consumer.InferenceLoggerOutput;
-
-import io.quarkus.funqy.knative.events.CloudEvent;
-import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.TestProfile;
-
-import jakarta.enterprise.inject.Instance;
-import jakarta.inject.Inject;
 
 import static io.smallrye.common.constraint.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.*;

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/consumer/ConsumerEndpointFormatsTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/consumer/ConsumerEndpointFormatsTest.java
@@ -1,19 +1,18 @@
 package org.kie.trustyai.service.endpoints.consumer;
 
-import java.util.Base64;
-import java.util.List;
-import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.http.ContentType;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
 import org.jboss.resteasy.reactive.RestResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.kie.trustyai.connectors.kserve.v2.grpc.ModelInferRequest;
 import org.kie.trustyai.connectors.kserve.v2.grpc.ModelInferResponse;
 import org.kie.trustyai.explainability.model.*;
-import org.kie.trustyai.service.profiles.MemoryTestProfile;
 import org.kie.trustyai.service.PayloadProducer;
 import org.kie.trustyai.service.data.exceptions.DataframeCreateException;
 import org.kie.trustyai.service.mocks.MockDatasource;
@@ -21,14 +20,13 @@ import org.kie.trustyai.service.mocks.MockMemoryStorage;
 import org.kie.trustyai.service.payloads.consumer.InferencePartialPayload;
 import org.kie.trustyai.service.payloads.consumer.InferencePayload;
 import org.kie.trustyai.service.payloads.consumer.PartialKind;
+import org.kie.trustyai.service.profiles.MemoryTestProfile;
 
-import io.quarkus.test.common.http.TestHTTPEndpoint;
-import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.TestProfile;
-import io.restassured.http.ContentType;
-
-import jakarta.enterprise.inject.Instance;
-import jakarta.inject.Inject;
+import java.util.Base64;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
@@ -64,7 +62,7 @@ class ConsumerEndpointFormatsTest {
 
     /**
      * Scenario 1:
-     *
+     * <p>
      * Consume a single payload with a single input and multiple outputs, using the NP codec.
      * The input corresponds to:
      *
@@ -81,7 +79,7 @@ class ConsumerEndpointFormatsTest {
      *   }
      * }
      * </pre>
-     *
+     * <p>
      * and the output corresponds to:
      *
      * <pre>
@@ -300,7 +298,7 @@ class ConsumerEndpointFormatsTest {
 
     /**
      * Scenario: 2 inputs, 1 output, PD codec, no batch
-     *
+     * <p>
      * The input corresponds to:
      *
      * <pre>
@@ -322,7 +320,6 @@ class ConsumerEndpointFormatsTest {
      *   }
      * }
      * </pre>
-     *
      */
     @Test
     void consumeMultiInputSingleOutputPDCodecNoBatch() {
@@ -403,12 +400,12 @@ class ConsumerEndpointFormatsTest {
     void consumeSingleInputMultiOutputNPCodecBatch() {
 
         final List<Prediction> predictions = IntStream.range(0, BATCH_SIZE).mapToObj(i -> new SimplePrediction(
-                new PredictionInput(
-                        List.of(FeatureFactory.newNumericalFeature("f-1", 10.0))),
-                new PredictionOutput(
-                        List.of(
-                                new Output("output-1", Type.NUMBER, new Value(1.0), 1.0),
-                                new Output("output-2", Type.NUMBER, new Value(2.0), 1.0)))))
+                        new PredictionInput(
+                                List.of(FeatureFactory.newNumericalFeature("f-1", 10.0))),
+                        new PredictionOutput(
+                                List.of(
+                                        new Output("output-1", Type.NUMBER, new Value(1.0), 1.0),
+                                        new Output("output-2", Type.NUMBER, new Value(2.0), 1.0)))))
                 .collect(Collectors.toList());
 
         final TensorDataframe df = TensorDataframe.createFrom(predictions);

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/consumer/ConsumerEndpointFormatsTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/consumer/ConsumerEndpointFormatsTest.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.jboss.resteasy.reactive.RestResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,8 +57,8 @@ class ConsumerEndpointFormatsTest {
      * Empty the storage before each test.
      */
     @BeforeEach
-    void emptyStorage() {
-        datasource.get().empty();
+    void emptyStorage() throws JsonProcessingException {
+        datasource.get().reset();
         storage.get().emptyStorage();
     }
 

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/consumer/ConsumerEndpointRawTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/consumer/ConsumerEndpointRawTest.java
@@ -1,13 +1,12 @@
 package org.kie.trustyai.service.endpoints.consumer;
 
-import java.util.Base64;
-import java.util.List;
-import java.util.Random;
-import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.http.ContentType;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
 import org.jboss.resteasy.reactive.RestResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -17,21 +16,20 @@ import org.kie.trustyai.connectors.kserve.v2.grpc.InferParameter;
 import org.kie.trustyai.connectors.kserve.v2.grpc.ModelInferRequest;
 import org.kie.trustyai.connectors.kserve.v2.grpc.ModelInferResponse;
 import org.kie.trustyai.explainability.model.Dataframe;
-import org.kie.trustyai.service.profiles.MemoryTestProfile;
 import org.kie.trustyai.service.data.exceptions.DataframeCreateException;
 import org.kie.trustyai.service.endpoints.explainers.ExplainerEndpoint;
 import org.kie.trustyai.service.mocks.MockDatasource;
 import org.kie.trustyai.service.mocks.MockMemoryStorage;
 import org.kie.trustyai.service.payloads.consumer.InferencePartialPayload;
 import org.kie.trustyai.service.payloads.consumer.PartialKind;
+import org.kie.trustyai.service.profiles.MemoryTestProfile;
 
-import io.quarkus.test.common.http.TestHTTPEndpoint;
-import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.TestProfile;
-import io.restassured.http.ContentType;
-
-import jakarta.enterprise.inject.Instance;
-import jakarta.inject.Inject;
+import java.util.Base64;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
@@ -55,7 +53,7 @@ class ConsumerEndpointRawTest {
 
     /**
      * Create an input partial payload with no synthetic flag
-     * 
+     *
      * @param id
      * @return
      */
@@ -65,7 +63,7 @@ class ConsumerEndpointRawTest {
 
     /**
      * Create an input partial payload with the specified synthetic flag
-     * 
+     *
      * @param id
      * @param synthetic
      * @return

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/consumer/ConsumerEndpointRawTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/consumer/ConsumerEndpointRawTest.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.jboss.resteasy.reactive.RestResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -204,8 +205,8 @@ class ConsumerEndpointRawTest {
      * Empty the storage before each test.
      */
     @BeforeEach
-    void emptyStorage() {
-        datasource.get().empty();
+    void emptyStorage() throws JsonProcessingException {
+        datasource.get().reset();
         storage.get().emptyStorage();
     }
 

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/consumer/ConsumerEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/consumer/ConsumerEndpointTest.java
@@ -1,16 +1,16 @@
 package org.kie.trustyai.service.endpoints.consumer;
 
-import java.util.List;
-import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.http.ContentType;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
 import org.jboss.resteasy.reactive.RestResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.kie.trustyai.explainability.model.Dataframe;
-import org.kie.trustyai.service.profiles.MemoryTestProfile;
 import org.kie.trustyai.service.PayloadProducer;
 import org.kie.trustyai.service.data.exceptions.DataframeCreateException;
 import org.kie.trustyai.service.mocks.MockDatasource;
@@ -18,14 +18,12 @@ import org.kie.trustyai.service.mocks.MockMemoryStorage;
 import org.kie.trustyai.service.payloads.consumer.InferencePartialPayload;
 import org.kie.trustyai.service.payloads.consumer.InferencePayload;
 import org.kie.trustyai.service.payloads.consumer.PartialKind;
+import org.kie.trustyai.service.profiles.MemoryTestProfile;
 
-import io.quarkus.test.common.http.TestHTTPEndpoint;
-import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.TestProfile;
-import io.restassured.http.ContentType;
-
-import jakarta.enterprise.inject.Instance;
-import jakarta.inject.Inject;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/consumer/ConsumerEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/consumer/ConsumerEndpointTest.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.jboss.resteasy.reactive.RestResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -47,8 +48,8 @@ class ConsumerEndpointTest {
      * Empty the storage before each test.
      */
     @BeforeEach
-    void emptyStorage() {
-        datasource.get().empty();
+    void emptyStorage() throws JsonProcessingException {
+        datasource.get().reset();
         storage.get().emptyStorage();
     }
 

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/data/DataEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/data/DataEndpointTest.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.jboss.resteasy.reactive.RestResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -58,8 +59,8 @@ class DataEndpointTest {
      * Empty the storage before each test.
      */
     @BeforeEach
-    void emptyStorage() {
-        datasource.get().empty();
+    void emptyStorage() throws JsonProcessingException {
+        datasource.get().reset();
         storage.get().emptyStorage();
     }
 
@@ -360,7 +361,7 @@ class DataEndpointTest {
 
     // data upload tests ===============================================================================================
     @Test
-    void uploadData() {
+    void uploadData() throws JsonProcessingException {
         int[] testInputRows = new int[] { 1, 5, 250 };
         int[] testInputCols = new int[] { 1, 4 };
         int[] testOutputCols = new int[] { 1, 2 };
@@ -459,7 +460,7 @@ class DataEndpointTest {
     }
 
     @Test
-    void uploadDataAndGroundTruth() {
+    void uploadDataAndGroundTruth() throws JsonProcessingException {
         int[] testInputRows = new int[] { 1, 5, 250 };
         int[] testInputCols = new int[] { 1, 4 };
         int[] testOutputCols = new int[] { 1, 2 };

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/data/DataEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/data/DataEndpointTest.java
@@ -1,18 +1,20 @@
 package org.kie.trustyai.service.endpoints.data;
 
-import java.io.IOException;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.http.ContentType;
+import io.restassured.response.ValidatableResponse;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
 import org.jboss.resteasy.reactive.RestResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.kie.trustyai.explainability.model.Dataframe;
 import org.kie.trustyai.explainability.model.Prediction;
-import org.kie.trustyai.service.profiles.MemoryTestProfile;
 import org.kie.trustyai.service.data.parsers.CSVParser;
 import org.kie.trustyai.service.data.utils.CSVUtils;
 import org.kie.trustyai.service.mocks.MockDatasource;
@@ -21,37 +23,29 @@ import org.kie.trustyai.service.payloads.data.download.DataRequestPayload;
 import org.kie.trustyai.service.payloads.data.download.DataResponsePayload;
 import org.kie.trustyai.service.payloads.data.download.RowMatcher;
 import org.kie.trustyai.service.payloads.data.upload.ModelInferJointPayload;
+import org.kie.trustyai.service.profiles.MemoryTestProfile;
 import org.kie.trustyai.service.utils.KserveRestPayloads;
 
-import com.fasterxml.jackson.databind.node.IntNode;
-import com.fasterxml.jackson.databind.node.TextNode;
-
-import io.quarkus.test.common.http.TestHTTPEndpoint;
-import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.TestProfile;
-import io.restassured.http.ContentType;
-import io.restassured.response.ValidatableResponse;
-
-import jakarta.enterprise.inject.Instance;
-import jakarta.inject.Inject;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @QuarkusTest
 @TestProfile(MemoryTestProfile.class)
 @TestHTTPEndpoint(DataEndpoint.class)
 class DataEndpointTest {
+    private static final String MODEL_ID = "example1";
     @Inject
     Instance<MockDatasource> datasource;
-
     @Inject
     CSVParser csvParser;
-
-    private static final String MODEL_ID = "example1";
-
     @Inject
     Instance<MockMemoryStorage> storage;
 
@@ -362,10 +356,10 @@ class DataEndpointTest {
     // data upload tests ===============================================================================================
     @Test
     void uploadData() throws JsonProcessingException {
-        int[] testInputRows = new int[] { 1, 5, 250 };
-        int[] testInputCols = new int[] { 1, 4 };
-        int[] testOutputCols = new int[] { 1, 2 };
-        String[] testDatatypes = new String[] { "INT64", "INT32", "FP32", "FP64", "BOOL" };
+        int[] testInputRows = new int[]{1, 5, 250};
+        int[] testInputCols = new int[]{1, 4};
+        int[] testOutputCols = new int[]{1, 2};
+        String[] testDatatypes = new String[]{"INT64", "INT32", "FP32", "FP64", "BOOL"};
         String dataTag = "TRAINING";
 
         for (int nInputRows : testInputRows) {
@@ -461,10 +455,10 @@ class DataEndpointTest {
 
     @Test
     void uploadDataAndGroundTruth() throws JsonProcessingException {
-        int[] testInputRows = new int[] { 1, 5, 250 };
-        int[] testInputCols = new int[] { 1, 4 };
-        int[] testOutputCols = new int[] { 1, 2 };
-        String[] testDatatypes = new String[] { "INT64", "INT32", "FP32", "FP64", "BOOL" };
+        int[] testInputRows = new int[]{1, 5, 250};
+        int[] testInputCols = new int[]{1, 4};
+        int[] testOutputCols = new int[]{1, 2};
+        String[] testDatatypes = new String[]{"INT64", "INT32", "FP32", "FP64", "BOOL"};
 
         // sorry for the quad loop
         for (int nInputRows : testInputRows) {

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/data/DataEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/data/DataEndpointTest.java
@@ -447,7 +447,6 @@ class DataEndpointTest {
                 .when().post("/upload")
                 .then();
 
-        System.out.println(r.extract().body().asString());
         for (String checkMsg : checkMsgs) {
             r.statusCode(statusCode).body(containsString(checkMsg));
         }

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/DisparateImpactRatioEndpointBaseTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/DisparateImpactRatioEndpointBaseTest.java
@@ -619,7 +619,6 @@ abstract class DisparateImpactRatioEndpointBaseTest {
         assertEquals("metric", responseSecond.getType());
         assertEquals("DIR", responseSecond.getName());
         assertFalse(Double.isNaN(responseSecond.getValue()));
-        System.out.println(responseSecond.getValue());
     }
 
 }

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/DisparateImpactRatioEndpointBaseTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/DisparateImpactRatioEndpointBaseTest.java
@@ -8,17 +8,14 @@ import java.util.UUID;
 
 import org.jboss.resteasy.reactive.RestResponse;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.kie.trustyai.explainability.model.Dataframe;
 import org.kie.trustyai.explainability.model.Prediction;
 import org.kie.trustyai.explainability.model.PredictionMetadata;
 import org.kie.trustyai.explainability.model.SimplePrediction;
-import org.kie.trustyai.service.endpoints.metrics.MetricsEndpointTestProfile;
 import org.kie.trustyai.service.endpoints.metrics.RequestPayloadGenerator;
 import org.kie.trustyai.service.mocks.MockDatasource;
-import org.kie.trustyai.service.mocks.MockMemoryStorage;
 import org.kie.trustyai.service.mocks.MockPrometheusScheduler;
 import org.kie.trustyai.service.payloads.BaseScheduledResponse;
 import org.kie.trustyai.service.payloads.metrics.BaseMetricResponse;
@@ -28,42 +25,26 @@ import org.kie.trustyai.service.payloads.scheduler.ScheduleList;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
-import io.quarkus.test.common.http.TestHTTPEndpoint;
-import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.TestProfile;
 import io.restassured.http.ContentType;
-
-import jakarta.enterprise.inject.Instance;
-import jakarta.inject.Inject;
-import jakarta.ws.rs.core.Response;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-@QuarkusTest
-@TestProfile(MetricsEndpointTestProfile.class)
-@TestHTTPEndpoint(DisparateImpactRatioEndpoint.class)
-class DisparateImpactRatioEndpointTest {
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
 
-    private static final String MODEL_ID = "example1";
-    private static final int N_SAMPLES = 100;
+abstract class DisparateImpactRatioEndpointBaseTest {
+
+    protected static final String MODEL_ID = "example1";
+    protected static final int N_SAMPLES = 100;
     @Inject
     Instance<MockDatasource> datasource;
-    @Inject
-    Instance<MockMemoryStorage> storage;
 
     @Inject
     Instance<MockPrometheusScheduler> scheduler;
-
-    @BeforeEach
-    void populateStorage() throws JsonProcessingException {
-        storage.get().emptyStorage();
-        final Dataframe dataframe = datasource.get().generateRandomDataframe(N_SAMPLES);
-        datasource.get().saveDataframe(dataframe, MODEL_ID);
-        datasource.get().saveMetadata(datasource.get().createMetadata(dataframe), MODEL_ID);
-    }
 
     @AfterEach
     void clearRequests() {
@@ -566,6 +547,7 @@ class DisparateImpactRatioEndpointTest {
     }
 
     @Test
+    @DisplayName("DIR request should produce correct result")
     void postCorrectFilteringSynthetic() throws JsonProcessingException {
         final GroupMetricRequest payload = RequestPayloadGenerator.correct();
         final BaseMetricResponse response = given()
@@ -577,15 +559,15 @@ class DisparateImpactRatioEndpointTest {
                 .extract()
                 .body().as(BaseMetricResponse.class);
 
-        Double value = response.getValue();
+        final Double value = response.getValue();
         assertEquals("metric", response.getType());
         assertEquals("DIR", response.getName());
         assertFalse(Double.isNaN(value));
 
         final Dataframe dataframe = datasource.get().generateRandomDataframe(N_SAMPLES);
-        Prediction prediction = dataframe.asPredictions().get(0);
-        PredictionMetadata predictionMetadata = new PredictionMetadata("123", LocalDateTime.now(), Dataframe.InternalTags.SYNTHETIC.get());
-        Prediction newPrediction = new SimplePrediction(prediction.getInput(), prediction.getOutput(), predictionMetadata);
+        final Prediction prediction = dataframe.asPredictions().get(0);
+        final PredictionMetadata predictionMetadata = new PredictionMetadata("123", LocalDateTime.now(), Dataframe.InternalTags.SYNTHETIC.get());
+        final Prediction newPrediction = new SimplePrediction(prediction.getInput(), prediction.getOutput(), predictionMetadata);
         Dataframe newDataframe = Dataframe.createFrom(newPrediction);
 
         datasource.get().saveDataframe(newDataframe, MODEL_ID);

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/DisparateImpactRatioEndpointBaseTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/DisparateImpactRatioEndpointBaseTest.java
@@ -1,10 +1,10 @@
 package org.kie.trustyai.service.endpoints.metrics.fairness.group;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.restassured.http.ContentType;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
 import org.jboss.resteasy.reactive.RestResponse;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -19,18 +19,15 @@ import org.kie.trustyai.service.payloads.metrics.fairness.group.GroupMetricReque
 import org.kie.trustyai.service.payloads.scheduler.ScheduleId;
 import org.kie.trustyai.service.payloads.scheduler.ScheduleList;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-
-import io.restassured.http.ContentType;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
-
-import jakarta.enterprise.inject.Instance;
-import jakarta.inject.Inject;
-import jakarta.ws.rs.core.Response;
 
 abstract class DisparateImpactRatioEndpointBaseTest {
 

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/DisparateImpactRatioEndpointMemoryTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/DisparateImpactRatioEndpointMemoryTest.java
@@ -1,0 +1,34 @@
+package org.kie.trustyai.service.endpoints.metrics.fairness.group;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.kie.trustyai.explainability.model.Dataframe;
+import org.kie.trustyai.service.mocks.MockMemoryStorage;
+import org.kie.trustyai.service.profiles.MemoryTestProfile;
+
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+@QuarkusTest
+@TestProfile(MemoryTestProfile.class)
+@TestHTTPEndpoint(DisparateImpactRatioEndpoint.class)
+class DisparateImpactRatioEndpointMemoryTest extends DisparateImpactRatioEndpointBaseTest {
+    @Inject
+    Instance<MockMemoryStorage> storage;
+
+    @BeforeEach
+    void reset() throws IOException {
+
+        storage.get().emptyStorage();
+
+        final Dataframe dataframe = datasource.get().generateRandomDataframe(N_SAMPLES);
+        datasource.get().saveDataframe(dataframe, MODEL_ID);
+        datasource.get().saveMetadata(datasource.get().createMetadata(dataframe), MODEL_ID);
+    }
+
+}

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/DisparateImpactRatioEndpointMemoryTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/DisparateImpactRatioEndpointMemoryTest.java
@@ -1,18 +1,15 @@
 package org.kie.trustyai.service.endpoints.metrics.fairness.group;
 
-import java.io.IOException;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.kie.trustyai.explainability.model.Dataframe;
-import org.kie.trustyai.service.mocks.MockMemoryStorage;
-import org.kie.trustyai.service.profiles.MemoryTestProfile;
-
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.kie.trustyai.service.mocks.MockMemoryStorage;
+import org.kie.trustyai.service.profiles.MemoryTestProfile;
+
+import java.io.IOException;
 
 @QuarkusTest
 @TestProfile(MemoryTestProfile.class)

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/DisparateImpactRatioEndpointMemoryTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/DisparateImpactRatioEndpointMemoryTest.java
@@ -23,12 +23,8 @@ class DisparateImpactRatioEndpointMemoryTest extends DisparateImpactRatioEndpoin
 
     @BeforeEach
     void reset() throws IOException {
-
+        datasource.get().reset();
         storage.get().emptyStorage();
-
-        final Dataframe dataframe = datasource.get().generateRandomDataframe(N_SAMPLES);
-        datasource.get().saveDataframe(dataframe, MODEL_ID);
-        datasource.get().saveMetadata(datasource.get().createMetadata(dataframe), MODEL_ID);
     }
 
 }

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/DisparateImpactRatioEndpointPVCTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/DisparateImpactRatioEndpointPVCTest.java
@@ -1,0 +1,35 @@
+package org.kie.trustyai.service.endpoints.metrics.fairness.group;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.kie.trustyai.explainability.model.Dataframe;
+import org.kie.trustyai.service.mocks.MockPVCStorage;
+import org.kie.trustyai.service.profiles.PVCTestProfile;
+
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+@QuarkusTest
+@TestProfile(PVCTestProfile.class)
+@TestHTTPEndpoint(DisparateImpactRatioEndpoint.class)
+class DisparateImpactRatioEndpointPVCTest extends DisparateImpactRatioEndpointBaseTest {
+    @Inject
+    Instance<MockPVCStorage> storage;
+
+    @BeforeEach
+    void reset() throws IOException {
+
+        storage.get().emptyStorage("/tmp/" + MODEL_ID + "-data.csv");
+        storage.get().emptyStorage("/tmp/" + MODEL_ID + "-internal_data.csv");
+        storage.get().emptyStorage("/tmp/" + MODEL_ID + "-metadata.json");
+
+        final Dataframe dataframe = datasource.get().generateRandomDataframe(N_SAMPLES);
+        datasource.get().saveDataframe(dataframe, MODEL_ID);
+        datasource.get().saveMetadata(datasource.get().createMetadata(dataframe), MODEL_ID);
+    }
+}

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/DisparateImpactRatioEndpointPVCTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/DisparateImpactRatioEndpointPVCTest.java
@@ -1,18 +1,15 @@
 package org.kie.trustyai.service.endpoints.metrics.fairness.group;
 
-import java.io.IOException;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.kie.trustyai.explainability.model.Dataframe;
-import org.kie.trustyai.service.mocks.MockPVCStorage;
-import org.kie.trustyai.service.profiles.PVCTestProfile;
-
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.kie.trustyai.service.mocks.MockPVCStorage;
+import org.kie.trustyai.service.profiles.PVCTestProfile;
+
+import java.io.IOException;
 
 @QuarkusTest
 @TestProfile(PVCTestProfile.class)

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/DisparateImpactRatioEndpointPVCTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/DisparateImpactRatioEndpointPVCTest.java
@@ -27,9 +27,5 @@ class DisparateImpactRatioEndpointPVCTest extends DisparateImpactRatioEndpointBa
         storage.get().emptyStorage("/tmp/" + MODEL_ID + "-data.csv");
         storage.get().emptyStorage("/tmp/" + MODEL_ID + "-internal_data.csv");
         storage.get().emptyStorage("/tmp/" + MODEL_ID + "-metadata.json");
-
-        final Dataframe dataframe = datasource.get().generateRandomDataframe(N_SAMPLES);
-        datasource.get().saveDataframe(dataframe, MODEL_ID);
-        datasource.get().saveMetadata(datasource.get().createMetadata(dataframe), MODEL_ID);
     }
 }

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/DisparateImpactRatioRequestsEndpointBaseTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/DisparateImpactRatioRequestsEndpointBaseTest.java
@@ -1,38 +1,27 @@
 package org.kie.trustyai.service.endpoints.metrics.fairness.group;
 
-import java.util.Map;
-import java.util.UUID;
-
+import io.restassured.http.ContentType;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
 import org.jboss.resteasy.reactive.RestResponse;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.kie.trustyai.explainability.model.Dataframe;
 import org.kie.trustyai.service.config.ServiceConfig;
-import org.kie.trustyai.service.endpoints.metrics.MetricsEndpointTestProfile;
 import org.kie.trustyai.service.endpoints.metrics.RequestPayloadGenerator;
 import org.kie.trustyai.service.mocks.MockDatasource;
-import org.kie.trustyai.service.mocks.MockMemoryStorage;
 import org.kie.trustyai.service.mocks.MockPrometheusScheduler;
 import org.kie.trustyai.service.payloads.BaseScheduledResponse;
 import org.kie.trustyai.service.payloads.metrics.BaseMetricRequest;
 import org.kie.trustyai.service.payloads.metrics.fairness.group.GroupMetricRequest;
 import org.kie.trustyai.service.payloads.scheduler.ScheduleList;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-
-import io.quarkus.test.common.http.TestHTTPEndpoint;
-import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.TestProfile;
-import io.restassured.http.ContentType;
+import java.util.Map;
+import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.*;
-
-import jakarta.enterprise.inject.Instance;
-import jakarta.inject.Inject;
-import jakarta.ws.rs.core.Response;
 
 abstract class DisparateImpactRatioRequestsEndpointBaseTest {
 

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/DisparateImpactRatioRequestsEndpointBaseTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/DisparateImpactRatioRequestsEndpointBaseTest.java
@@ -26,40 +26,27 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.restassured.http.ContentType;
 
-import jakarta.enterprise.inject.Instance;
-import jakarta.inject.Inject;
-import jakarta.ws.rs.core.Response;
-
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.*;
 
-@QuarkusTest
-@TestProfile(MetricsEndpointTestProfile.class)
-@TestHTTPEndpoint(DisparateImpactRatioEndpoint.class)
-class DisparateImpactRatioRequestsEndpointTest {
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
 
-    private static final int N_SAMPLES = 100;
-    private static final String MODEL_ID = "example1";
+abstract class DisparateImpactRatioRequestsEndpointBaseTest {
+
+    protected static final int N_SAMPLES = 100;
+    protected static final String MODEL_ID = "example1";
     @Inject
     Instance<MockDatasource> datasource;
 
-    @Inject
-    Instance<MockMemoryStorage> storage;
 
     @Inject
     Instance<MockPrometheusScheduler> scheduler;
 
     @Inject
     Instance<ServiceConfig> serviceConfig;
-
-    @BeforeEach
-    void populateStorage() throws JsonProcessingException {
-        storage.get().emptyStorage();
-        final Dataframe dataframe = datasource.get().generateRandomDataframe(1000);
-        datasource.get().saveDataframe(dataframe, MODEL_ID);
-        datasource.get().saveMetadata(datasource.get().createMetadata(dataframe), MODEL_ID);
-    }
 
     /**
      * When no batch size is specified in the request, the service's default batch size should be used

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/DisparateImpactRatioRequestsEndpointMemoryTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/DisparateImpactRatioRequestsEndpointMemoryTest.java
@@ -1,39 +1,15 @@
 package org.kie.trustyai.service.endpoints.metrics.fairness.group;
 
-import java.util.Map;
-import java.util.UUID;
-
-import org.jboss.resteasy.reactive.RestResponse;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.kie.trustyai.explainability.model.Dataframe;
-import org.kie.trustyai.service.config.ServiceConfig;
-import org.kie.trustyai.service.endpoints.metrics.MetricsEndpointTestProfile;
-import org.kie.trustyai.service.endpoints.metrics.RequestPayloadGenerator;
-import org.kie.trustyai.service.mocks.MockDatasource;
-import org.kie.trustyai.service.mocks.MockMemoryStorage;
-import org.kie.trustyai.service.mocks.MockPrometheusScheduler;
-import org.kie.trustyai.service.payloads.BaseScheduledResponse;
-import org.kie.trustyai.service.payloads.metrics.BaseMetricRequest;
-import org.kie.trustyai.service.payloads.metrics.fairness.group.GroupMetricRequest;
-import org.kie.trustyai.service.payloads.scheduler.ScheduleList;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
-
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.restassured.http.ContentType;
-
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
-import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.kie.trustyai.explainability.model.Dataframe;
+import org.kie.trustyai.service.mocks.MockMemoryStorage;
 import org.kie.trustyai.service.profiles.MemoryTestProfile;
-
-import static io.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.containsString;
-import static org.junit.jupiter.api.Assertions.*;
 
 @QuarkusTest
 @TestProfile(MemoryTestProfile.class)

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/DisparateImpactRatioRequestsEndpointMemoryTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/DisparateImpactRatioRequestsEndpointMemoryTest.java
@@ -1,0 +1,55 @@
+package org.kie.trustyai.service.endpoints.metrics.fairness.group;
+
+import java.util.Map;
+import java.util.UUID;
+
+import org.jboss.resteasy.reactive.RestResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.kie.trustyai.explainability.model.Dataframe;
+import org.kie.trustyai.service.config.ServiceConfig;
+import org.kie.trustyai.service.endpoints.metrics.MetricsEndpointTestProfile;
+import org.kie.trustyai.service.endpoints.metrics.RequestPayloadGenerator;
+import org.kie.trustyai.service.mocks.MockDatasource;
+import org.kie.trustyai.service.mocks.MockMemoryStorage;
+import org.kie.trustyai.service.mocks.MockPrometheusScheduler;
+import org.kie.trustyai.service.payloads.BaseScheduledResponse;
+import org.kie.trustyai.service.payloads.metrics.BaseMetricRequest;
+import org.kie.trustyai.service.payloads.metrics.fairness.group.GroupMetricRequest;
+import org.kie.trustyai.service.payloads.scheduler.ScheduleList;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.http.ContentType;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+import org.kie.trustyai.service.profiles.MemoryTestProfile;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+@TestProfile(MemoryTestProfile.class)
+@TestHTTPEndpoint(DisparateImpactRatioEndpoint.class)
+class DisparateImpactRatioRequestsEndpointMemoryTest extends DisparateImpactRatioRequestsEndpointBaseTest {
+
+    @Inject
+    Instance<MockMemoryStorage> storage;
+
+
+    @BeforeEach
+    void populateStorage() throws JsonProcessingException {
+        storage.get().emptyStorage();
+        final Dataframe dataframe = datasource.get().generateRandomDataframe(1000);
+        datasource.get().saveDataframe(dataframe, MODEL_ID);
+        datasource.get().saveMetadata(datasource.get().createMetadata(dataframe), MODEL_ID);
+    }
+
+}

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/DisparateImpactRatioRequestsEndpointPVCTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/DisparateImpactRatioRequestsEndpointPVCTest.java
@@ -1,0 +1,39 @@
+package org.kie.trustyai.service.endpoints.metrics.fairness.group;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.kie.trustyai.explainability.model.Dataframe;
+import org.kie.trustyai.service.mocks.MockMemoryStorage;
+import org.kie.trustyai.service.mocks.MockPVCStorage;
+import org.kie.trustyai.service.profiles.MemoryTestProfile;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import org.kie.trustyai.service.profiles.PVCTestProfile;
+
+@QuarkusTest
+@TestProfile(PVCTestProfile.class)
+@TestHTTPEndpoint(DisparateImpactRatioEndpoint.class)
+class DisparateImpactRatioRequestsEndpointPVCTest extends DisparateImpactRatioRequestsEndpointBaseTest {
+
+    @Inject
+    Instance<MockPVCStorage> storage;
+
+
+    @BeforeEach
+    void populateStorage() throws JsonProcessingException {
+        storage.get().emptyStorage("/tmp/" + MODEL_ID + "-data.csv");
+        storage.get().emptyStorage("/tmp/" + MODEL_ID + "-internal_data.csv");
+        storage.get().emptyStorage("/tmp/" + MODEL_ID + "-metadata.json");
+
+        final Dataframe dataframe = datasource.get().generateRandomDataframe(1000);
+        datasource.get().saveDataframe(dataframe, MODEL_ID);
+        datasource.get().saveMetadata(datasource.get().createMetadata(dataframe), MODEL_ID);
+    }
+    
+}

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/DisparateImpactRatioRequestsEndpointPVCTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/DisparateImpactRatioRequestsEndpointPVCTest.java
@@ -1,19 +1,14 @@
 package org.kie.trustyai.service.endpoints.metrics.fairness.group;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.kie.trustyai.explainability.model.Dataframe;
-import org.kie.trustyai.service.mocks.MockMemoryStorage;
-import org.kie.trustyai.service.mocks.MockPVCStorage;
-import org.kie.trustyai.service.profiles.MemoryTestProfile;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
-
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.kie.trustyai.explainability.model.Dataframe;
+import org.kie.trustyai.service.mocks.MockPVCStorage;
 import org.kie.trustyai.service.profiles.PVCTestProfile;
 
 @QuarkusTest
@@ -35,5 +30,5 @@ class DisparateImpactRatioRequestsEndpointPVCTest extends DisparateImpactRatioRe
         datasource.get().saveDataframe(dataframe, MODEL_ID);
         datasource.get().saveMetadata(datasource.get().createMetadata(dataframe), MODEL_ID);
     }
-    
+
 }

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupStatisticalParityDifferenceEndpointBaseTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupStatisticalParityDifferenceEndpointBaseTest.java
@@ -4,18 +4,14 @@ import java.time.LocalDateTime;
 import java.util.Map;
 
 import org.jboss.resteasy.reactive.RestResponse;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.kie.trustyai.explainability.model.Dataframe;
 import org.kie.trustyai.explainability.model.Prediction;
 import org.kie.trustyai.explainability.model.PredictionMetadata;
 import org.kie.trustyai.explainability.model.SimplePrediction;
-import org.kie.trustyai.service.endpoints.metrics.MetricsEndpointTestProfile;
 import org.kie.trustyai.service.endpoints.metrics.RequestPayloadGenerator;
 import org.kie.trustyai.service.mocks.MockDatasource;
-import org.kie.trustyai.service.mocks.MockMemoryStorage;
 import org.kie.trustyai.service.mocks.MockPrometheusScheduler;
 import org.kie.trustyai.service.payloads.BaseScheduledResponse;
 import org.kie.trustyai.service.payloads.metrics.BaseMetricResponse;
@@ -25,9 +21,6 @@ import org.kie.trustyai.service.payloads.scheduler.ScheduleList;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
-import io.quarkus.test.common.http.TestHTTPEndpoint;
-import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.TestProfile;
 import io.restassured.http.ContentType;
 
 import static io.restassured.RestAssured.given;
@@ -364,13 +357,8 @@ abstract class GroupStatisticalParityDifferenceEndpointBaseTest {
         Double value = response.getValue();
         assertFalse(Double.isNaN(value));
 
-        final Dataframe dataframe = datasource.get().generateRandomDataframe(N_SAMPLES);
-        Prediction prediction = dataframe.asPredictions().get(0);
-        PredictionMetadata predictionMetadata = new PredictionMetadata("123", LocalDateTime.now(), Dataframe.InternalTags.SYNTHETIC.get());
-        Prediction newPrediction = new SimplePrediction(prediction.getInput(), prediction.getOutput(), predictionMetadata);
-        Dataframe newDataframe = Dataframe.createFrom(newPrediction);
-
-        datasource.get().saveDataframe(newDataframe, MODEL_ID);
+        final Dataframe syntheticDataframe = datasource.get().generateRandomSyntheticDataframe(N_SAMPLES);
+        datasource.get().saveDataframe(syntheticDataframe, MODEL_ID);
 
         final BaseMetricResponse responseSecond = given()
                 .contentType(ContentType.JSON)
@@ -386,4 +374,40 @@ abstract class GroupStatisticalParityDifferenceEndpointBaseTest {
         assertEquals(value, responseSecond.getValue());
     }
 
+    @Test
+    @DisplayName("SPD request with only synthetic data")
+    void postCorrectFilteringOnlySynthetic() throws JsonProcessingException {
+        datasource.get().reset();
+        final GroupMetricRequest payload = RequestPayloadGenerator.correct();
+
+        final BaseMetricResponse response = given()
+                .contentType(ContentType.JSON)
+                .body(payload)
+                .when().post()
+                .then()
+                .statusCode(200)
+                .extract()
+                .body().as(BaseMetricResponse.class);
+
+        assertEquals("metric", response.getType());
+        assertEquals("SPD", response.getName());
+        Double value = response.getValue();
+        assertFalse(Double.isNaN(value));
+
+        final Dataframe syntheticDataframe = datasource.get().generateRandomSyntheticDataframe(N_SAMPLES);
+        datasource.get().saveDataframe(syntheticDataframe, MODEL_ID);
+
+        final BaseMetricResponse responseSecond = given()
+                .contentType(ContentType.JSON)
+                .body(payload)
+                .when().post()
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .extract()
+                .body().as(BaseMetricResponse.class);
+
+        assertEquals("metric", responseSecond.getType());
+        assertEquals("SPD", responseSecond.getName());
+        assertEquals(value, responseSecond.getValue());
+    }
 }

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupStatisticalParityDifferenceEndpointBaseTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupStatisticalParityDifferenceEndpointBaseTest.java
@@ -1,15 +1,14 @@
 package org.kie.trustyai.service.endpoints.metrics.fairness.group;
 
-import java.time.LocalDateTime;
-import java.util.Map;
-
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.restassured.http.ContentType;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
 import org.jboss.resteasy.reactive.RestResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.kie.trustyai.explainability.model.Dataframe;
-import org.kie.trustyai.explainability.model.Prediction;
-import org.kie.trustyai.explainability.model.PredictionMetadata;
-import org.kie.trustyai.explainability.model.SimplePrediction;
 import org.kie.trustyai.service.endpoints.metrics.RequestPayloadGenerator;
 import org.kie.trustyai.service.mocks.MockDatasource;
 import org.kie.trustyai.service.mocks.MockPrometheusScheduler;
@@ -19,18 +18,12 @@ import org.kie.trustyai.service.payloads.metrics.fairness.group.GroupMetricReque
 import org.kie.trustyai.service.payloads.scheduler.ScheduleId;
 import org.kie.trustyai.service.payloads.scheduler.ScheduleList;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-
-import io.restassured.http.ContentType;
+import java.util.Map;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
-
-import jakarta.enterprise.inject.Instance;
-import jakarta.inject.Inject;
-import jakarta.ws.rs.core.Response;
 
 abstract class GroupStatisticalParityDifferenceEndpointBaseTest {
 

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupStatisticalParityDifferenceEndpointBaseTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupStatisticalParityDifferenceEndpointBaseTest.java
@@ -30,43 +30,24 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.restassured.http.ContentType;
 
-import jakarta.enterprise.inject.Instance;
-import jakarta.inject.Inject;
-import jakarta.ws.rs.core.Response;
-
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-@QuarkusTest
-@TestProfile(MetricsEndpointTestProfile.class)
-@TestHTTPEndpoint(GroupStatisticalParityDifferenceEndpoint.class)
-class GroupStatisticalParityDifferenceEndpointTest {
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
 
-    private static final String MODEL_ID = "example1";
-    private static final int N_SAMPLES = 100;
+abstract class GroupStatisticalParityDifferenceEndpointBaseTest {
+
+    protected static final String MODEL_ID = "example1";
+    protected static final int N_SAMPLES = 100;
     @Inject
     Instance<MockDatasource> datasource;
-    @Inject
-    Instance<MockMemoryStorage> storage;
 
     @Inject
     Instance<MockPrometheusScheduler> scheduler;
-
-    @BeforeEach
-    void populateStorage() throws JsonProcessingException {
-        storage.get().emptyStorage();
-        final Dataframe dataframe = datasource.get().generateRandomDataframe(1000);
-        datasource.get().saveDataframe(dataframe, MODEL_ID);
-        datasource.get().saveMetadata(datasource.get().createMetadata(dataframe), MODEL_ID);
-    }
-
-    @AfterEach
-    void clearRequests() {
-        // prevent a failing test from failing other tests erroneously
-        scheduler.get().getAllRequests().clear();
-    }
 
     @Test
     void get() {

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupStatisticalParityDifferenceEndpointMemoryTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupStatisticalParityDifferenceEndpointMemoryTest.java
@@ -1,44 +1,16 @@
 package org.kie.trustyai.service.endpoints.metrics.fairness.group;
 
-import java.time.LocalDateTime;
-import java.util.Map;
-
-import org.jboss.resteasy.reactive.RestResponse;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.kie.trustyai.explainability.model.Dataframe;
-import org.kie.trustyai.explainability.model.Prediction;
-import org.kie.trustyai.explainability.model.PredictionMetadata;
-import org.kie.trustyai.explainability.model.SimplePrediction;
-import org.kie.trustyai.service.endpoints.metrics.MetricsEndpointTestProfile;
-import org.kie.trustyai.service.endpoints.metrics.RequestPayloadGenerator;
-import org.kie.trustyai.service.mocks.MockDatasource;
-import org.kie.trustyai.service.mocks.MockMemoryStorage;
-import org.kie.trustyai.service.mocks.MockPrometheusScheduler;
-import org.kie.trustyai.service.payloads.BaseScheduledResponse;
-import org.kie.trustyai.service.payloads.metrics.BaseMetricResponse;
-import org.kie.trustyai.service.payloads.metrics.fairness.group.GroupMetricRequest;
-import org.kie.trustyai.service.payloads.scheduler.ScheduleId;
-import org.kie.trustyai.service.payloads.scheduler.ScheduleList;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
-
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.restassured.http.ContentType;
-
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
-import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.kie.trustyai.service.mocks.MockMemoryStorage;
+import org.kie.trustyai.service.mocks.MockPrometheusScheduler;
 import org.kie.trustyai.service.profiles.MemoryTestProfile;
-
-import static io.restassured.RestAssured.given;
-import static io.restassured.RestAssured.when;
-import static org.hamcrest.Matchers.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 @QuarkusTest
 @TestProfile(MemoryTestProfile.class)

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupStatisticalParityDifferenceEndpointMemoryTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupStatisticalParityDifferenceEndpointMemoryTest.java
@@ -1,0 +1,68 @@
+package org.kie.trustyai.service.endpoints.metrics.fairness.group;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import org.jboss.resteasy.reactive.RestResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.kie.trustyai.explainability.model.Dataframe;
+import org.kie.trustyai.explainability.model.Prediction;
+import org.kie.trustyai.explainability.model.PredictionMetadata;
+import org.kie.trustyai.explainability.model.SimplePrediction;
+import org.kie.trustyai.service.endpoints.metrics.MetricsEndpointTestProfile;
+import org.kie.trustyai.service.endpoints.metrics.RequestPayloadGenerator;
+import org.kie.trustyai.service.mocks.MockDatasource;
+import org.kie.trustyai.service.mocks.MockMemoryStorage;
+import org.kie.trustyai.service.mocks.MockPrometheusScheduler;
+import org.kie.trustyai.service.payloads.BaseScheduledResponse;
+import org.kie.trustyai.service.payloads.metrics.BaseMetricResponse;
+import org.kie.trustyai.service.payloads.metrics.fairness.group.GroupMetricRequest;
+import org.kie.trustyai.service.payloads.scheduler.ScheduleId;
+import org.kie.trustyai.service.payloads.scheduler.ScheduleList;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.http.ContentType;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+import org.kie.trustyai.service.profiles.MemoryTestProfile;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+@TestProfile(MemoryTestProfile.class)
+@TestHTTPEndpoint(GroupStatisticalParityDifferenceEndpoint.class)
+class GroupStatisticalParityDifferenceEndpointMemoryTest extends GroupStatisticalParityDifferenceEndpointBaseTest {
+
+    @Inject
+    Instance<MockMemoryStorage> storage;
+
+    @Inject
+    Instance<MockPrometheusScheduler> scheduler;
+
+    @BeforeEach
+    void populateStorage() throws JsonProcessingException {
+        storage.get().emptyStorage();
+        final Dataframe dataframe = datasource.get().generateRandomDataframe(1000);
+        datasource.get().saveDataframe(dataframe, MODEL_ID);
+        datasource.get().saveMetadata(datasource.get().createMetadata(dataframe), MODEL_ID);
+    }
+
+    @AfterEach
+    void clearRequests() {
+        // prevent a failing test from failing other tests erroneously
+        scheduler.get().getAllRequests().clear();
+    }
+
+}

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupStatisticalParityDifferenceEndpointMemoryTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupStatisticalParityDifferenceEndpointMemoryTest.java
@@ -52,11 +52,8 @@ class GroupStatisticalParityDifferenceEndpointMemoryTest extends GroupStatistica
     Instance<MockPrometheusScheduler> scheduler;
 
     @BeforeEach
-    void populateStorage() throws JsonProcessingException {
+    void reset() throws JsonProcessingException {
         storage.get().emptyStorage();
-        final Dataframe dataframe = datasource.get().generateRandomDataframe(1000);
-        datasource.get().saveDataframe(dataframe, MODEL_ID);
-        datasource.get().saveMetadata(datasource.get().createMetadata(dataframe), MODEL_ID);
     }
 
     @AfterEach

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupStatisticalParityDifferenceEndpointPVCTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupStatisticalParityDifferenceEndpointPVCTest.java
@@ -1,21 +1,15 @@
 package org.kie.trustyai.service.endpoints.metrics.fairness.group;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.kie.trustyai.explainability.model.Dataframe;
-import org.kie.trustyai.service.mocks.MockMemoryStorage;
-import org.kie.trustyai.service.mocks.MockPVCStorage;
-import org.kie.trustyai.service.mocks.MockPrometheusScheduler;
-import org.kie.trustyai.service.profiles.MemoryTestProfile;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
-
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.kie.trustyai.service.mocks.MockPVCStorage;
+import org.kie.trustyai.service.mocks.MockPrometheusScheduler;
 import org.kie.trustyai.service.profiles.PVCTestProfile;
 
 @QuarkusTest
@@ -41,5 +35,5 @@ class GroupStatisticalParityDifferenceEndpointPVCTest extends GroupStatisticalPa
         // prevent a failing test from failing other tests erroneously
         scheduler.get().getAllRequests().clear();
     }
-    
+
 }

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupStatisticalParityDifferenceEndpointPVCTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupStatisticalParityDifferenceEndpointPVCTest.java
@@ -1,0 +1,49 @@
+package org.kie.trustyai.service.endpoints.metrics.fairness.group;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.kie.trustyai.explainability.model.Dataframe;
+import org.kie.trustyai.service.mocks.MockMemoryStorage;
+import org.kie.trustyai.service.mocks.MockPVCStorage;
+import org.kie.trustyai.service.mocks.MockPrometheusScheduler;
+import org.kie.trustyai.service.profiles.MemoryTestProfile;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import org.kie.trustyai.service.profiles.PVCTestProfile;
+
+@QuarkusTest
+@TestProfile(PVCTestProfile.class)
+@TestHTTPEndpoint(GroupStatisticalParityDifferenceEndpoint.class)
+class GroupStatisticalParityDifferenceEndpointPVCTest extends GroupStatisticalParityDifferenceEndpointBaseTest {
+
+    @Inject
+    Instance<MockPVCStorage> storage;
+
+    @Inject
+    Instance<MockPrometheusScheduler> scheduler;
+
+    @BeforeEach
+    void populateStorage() throws JsonProcessingException {
+        storage.get().emptyStorage("/tmp/" + MODEL_ID + "-data.csv");
+        storage.get().emptyStorage("/tmp/" + MODEL_ID + "-internal_data.csv");
+        storage.get().emptyStorage("/tmp/" + MODEL_ID + "-metadata.json");
+
+        final Dataframe dataframe = datasource.get().generateRandomDataframe(1000);
+        datasource.get().saveDataframe(dataframe, MODEL_ID);
+        datasource.get().saveMetadata(datasource.get().createMetadata(dataframe), MODEL_ID);
+    }
+
+    @AfterEach
+    void clearRequests() {
+        // prevent a failing test from failing other tests erroneously
+        scheduler.get().getAllRequests().clear();
+    }
+    
+}

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupStatisticalParityDifferenceEndpointPVCTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupStatisticalParityDifferenceEndpointPVCTest.java
@@ -30,14 +30,10 @@ class GroupStatisticalParityDifferenceEndpointPVCTest extends GroupStatisticalPa
     Instance<MockPrometheusScheduler> scheduler;
 
     @BeforeEach
-    void populateStorage() throws JsonProcessingException {
+    void reset() throws JsonProcessingException {
         storage.get().emptyStorage("/tmp/" + MODEL_ID + "-data.csv");
         storage.get().emptyStorage("/tmp/" + MODEL_ID + "-internal_data.csv");
         storage.get().emptyStorage("/tmp/" + MODEL_ID + "-metadata.json");
-
-        final Dataframe dataframe = datasource.get().generateRandomDataframe(1000);
-        datasource.get().saveDataframe(dataframe, MODEL_ID);
-        datasource.get().saveMetadata(datasource.get().createMetadata(dataframe), MODEL_ID);
     }
 
     @AfterEach

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupStatisticalParityDifferenceRequestsEndpointBaseTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupStatisticalParityDifferenceRequestsEndpointBaseTest.java
@@ -24,43 +24,27 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.restassured.http.ContentType;
 
-import jakarta.enterprise.inject.Instance;
-import jakarta.inject.Inject;
-import jakarta.ws.rs.core.Response;
-
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.*;
 
-@QuarkusTest
-@TestProfile(MetricsEndpointTestProfile.class)
-@TestHTTPEndpoint(GroupStatisticalParityDifferenceEndpoint.class)
-class GroupStatisticalParityDifferenceRequestsEndpointTest {
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
 
-    private static final String MODEL_ID = "example1";
-    private static final int N_SAMPLES = 100;
+abstract class GroupStatisticalParityDifferenceRequestsEndpointBaseTest {
+
+    protected static final String MODEL_ID = "example1";
+    protected static final int N_SAMPLES = 100;
     @Inject
     Instance<MockDatasource> datasource;
 
-    @Inject
-    Instance<MockMemoryStorage> storage;
 
     @Inject
     Instance<MockPrometheusScheduler> scheduler;
 
     @Inject
     Instance<ServiceConfig> serviceConfig;
-
-    @BeforeEach
-    void populateStorage() {
-        // Empty mock storage
-        storage.get().emptyStorage();
-        // Clear any requests between tests
-        scheduler.get().getAllRequestsFlat().clear();
-        final Dataframe dataframe = datasource.get().generateRandomDataframe(1000);
-        datasource.get().saveDataframe(dataframe, MODEL_ID);
-        datasource.get().saveMetadata(datasource.get().createMetadata(dataframe), MODEL_ID);
-    }
 
     /**
      * When no batch size is specified in the request, the service's default batch size should be used

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupStatisticalParityDifferenceRequestsEndpointBaseTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupStatisticalParityDifferenceRequestsEndpointBaseTest.java
@@ -1,36 +1,27 @@
 package org.kie.trustyai.service.endpoints.metrics.fairness.group;
 
-import java.util.Map;
-import java.util.UUID;
-
+import io.restassured.http.ContentType;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
 import org.jboss.resteasy.reactive.RestResponse;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.kie.trustyai.explainability.model.Dataframe;
 import org.kie.trustyai.service.config.ServiceConfig;
-import org.kie.trustyai.service.endpoints.metrics.MetricsEndpointTestProfile;
 import org.kie.trustyai.service.endpoints.metrics.RequestPayloadGenerator;
 import org.kie.trustyai.service.mocks.MockDatasource;
-import org.kie.trustyai.service.mocks.MockMemoryStorage;
 import org.kie.trustyai.service.mocks.MockPrometheusScheduler;
 import org.kie.trustyai.service.payloads.BaseScheduledResponse;
 import org.kie.trustyai.service.payloads.metrics.BaseMetricRequest;
 import org.kie.trustyai.service.payloads.metrics.fairness.group.GroupMetricRequest;
 import org.kie.trustyai.service.payloads.scheduler.ScheduleList;
 
-import io.quarkus.test.common.http.TestHTTPEndpoint;
-import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.TestProfile;
-import io.restassured.http.ContentType;
+import java.util.Map;
+import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.*;
-
-import jakarta.enterprise.inject.Instance;
-import jakarta.inject.Inject;
-import jakarta.ws.rs.core.Response;
 
 abstract class GroupStatisticalParityDifferenceRequestsEndpointBaseTest {
 

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupStatisticalParityDifferenceRequestsEndpointMemoryTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupStatisticalParityDifferenceRequestsEndpointMemoryTest.java
@@ -1,37 +1,14 @@
 package org.kie.trustyai.service.endpoints.metrics.fairness.group;
 
-import java.util.Map;
-import java.util.UUID;
-
-import org.jboss.resteasy.reactive.RestResponse;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.kie.trustyai.explainability.model.Dataframe;
-import org.kie.trustyai.service.config.ServiceConfig;
-import org.kie.trustyai.service.endpoints.metrics.MetricsEndpointTestProfile;
-import org.kie.trustyai.service.endpoints.metrics.RequestPayloadGenerator;
-import org.kie.trustyai.service.mocks.MockDatasource;
-import org.kie.trustyai.service.mocks.MockMemoryStorage;
-import org.kie.trustyai.service.mocks.MockPrometheusScheduler;
-import org.kie.trustyai.service.payloads.BaseScheduledResponse;
-import org.kie.trustyai.service.payloads.metrics.BaseMetricRequest;
-import org.kie.trustyai.service.payloads.metrics.fairness.group.GroupMetricRequest;
-import org.kie.trustyai.service.payloads.scheduler.ScheduleList;
-
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.restassured.http.ContentType;
-
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
-import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.kie.trustyai.explainability.model.Dataframe;
+import org.kie.trustyai.service.mocks.MockMemoryStorage;
 import org.kie.trustyai.service.profiles.MemoryTestProfile;
-
-import static io.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.containsString;
-import static org.junit.jupiter.api.Assertions.*;
 
 @QuarkusTest
 @TestProfile(MemoryTestProfile.class)

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupStatisticalParityDifferenceRequestsEndpointMemoryTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupStatisticalParityDifferenceRequestsEndpointMemoryTest.java
@@ -1,0 +1,56 @@
+package org.kie.trustyai.service.endpoints.metrics.fairness.group;
+
+import java.util.Map;
+import java.util.UUID;
+
+import org.jboss.resteasy.reactive.RestResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.kie.trustyai.explainability.model.Dataframe;
+import org.kie.trustyai.service.config.ServiceConfig;
+import org.kie.trustyai.service.endpoints.metrics.MetricsEndpointTestProfile;
+import org.kie.trustyai.service.endpoints.metrics.RequestPayloadGenerator;
+import org.kie.trustyai.service.mocks.MockDatasource;
+import org.kie.trustyai.service.mocks.MockMemoryStorage;
+import org.kie.trustyai.service.mocks.MockPrometheusScheduler;
+import org.kie.trustyai.service.payloads.BaseScheduledResponse;
+import org.kie.trustyai.service.payloads.metrics.BaseMetricRequest;
+import org.kie.trustyai.service.payloads.metrics.fairness.group.GroupMetricRequest;
+import org.kie.trustyai.service.payloads.scheduler.ScheduleList;
+
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.http.ContentType;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+import org.kie.trustyai.service.profiles.MemoryTestProfile;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+@TestProfile(MemoryTestProfile.class)
+@TestHTTPEndpoint(GroupStatisticalParityDifferenceEndpoint.class)
+class GroupStatisticalParityDifferenceRequestsEndpointMemoryTest extends GroupStatisticalParityDifferenceRequestsEndpointBaseTest {
+
+    @Inject
+    Instance<MockMemoryStorage> storage;
+
+    @BeforeEach
+    void populateStorage() {
+        // Empty mock storage
+        storage.get().emptyStorage();
+        // Clear any requests between tests
+        scheduler.get().getAllRequestsFlat().clear();
+        final Dataframe dataframe = datasource.get().generateRandomDataframe(1000);
+        datasource.get().saveDataframe(dataframe, MODEL_ID);
+        datasource.get().saveMetadata(datasource.get().createMetadata(dataframe), MODEL_ID);
+    }
+
+
+}

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupStatisticalParityDifferenceRequestsEndpointPVCTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupStatisticalParityDifferenceRequestsEndpointPVCTest.java
@@ -1,0 +1,40 @@
+package org.kie.trustyai.service.endpoints.metrics.fairness.group;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.kie.trustyai.explainability.model.Dataframe;
+import org.kie.trustyai.service.mocks.MockMemoryStorage;
+import org.kie.trustyai.service.mocks.MockPVCStorage;
+import org.kie.trustyai.service.profiles.MemoryTestProfile;
+
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import org.kie.trustyai.service.profiles.PVCTestProfile;
+
+@QuarkusTest
+@TestProfile(PVCTestProfile.class)
+@TestHTTPEndpoint(GroupStatisticalParityDifferenceEndpoint.class)
+class GroupStatisticalParityDifferenceRequestsEndpointPVCTest extends GroupStatisticalParityDifferenceRequestsEndpointBaseTest {
+
+    @Inject
+    Instance<MockPVCStorage> storage;
+
+    @BeforeEach
+    void populateStorage() {
+        // Empty mock storage
+        storage.get().emptyStorage("/tmp/" + MODEL_ID + "-data.csv");
+        storage.get().emptyStorage("/tmp/" + MODEL_ID + "-internal_data.csv");
+        storage.get().emptyStorage("/tmp/" + MODEL_ID + "-metadata.json");
+
+        // Clear any requests between tests
+        scheduler.get().getAllRequestsFlat().clear();
+        final Dataframe dataframe = datasource.get().generateRandomDataframe(1000);
+        datasource.get().saveDataframe(dataframe, MODEL_ID);
+        datasource.get().saveMetadata(datasource.get().createMetadata(dataframe), MODEL_ID);
+    }
+    
+
+}

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupStatisticalParityDifferenceRequestsEndpointPVCTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupStatisticalParityDifferenceRequestsEndpointPVCTest.java
@@ -1,17 +1,13 @@
 package org.kie.trustyai.service.endpoints.metrics.fairness.group;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.kie.trustyai.explainability.model.Dataframe;
-import org.kie.trustyai.service.mocks.MockMemoryStorage;
-import org.kie.trustyai.service.mocks.MockPVCStorage;
-import org.kie.trustyai.service.profiles.MemoryTestProfile;
-
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.kie.trustyai.explainability.model.Dataframe;
+import org.kie.trustyai.service.mocks.MockPVCStorage;
 import org.kie.trustyai.service.profiles.PVCTestProfile;
 
 @QuarkusTest
@@ -35,6 +31,6 @@ class GroupStatisticalParityDifferenceRequestsEndpointPVCTest extends GroupStati
         datasource.get().saveDataframe(dataframe, MODEL_ID);
         datasource.get().saveMetadata(datasource.get().createMetadata(dataframe), MODEL_ID);
     }
-    
+
 
 }

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/service/ServiceMetadataEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/service/ServiceMetadataEndpointTest.java
@@ -1,20 +1,21 @@
 package org.kie.trustyai.service.endpoints.service;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.IntStream;
-
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.node.IntNode;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.common.mapper.TypeRef;
+import io.restassured.http.ContentType;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
 import org.hamcrest.Matchers;
 import org.jboss.resteasy.reactive.RestResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.kie.trustyai.explainability.model.Dataframe;
-import org.kie.trustyai.service.mocks.MockMemoryStorage;
-import org.kie.trustyai.service.profiles.MemoryTestProfile;
 import org.kie.trustyai.service.mocks.MockDatasource;
+import org.kie.trustyai.service.mocks.MockMemoryStorage;
 import org.kie.trustyai.service.mocks.MockPrometheusScheduler;
 import org.kie.trustyai.service.payloads.metrics.fairness.group.GroupMetricRequest;
 import org.kie.trustyai.service.payloads.service.DataTagging;
@@ -22,17 +23,13 @@ import org.kie.trustyai.service.payloads.service.NameMapping;
 import org.kie.trustyai.service.payloads.service.ServiceMetadata;
 import org.kie.trustyai.service.payloads.values.reconcilable.ReconcilableFeature;
 import org.kie.trustyai.service.payloads.values.reconcilable.ReconcilableOutput;
+import org.kie.trustyai.service.profiles.MemoryTestProfile;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.node.IntNode;
-
-import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.TestProfile;
-import io.restassured.common.mapper.TypeRef;
-import io.restassured.http.ContentType;
-
-import jakarta.enterprise.inject.Instance;
-import jakarta.inject.Inject;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.IntStream;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
@@ -134,7 +131,7 @@ class ServiceMetadataEndpointTest {
         assertEquals(1000, serviceMetadata.get(0).getData().getObservations());
 
         // check column values
-        assertEquals(null, serviceMetadata.get(0).getData().getInputSchema().getItems().get("age").getValues());
+        assertNull(serviceMetadata.get(0).getData().getInputSchema().getItems().get("age").getValues());
         assertEquals(2, serviceMetadata.get(0).getData().getInputSchema().getItems().get("race").getValues().size());
         assertFalse(serviceMetadata.get(0).getData().getOutputSchema().getItems().isEmpty());
         assertFalse(serviceMetadata.get(0).getData().getInputSchema().getItems().isEmpty());

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/service/ServiceMetadataEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/service/ServiceMetadataEndpointTest.java
@@ -54,9 +54,9 @@ class ServiceMetadataEndpointTest {
     Instance<MockPrometheusScheduler> scheduler;
 
     @BeforeEach
-    void clearStorage() {
+    void clearStorage() throws JsonProcessingException {
         storage.get().emptyStorage();
-        datasource.get().empty();
+        datasource.get().reset();
         scheduler.get().empty();
     }
 
@@ -90,7 +90,7 @@ class ServiceMetadataEndpointTest {
 
     @Test
     void getThousandObservations() throws JsonProcessingException {
-        final Dataframe dataframe = datasource.get().generateRandomDataframe(1000, 50);
+        final Dataframe dataframe = datasource.get().generateRandomDataframe(1000, 50, false);
         datasource.get().saveDataframe(dataframe, MODEL_ID);
         datasource.get().saveMetadata(datasource.get().createMetadata(dataframe), MODEL_ID);
 
@@ -116,7 +116,7 @@ class ServiceMetadataEndpointTest {
 
     @Test
     void getThousandDiverseObservations() throws JsonProcessingException {
-        final Dataframe dataframe = datasource.get().generateRandomDataframe(1000, 1000);
+        final Dataframe dataframe = datasource.get().generateRandomDataframe(1000, 1000, false);
         datasource.get().saveDataframe(dataframe, MODEL_ID);
         datasource.get().saveMetadata(datasource.get().createMetadata(dataframe), MODEL_ID);
 
@@ -141,8 +141,8 @@ class ServiceMetadataEndpointTest {
     }
 
     @Test
-    void getNoObservations() {
-        datasource.get().empty();
+    void getNoObservations() throws JsonProcessingException {
+        datasource.get().reset();
         final List<ServiceMetadata> serviceMetadata = given()
                 .when().get(metadataUrl)
                 .then()
@@ -156,7 +156,7 @@ class ServiceMetadataEndpointTest {
 
     @Test
     void setNameMapping() throws JsonProcessingException {
-        final Dataframe dataframe = datasource.get().generateRandomDataframe(1000, 10);
+        final Dataframe dataframe = datasource.get().generateRandomDataframe(1000, 10, false);
         datasource.get().saveDataframe(dataframe, MODEL_ID);
         datasource.get().saveMetadata(datasource.get().createMetadata(dataframe), MODEL_ID);
 
@@ -196,7 +196,7 @@ class ServiceMetadataEndpointTest {
 
     @Test
     void setNameMappingPartial() throws JsonProcessingException {
-        final Dataframe dataframe = datasource.get().generateRandomDataframe(1000, 10);
+        final Dataframe dataframe = datasource.get().generateRandomDataframe(1000, 10, false);
         datasource.get().saveDataframe(dataframe, MODEL_ID);
         datasource.get().saveMetadata(datasource.get().createMetadata(dataframe), MODEL_ID);
 
@@ -248,7 +248,7 @@ class ServiceMetadataEndpointTest {
 
     @Test
     void setNameMappingWrongInputs() throws JsonProcessingException {
-        final Dataframe dataframe = datasource.get().generateRandomDataframe(1000, 10);
+        final Dataframe dataframe = datasource.get().generateRandomDataframe(1000, 10, false);
         datasource.get().saveDataframe(dataframe, MODEL_ID);
         datasource.get().saveMetadata(datasource.get().createMetadata(dataframe), MODEL_ID);
 
@@ -268,7 +268,7 @@ class ServiceMetadataEndpointTest {
 
     @Test
     void setNameMappingWrongOutputs() throws JsonProcessingException {
-        final Dataframe dataframe = datasource.get().generateRandomDataframe(1000, 10);
+        final Dataframe dataframe = datasource.get().generateRandomDataframe(1000, 10, false);
         datasource.get().saveDataframe(dataframe, MODEL_ID);
         datasource.get().saveMetadata(datasource.get().createMetadata(dataframe), MODEL_ID);
 
@@ -498,7 +498,7 @@ class ServiceMetadataEndpointTest {
 
     @Test
     void setDatapointTagging() throws JsonProcessingException {
-        final Dataframe dataframe = datasource.get().generateRandomDataframe(50, 10);
+        final Dataframe dataframe = datasource.get().generateRandomDataframe(50, 10, false);
         datasource.get().saveDataframe(dataframe, MODEL_ID);
         datasource.get().saveMetadata(datasource.get().createMetadata(dataframe), MODEL_ID);
         List<String> originalTags = datasource.get().getDataframe(MODEL_ID).getTags();

--- a/explainability-service/src/test/java/org/kie/trustyai/service/scenarios/nodata/DisparateImpactRatioEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/scenarios/nodata/DisparateImpactRatioEndpointTest.java
@@ -1,12 +1,15 @@
 package org.kie.trustyai.service.scenarios.nodata;
 
-import java.util.UUID;
-
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.http.ContentType;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
 import org.jboss.resteasy.reactive.RestResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.kie.trustyai.service.profiles.MemoryTestProfile;
 import org.kie.trustyai.service.endpoints.metrics.RequestPayloadGenerator;
 import org.kie.trustyai.service.endpoints.metrics.fairness.group.DisparateImpactRatioEndpoint;
 import org.kie.trustyai.service.mocks.MockDatasource;
@@ -14,14 +17,9 @@ import org.kie.trustyai.service.mocks.MockMemoryStorage;
 import org.kie.trustyai.service.payloads.metrics.fairness.group.GroupMetricRequest;
 import org.kie.trustyai.service.payloads.scheduler.ScheduleId;
 import org.kie.trustyai.service.payloads.scheduler.ScheduleList;
+import org.kie.trustyai.service.profiles.MemoryTestProfile;
 
-import io.quarkus.test.common.http.TestHTTPEndpoint;
-import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.TestProfile;
-import io.restassured.http.ContentType;
-
-import jakarta.enterprise.inject.Instance;
-import jakarta.inject.Inject;
+import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
@@ -42,7 +40,6 @@ class DisparateImpactRatioEndpointTest {
 
     /**
      * Populate storage with 1000 random observations before each test.
-     *
      */
     @BeforeEach
     void populateStorage() {

--- a/explainability-service/src/test/java/org/kie/trustyai/service/scenarios/nodata/GroupStatisticalParityDifferenceEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/scenarios/nodata/GroupStatisticalParityDifferenceEndpointTest.java
@@ -1,12 +1,16 @@
 package org.kie.trustyai.service.scenarios.nodata;
 
-import java.util.UUID;
-
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.http.ContentType;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
 import org.jboss.resteasy.reactive.RestResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.kie.trustyai.service.profiles.MemoryTestProfile;
 import org.kie.trustyai.service.endpoints.metrics.RequestPayloadGenerator;
 import org.kie.trustyai.service.endpoints.metrics.fairness.group.GroupStatisticalParityDifferenceEndpoint;
 import org.kie.trustyai.service.mocks.MockDatasource;
@@ -14,16 +18,9 @@ import org.kie.trustyai.service.mocks.MockMemoryStorage;
 import org.kie.trustyai.service.payloads.metrics.fairness.group.GroupMetricRequest;
 import org.kie.trustyai.service.payloads.scheduler.ScheduleId;
 import org.kie.trustyai.service.payloads.scheduler.ScheduleList;
+import org.kie.trustyai.service.profiles.MemoryTestProfile;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-
-import io.quarkus.test.common.http.TestHTTPEndpoint;
-import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.TestProfile;
-import io.restassured.http.ContentType;
-
-import jakarta.enterprise.inject.Instance;
-import jakarta.inject.Inject;
+import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;

--- a/explainability-service/src/test/java/org/kie/trustyai/service/scenarios/nodata/ServiceMetadataEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/scenarios/nodata/ServiceMetadataEndpointTest.java
@@ -1,24 +1,22 @@
 package org.kie.trustyai.service.scenarios.nodata;
 
-import java.util.List;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.jboss.resteasy.reactive.RestResponse;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.kie.trustyai.service.profiles.MemoryTestProfile;
-import org.kie.trustyai.service.endpoints.service.ServiceMetadataEndpoint;
-import org.kie.trustyai.service.mocks.MockDatasource;
-import org.kie.trustyai.service.mocks.MockMemoryStorage;
-import org.kie.trustyai.service.payloads.service.ServiceMetadata;
-
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.restassured.common.mapper.TypeRef;
-
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
+import org.jboss.resteasy.reactive.RestResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.kie.trustyai.service.endpoints.service.ServiceMetadataEndpoint;
+import org.kie.trustyai.service.mocks.MockDatasource;
+import org.kie.trustyai.service.mocks.MockMemoryStorage;
+import org.kie.trustyai.service.payloads.service.ServiceMetadata;
+import org.kie.trustyai.service.profiles.MemoryTestProfile;
+
+import java.util.List;
 
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/explainability-service/src/test/java/org/kie/trustyai/service/scenarios/nodata/ServiceMetadataEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/scenarios/nodata/ServiceMetadataEndpointTest.java
@@ -2,6 +2,7 @@ package org.kie.trustyai.service.scenarios.nodata;
 
 import java.util.List;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.jboss.resteasy.reactive.RestResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,8 +40,8 @@ class ServiceMetadataEndpointTest {
     }
 
     @Test
-    void get() {
-        datasource.get().empty();
+    void get() throws JsonProcessingException {
+        datasource.get().reset();
         final List<ServiceMetadata> serviceMetadata = given()
                 .when().get()
                 .then()

--- a/explainability-service/src/test/java/org/kie/trustyai/service/scenarios/nodata/StorageTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/scenarios/nodata/StorageTest.java
@@ -1,26 +1,24 @@
 package org.kie.trustyai.service.scenarios.nodata;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.kie.trustyai.service.data.exceptions.StorageReadException;
+import org.kie.trustyai.service.data.exceptions.StorageWriteException;
+import org.kie.trustyai.service.mocks.MockDatasource;
+import org.kie.trustyai.service.mocks.MockMemoryStorage;
+import org.kie.trustyai.service.profiles.MemoryTestProfile;
+
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.kie.trustyai.service.profiles.MemoryTestProfile;
-import org.kie.trustyai.service.data.exceptions.StorageReadException;
-import org.kie.trustyai.service.data.exceptions.StorageWriteException;
-import org.kie.trustyai.service.mocks.MockDatasource;
-import org.kie.trustyai.service.mocks.MockMemoryStorage;
-
-import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.TestProfile;
-
-import jakarta.enterprise.inject.Instance;
-import jakarta.inject.Inject;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/explainability-service/src/test/java/org/kie/trustyai/service/scenarios/nodata/StorageTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/scenarios/nodata/StorageTest.java
@@ -7,6 +7,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.kie.trustyai.service.profiles.MemoryTestProfile;
@@ -36,8 +37,8 @@ class StorageTest {
     Instance<MockDatasource> datasource;
 
     @BeforeEach
-    void emptyStorage() {
-        datasource.get().empty();
+    void emptyStorage() throws JsonProcessingException {
+        datasource.get().reset();
         storage.get().emptyStorage();
     }
 


### PR DESCRIPTION
This PR fixes the problem of reading data batches for fairness metrics when using synthetic data.

Before explainers, a data batch of size `N` of organic data (`O`) would be read as follows:

```
┌────┬────┬────┬────┬────┬────┬────┐
│ O1 │ O2 │ O3 │ O4 │ O5 │... │ OM │
└────┴────┴────┴────┴────┴────┴────┘
        ▲                        ▲  
        │                           
         ─ ─ ─ ─ ─ N ─ ─ ─ ─ ─ ─ ┘  
```

With the introduction of explainer's synthetic data (`S`) a batch would have been read as

```
┌────┬────┬────┬────┬────┬────┬────┐
│ O1 │ O2 │ S1 │ O4 │ S2 │... │ OM │
└────┴────┴────┴────┴────┴────┴────┘
        ▲                        ▲  
        │                           
         ─ ─ ─ ─ ─ N ─ ─ ─ ─ ─ ─ ┘  
```

effectively yelding a batch size < N in terms of organic data (and with internal id mismatch).
This PR introduces the `Datasource` method `getOrganicDataframe`, using the underlying `readWithTags` in `Storage`.
This methods scans the data and internal id files line by line, using a circular queue and only filling the batch when the tag is a match.

```
                  ┌ ─ ─ ─ ─ ─ ─ ─                                                        
                      Scanner    │                                                       
                  └ ─ ─ ─ ─ ─ ─ ─                                             ┌─────────┐
                          │                                                   │         │
┌──────────────┐                  ┌──────────────────────┐                    │         │
│    Data 1    │──────────▶───────▶  Metadata 1, tag: O  │────────────────────▶         │
├──────────────┤                  ├──────────────────────┤                    │  Queue  │
│    Data 2    │          │       │  Metadata 2, tag: S  │                    │         │
├──────────────┤                  ├──────────────────────┤                    │         │
│    Data 3    │──────────▶───────▶  Metadata 3, tag: O  │────────────────────▶         │
└──────────────┘                  └──────────────────────┘                    │         │
                          │                                                   └─────────┘
                                                                                         
                          ▼                                                              
```

If the amount of organic data is < batch, the behaviour is the same as before (i.e. returning `min(data size, batch)`.

Unit test are provided for the storage methods as well as the following scenarios:

- Metrics requests when having a mix of O and S data
- Metrics requests when only having S data. This is a special case since now the service reports data as _existing_, although no data is available to calculate metrics.