### PR TITLE
RHOAIENG-5466: Add KServeV1HTTPPredictionProvider

### DIFF
--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/AbstractKServePredictionProvider.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/AbstractKServePredictionProvider.java
@@ -1,0 +1,15 @@
+package org.kie.trustyai.connectors.kserve;
+
+import java.util.List;
+
+public abstract class AbstractKServePredictionProvider {
+    protected static final String DEFAULT_TENSOR_NAME = "predict";
+    protected static final KServeDatatype DEFAULT_DATATYPE = KServeDatatype.FP64;
+    protected final List<String> outputNames;
+    protected final String inputName;
+
+    protected AbstractKServePredictionProvider(List<String> outputNames, String inputName) {
+        this.outputNames = outputNames;
+        this.inputName = inputName;
+    }
+}

--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/KServeDatatype.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/KServeDatatype.java
@@ -1,6 +1,6 @@
-package org.kie.trustyai.connectors.kserve.v2;
+package org.kie.trustyai.connectors.kserve;
 
-enum KServeDatatype {
+public enum KServeDatatype {
     BOOL,
     INT8,
     INT16,

--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/PayloadParser.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/PayloadParser.java
@@ -1,0 +1,15 @@
+package org.kie.trustyai.connectors.kserve;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.kie.trustyai.explainability.model.PredictionInput;
+import org.kie.trustyai.explainability.model.PredictionOutput;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+public abstract class PayloadParser<T> {
+    public abstract List<PredictionInput> parseRequest(T request) throws IOException;
+
+    public abstract List<PredictionOutput> parseResponse(T response) throws JsonProcessingException;
+}

--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v1/KServeV1HTTPPayloadParser.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v1/KServeV1HTTPPayloadParser.java
@@ -1,0 +1,81 @@
+package org.kie.trustyai.connectors.kserve.v1;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kie.trustyai.connectors.kserve.PayloadParser;
+import org.kie.trustyai.explainability.model.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class KServeV1HTTPPayloadParser extends PayloadParser<String> {
+    private static final Logger logger = LoggerFactory.getLogger(KServeV1HTTPPayloadParser.class);
+    private static KServeV1HTTPPayloadParser instance;
+    private ObjectMapper mapper;
+
+    private KServeV1HTTPPayloadParser() {
+        this.mapper = new ObjectMapper();
+    }
+
+    public static synchronized KServeV1HTTPPayloadParser getInstance() {
+        if (instance == null) {
+            instance = new KServeV1HTTPPayloadParser();
+        }
+        return instance;
+    }
+
+    @Override
+    public List<PredictionInput> parseRequest(String json) throws IOException {
+        final KServeV1RequestPayload payload = mapper.readValue(json, KServeV1RequestPayload.class);
+        final List<PredictionInput> predictionInputs = new ArrayList<>();
+
+        // Process each list of instances as a separate PredictionInput
+        for (List<Double> featureValues : payload.instances) {
+            final List<Feature> features = new ArrayList<>();
+            for (int i = 0; i < featureValues.size(); i++) {
+                features.add(new Feature("Feature" + (i + 1), Type.NUMBER, new Value(featureValues.get(i))));
+            }
+            predictionInputs.add(new PredictionInput(features));
+        }
+
+        return predictionInputs;
+    }
+
+    @Override
+    public List<PredictionOutput> parseResponse(String jsonResponse) throws JsonProcessingException {
+        logger.debug("Parsing response " + jsonResponse);
+        final KServeV1ResponsePayload response = mapper.readValue(jsonResponse, KServeV1ResponsePayload.class);
+        final List<PredictionOutput> predictionOutputs = new ArrayList<>();
+
+        for (Object prediction : response.getPredictions()) {
+            if (prediction instanceof List) {
+                // Iterate over each element in the list, treating each as a separate PredictionOutput
+                for (Object value : (List<?>) prediction) {
+                    final List<Output> outputs = new ArrayList<>();
+                    if (value instanceof Integer) {
+                        outputs.add(new Output("value", Type.NUMBER, new Value((int) value), 1.0));
+                    } else {
+                        outputs.add(new Output("value", Type.NUMBER, new Value((double) value), 1.0));
+                    }
+                    predictionOutputs.add(new PredictionOutput(outputs));
+                }
+            } else {
+                // Handle non-list single values by creating one PredictionOutput per value
+                final List<Output> outputs = new ArrayList<>();
+                if (prediction instanceof Integer) {
+                    outputs.add(new Output("value", Type.NUMBER, new Value((int) prediction), 1.0));
+                } else {
+                    outputs.add(new Output("value", Type.NUMBER, new Value((double) prediction), 1.0));
+                }
+                predictionOutputs.add(new PredictionOutput(outputs));
+            }
+        }
+
+        return predictionOutputs;
+    }
+
+}

--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v1/KServeV1HTTPPredictionProvider.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v1/KServeV1HTTPPredictionProvider.java
@@ -1,0 +1,80 @@
+package org.kie.trustyai.connectors.kserve.v1;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.stream.Collectors;
+
+import org.kie.trustyai.connectors.kserve.AbstractKServePredictionProvider;
+import org.kie.trustyai.explainability.model.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Wraps a KServe v1-compatible HTTP model server as a TrustyAI {@link PredictionProvider}
+ */
+public class KServeV1HTTPPredictionProvider extends AbstractKServePredictionProvider implements PredictionProvider {
+
+    private static final Logger logger = LoggerFactory.getLogger(KServeV1HTTPPredictionProvider.class);
+    private final HttpClient httpClient;
+    private final String endpointUrl;
+
+    public KServeV1HTTPPredictionProvider(String inputName, List<String> outputNames, String endpointUrl) {
+        super(outputNames, inputName);
+        this.httpClient = HttpClient.newHttpClient();
+        this.endpointUrl = endpointUrl;
+    }
+
+    public CompletableFuture<List<PredictionOutput>> predictAsync(List<PredictionInput> inputs) {
+        final ObjectMapper mapper = new ObjectMapper();
+
+        final List<List<Double>> instances = inputs.stream()
+                .map(input -> input.getFeatures().stream()
+                        .map(Feature::getValue).map(Value::asNumber)
+                        .collect(Collectors.toList()))
+                .collect(Collectors.toList());
+
+        final KServeV1RequestPayload wrapper = new KServeV1RequestPayload(instances);
+
+        // Convert to JSON
+        try {
+            final String json = mapper.writeValueAsString(wrapper);
+            logger.debug("Sending " + json + " to " + endpointUrl);
+            final HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(endpointUrl))
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(json))
+                    .build();
+
+            return httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                    .thenApply(HttpResponse::body)
+                    .thenApply(response -> {
+                        try {
+                            return KServeV1HTTPPayloadParser.getInstance().parseResponse(response);
+                        } catch (JsonProcessingException e) {
+                            throw new CompletionException(e);
+                        }
+                    })
+                    .handle((result, throwable) -> {
+                        if (throwable != null) {
+                            logger.error("Error processing response: " + throwable.getMessage());
+                            throw new RuntimeException("Error parsing server response", throwable);
+                        }
+                        return result;
+                    });
+
+        } catch (JsonProcessingException e) {
+            final CompletableFuture<List<PredictionOutput>> future = new CompletableFuture<>();
+            future.completeExceptionally(e);
+            return future;
+        }
+    }
+
+}

