### PR TITLE
Upgrade Quarkus from 3.2.11.Final to 3.2.12.Final

### DIFF
--- a/explainability-service/pom.xml
+++ b/explainability-service/pom.xml
@@ -19,7 +19,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.bom-group-id>io.quarkus</quarkus.platform.bom-group-id>
-        <quarkus.platform.version>3.2.11.Final</quarkus.platform.version>
+        <quarkus.platform.version>3.2.12.Final</quarkus.platform.version>
         <apache.commons.collections.version>4.4</apache.commons.collections.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>


### PR DESCRIPTION
Fixes CVE-2024-2700. See [RHOAIENG-6179](https://issues.redhat.com/browse/RHOAIENG-6179)