--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v1/KServeV1RequestPayload.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v1/KServeV1RequestPayload.java
@@ -1,0 +1,32 @@
+package org.kie.trustyai.connectors.kserve.v1;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.kie.trustyai.explainability.model.FeatureFactory;
+import org.kie.trustyai.explainability.model.PredictionInput;
+
+public class KServeV1RequestPayload {
+
+    public KServeV1RequestPayload() {
+        // NO OP - Required for JSON deserialisation
+    }
+
+    public List<List<Double>> instances;
+
+    public KServeV1RequestPayload(List<List<Double>> instances) {
+        this.instances = instances;
+    }
+
+    public List<PredictionInput> toPredictionInputs() {
+        return instances.stream().map(values -> values.stream().map(value -> FeatureFactory.newNumericalFeature("f", value))
+                .collect(Collectors.toList())).map(PredictionInput::new).collect(Collectors.toList());
+    }
+
+    @Override
+    public String toString() {
+        return "KServeV1RequestPayload{" +
+                "instances=" + instances +
+                '}';
+    }
+}

--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v1/KServeV1ResponsePayload.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v1/KServeV1ResponsePayload.java
@@ -1,0 +1,25 @@
+package org.kie.trustyai.connectors.kserve.v1;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class KServeV1ResponsePayload {
+    @JsonProperty("predictions")
+    private List<Object> predictions;
+
+    public List<Object> getPredictions() {
+        return predictions;
+    }
+
+    public void setPredictions(List<Object> predictions) {
+        this.predictions = predictions;
+    }
+
+    @Override
+    public String toString() {
+        return "KServeV1ResponsePayload{" +
+                "predictions=" + predictions +
+                '}';
+    }
+}

--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/KServeV2GRPCPredictionProvider.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/KServeV2GRPCPredictionProvider.java
@@ -3,6 +3,7 @@ package org.kie.trustyai.connectors.kserve.v2;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 
+import org.kie.trustyai.connectors.kserve.AbstractKServePredictionProvider;
 import org.kie.trustyai.connectors.kserve.v2.grpc.GRPCInferenceServiceGrpc;
 import org.kie.trustyai.connectors.kserve.v2.grpc.InferParameter;
 import org.kie.trustyai.connectors.kserve.v2.grpc.InferTensorContents;
@@ -21,23 +22,19 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 
 /**
- * Wraps a KServe v2-compatible model server as a TrustyAI {@link PredictionProvider}
+ * Wraps a KServe v2-compatible gRPC model server as a TrustyAI {@link PredictionProvider}
  */
-public class KServeV2GRPCPredictionProvider implements PredictionProvider {
+public class KServeV2GRPCPredictionProvider extends AbstractKServePredictionProvider implements PredictionProvider {
 
     private static final Logger logger = LoggerFactory.getLogger(KServeV2GRPCPredictionProvider.class);
-    private static final String DEFAULT_TENSOR_NAME = "predict";
-    private static final KServeDatatype DEFAULT_DATATYPE = KServeDatatype.FP64;
+
     private final KServeConfig kServeConfig;
-    private final List<String> outputNames;
-    private final String inputName;
     private final Map<String, String> optionalParameters;
 
     private KServeV2GRPCPredictionProvider(KServeConfig kServeConfig, String inputName, List<String> outputNames, Map<String, String> optionalParameters) {
 
+        super(outputNames, inputName);
         this.kServeConfig = kServeConfig;
-        this.inputName = inputName;
-        this.outputNames = outputNames;
         this.optionalParameters = optionalParameters;
     }
 

--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/PayloadParser.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/PayloadParser.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.kie.trustyai.connectors.kserve.KServeDatatype;
 import org.kie.trustyai.connectors.kserve.v2.grpc.InferTensorContents;
 import org.kie.trustyai.connectors.kserve.v2.grpc.ModelInferRequest;
 import org.kie.trustyai.connectors.kserve.v2.grpc.ModelInferResponse;

--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/TensorConverter.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/TensorConverter.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.kie.trustyai.connectors.kserve.KServeDatatype;
 import org.kie.trustyai.connectors.kserve.v2.grpc.InferTensorContents;
 import org.kie.trustyai.connectors.kserve.v2.grpc.ModelInferRequest;
 import org.kie.trustyai.connectors.kserve.v2.grpc.ModelInferResponse;

--- a/explainability-connectors/src/test/java/org/kie/trustyai/connectors/kserve/v1/KServeV1HTTPPayloadParserTest.java
+++ b/explainability-connectors/src/test/java/org/kie/trustyai/connectors/kserve/v1/KServeV1HTTPPayloadParserTest.java
@@ -1,0 +1,146 @@
+package org.kie.trustyai.connectors.kserve.v1;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.kie.trustyai.explainability.model.PredictionInput;
+import org.kie.trustyai.explainability.model.PredictionOutput;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class KServeV1HTTPPayloadParserTest {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public static String toJson(List<Object> predictions) {
+        try {
+            KServeV1ResponsePayload payload = new KServeV1ResponsePayload();
+            payload.setPredictions(predictions);
+            return objectMapper.writeValueAsString(payload);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to serialize predictions to JSON", e);
+        }
+    }
+
+    public static String generateJSONInputs(int inputs, int features) throws JsonProcessingException {
+        final Random random = new Random(0);
+
+        final List<List<Double>> inputList = new ArrayList<>();
+        for (int i = 0; i < inputs; i++) {
+            final List<Double> featureList = new ArrayList<>();
+            for (int j = 0; j < features; j++) {
+                featureList.add(random.nextDouble());
+            }
+            inputList.add(featureList);
+        }
+        final KServeV1RequestPayload payload = new KServeV1RequestPayload(inputList);
+
+        return objectMapper.writeValueAsString(payload);
+    }
+
+    @Test
+    void modelResponseToPredictionOutputSingle() throws JsonProcessingException {
+
+        final Random random = new Random(0);
+        final double value = random.nextDouble();
+
+        final String json = toJson(List.of(value));
+
+        final List<PredictionOutput> predictionOutput = KServeV1HTTPPayloadParser.getInstance().parseResponse(json);
+
+        assertEquals(1, predictionOutput.size());
+        assertEquals(1, predictionOutput.get(0).getOutputs().size());
+    }
+
+    @Test
+    void modelResponseToPredictionOutputMulti() throws JsonProcessingException {
+
+        final Random random = new Random(0);
+        final List<Object> values = random.doubles(3).boxed().collect(Collectors.toList());
+
+        final String json = toJson(values);
+
+        final List<PredictionOutput> predictionOutput = KServeV1HTTPPayloadParser.getInstance().parseResponse(json);
+
+        assertEquals(3, predictionOutput.size());
+        assertEquals(1, predictionOutput.get(0).getOutputs().size());
+        for (int i = 0; i < 3; i++) {
+            assertEquals(values.get(i), predictionOutput.get(i).getOutputs().get(0).getValue().asNumber());
+        }
+    }
+
+    @Test
+    void modelResponseToPredictionOutputFp32() throws JsonProcessingException {
+
+        final Random random = new Random(0);
+        final List<Object> values = List.of(random.nextFloat(), random.nextFloat(), random.nextFloat());
+        final String json = toJson(values);
+
+        final List<PredictionOutput> predictionOutput = KServeV1HTTPPayloadParser.getInstance().parseResponse(json);
+
+        assertEquals(3, predictionOutput.size());
+        assertEquals(1, predictionOutput.get(0).getOutputs().size());
+        for (int i = 0; i < 3; i++) {
+            assertEquals(values.get(i), Double.valueOf(predictionOutput.get(i).getOutputs().get(0).getValue().asNumber()).floatValue());
+        }
+    }
+
+    @Test
+    void modelResponseToPredictionOutputFp64() throws JsonProcessingException {
+
+        final Random random = new Random(0);
+        final List<Object> values = List.of(random.nextDouble(), random.nextDouble(), random.nextDouble());
+        final String json = toJson(values);
+
+        final List<PredictionOutput> predictionOutput = KServeV1HTTPPayloadParser.getInstance().parseResponse(json);
+
+        assertEquals(3, predictionOutput.size());
+        assertEquals(1, predictionOutput.get(0).getOutputs().size());
+        for (int i = 0; i < 3; i++) {
+            assertEquals(values.get(i), predictionOutput.get(i).getOutputs().get(0).getValue().asNumber());
+        }
+    }
+
+
+    @Test
+    void modelSingleToRequestToPredictionInput() throws IOException {
+
+        final String json = generateJSONInputs(1, 1);
+
+        final List<PredictionInput> inputs = KServeV1HTTPPayloadParser.getInstance().parseRequest(json);
+
+        assertEquals(1, inputs.size());
+        assertEquals(1, inputs.get(0).getFeatures().size());
+    }
+
+    @Test
+    void modelRequestToPredictionInputMulti() throws IOException {
+
+        final String json = generateJSONInputs(1, 3);
+
+        final List<PredictionInput> inputs = KServeV1HTTPPayloadParser.getInstance().parseRequest(json);
+
+        assertEquals(1, inputs.size());
+        assertEquals(3, inputs.get(0).getFeatures().size());
+    }
+
+    @Test
+    void modelRequestToPredictionInputFp32() throws IOException {
+
+        final String json = generateJSONInputs(3, 1);
+
+        final List<PredictionInput> inputs = KServeV1HTTPPayloadParser.getInstance().parseRequest(json);
+
+        assertEquals(3, inputs.size());
+        assertEquals(1, inputs.get(0).getFeatures().size());
+    }
+
+
+
+}


### PR DESCRIPTION
[RHOAIENG-5466](https://issues.redhat.com/browse/RHOAIENG-5466):

This PR allows to call KServe models using HTTP and JSON payloads and the v1 protocol.

