### PR TITLE
Add KServe v1 HTTP parser optional output size

### DIFF
--- a/explainability-arrow/pom.xml
+++ b/explainability-arrow/pom.xml
@@ -14,7 +14,6 @@
 
     <properties>
         <version.org.apache.arrow>15.0.2</version.org.apache.arrow>
-        <version.io.netty>4.1.68.Final</version.io.netty>
         <version.com.google.flatbuffers>2.0.3</version.com.google.flatbuffers>
         <version.com.fasterxml.jackson.core>2.13.4</version.com.fasterxml.jackson.core> <!-- sync this with the databind version -->
     </properties>

--- a/explainability-connectors/pom.xml
+++ b/explainability-connectors/pom.xml
@@ -67,6 +67,19 @@
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+            <version>${version.io.netty}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http</artifactId>
+            <version>${version.io.netty}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/PayloadParser.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/PayloadParser.java
@@ -11,5 +11,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 public abstract class PayloadParser<T> {
     public abstract List<PredictionInput> parseRequest(T request) throws IOException;
 
-    public abstract List<PredictionOutput> parseResponse(T response) throws JsonProcessingException;
+    public abstract List<PredictionOutput> parseResponse(T response, int outputShape) throws JsonProcessingException;
+
+    public List<PredictionOutput> parseResponse(T response) throws JsonProcessingException {
+        return parseResponse(response, 1);
+    }
 }

--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v1/KServeV1HTTPPayloadParser.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v1/KServeV1HTTPPayloadParser.java
@@ -46,33 +46,28 @@ public class KServeV1HTTPPayloadParser extends PayloadParser<String> {
     }
 
     @Override
-    public List<PredictionOutput> parseResponse(String jsonResponse) throws JsonProcessingException {
+    public List<PredictionOutput> parseResponse(String jsonResponse, int outputShape) throws JsonProcessingException {
         logger.debug("Parsing response " + jsonResponse);
         final KServeV1ResponsePayload response = mapper.readValue(jsonResponse, KServeV1ResponsePayload.class);
         final List<PredictionOutput> predictionOutputs = new ArrayList<>();
 
-        for (Object prediction : response.getPredictions()) {
-            if (prediction instanceof List) {
-                // Iterate over each element in the list, treating each as a separate PredictionOutput
-                for (Object value : (List<?>) prediction) {
-                    final List<Output> outputs = new ArrayList<>();
-                    if (value instanceof Integer) {
-                        outputs.add(new Output("value", Type.NUMBER, new Value((int) value), 1.0));
-                    } else {
-                        outputs.add(new Output("value", Type.NUMBER, new Value((double) value), 1.0));
-                    }
-                    predictionOutputs.add(new PredictionOutput(outputs));
-                }
-            } else {
-                // Handle non-list single values by creating one PredictionOutput per value
-                final List<Output> outputs = new ArrayList<>();
-                if (prediction instanceof Integer) {
-                    outputs.add(new Output("value", Type.NUMBER, new Value((int) prediction), 1.0));
+        final List<?> predictions = response.getPredictions();
+        final int numPredictions = predictions.size();
+
+        for (int i = 0; i < numPredictions; i += outputShape) {
+            final List<Output> outputs = new ArrayList<>();
+
+            for (int j = 0; j < outputShape && i + j < numPredictions; j++) {
+                final Object value = predictions.get(i + j);
+
+                if (value instanceof Integer) {
+                    outputs.add(new Output("value", Type.NUMBER, new Value((int) value), 1.0));
                 } else {
-                    outputs.add(new Output("value", Type.NUMBER, new Value((double) prediction), 1.0));
+                    outputs.add(new Output("value", Type.NUMBER, new Value((double) value), 1.0));
                 }
-                predictionOutputs.add(new PredictionOutput(outputs));
             }
+
+            predictionOutputs.add(new PredictionOutput(outputs));
         }
 
         return predictionOutputs;

--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v1/KServeV1HTTPPayloadParser.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v1/KServeV1HTTPPayloadParser.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class KServeV1HTTPPayloadParser extends PayloadParser<String> {
     private static final Logger logger = LoggerFactory.getLogger(KServeV1HTTPPayloadParser.class);
     private static KServeV1HTTPPayloadParser instance;
-    private ObjectMapper mapper;
+    private final ObjectMapper mapper;
 
     private KServeV1HTTPPayloadParser() {
         this.mapper = new ObjectMapper();

--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v1/KServeV1HTTPPredictionProvider.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v1/KServeV1HTTPPredictionProvider.java
@@ -25,11 +25,17 @@ public class KServeV1HTTPPredictionProvider extends AbstractKServePredictionProv
     private static final Logger logger = LoggerFactory.getLogger(KServeV1HTTPPredictionProvider.class);
     private final HttpClient httpClient;
     private final String endpointUrl;
+    private final int outputShape;
 
     public KServeV1HTTPPredictionProvider(String inputName, List<String> outputNames, String endpointUrl) {
+        this(inputName, outputNames, endpointUrl, 1);
+    }
+
+    public KServeV1HTTPPredictionProvider(String inputName, List<String> outputNames, String endpointUrl, int outputShape) {
         super(outputNames, inputName);
         this.httpClient = HttpClient.newHttpClient();
         this.endpointUrl = endpointUrl;
+        this.outputShape = outputShape;
     }
 
     public CompletableFuture<List<PredictionOutput>> predictAsync(List<PredictionInput> inputs) {
@@ -57,7 +63,7 @@ public class KServeV1HTTPPredictionProvider extends AbstractKServePredictionProv
                     .thenApply(HttpResponse::body)
                     .thenApply(response -> {
                         try {
-                            return KServeV1HTTPPayloadParser.getInstance().parseResponse(response);
+                            return KServeV1HTTPPayloadParser.getInstance().parseResponse(response, outputShape);
                         } catch (JsonProcessingException e) {
                             throw new CompletionException(e);
                         }

--- a/explainability-connectors/src/test/java/org/kie/trustyai/connectors/kserve/v1/JsonRequestHandler.java
+++ b/explainability-connectors/src/test/java/org/kie/trustyai/connectors/kserve/v1/JsonRequestHandler.java
@@ -1,0 +1,78 @@
+package org.kie.trustyai.connectors.kserve.v1;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import org.kie.trustyai.explainability.model.Output;
+import org.kie.trustyai.explainability.model.PredictionInput;
+import org.kie.trustyai.explainability.model.PredictionOutput;
+import org.kie.trustyai.explainability.model.PredictionProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.*;
+import io.netty.util.CharsetUtil;
+
+public class JsonRequestHandler extends SimpleChannelInboundHandler<HttpObject> {
+    private static final Logger logger = LoggerFactory.getLogger(JsonRequestHandler.class);
+    private final String endpoint;
+    private final PredictionProvider predictionProvider;
+
+    public JsonRequestHandler(String endpoint, PredictionProvider predictionProvider) {
+        this.endpoint = endpoint;
+        this.predictionProvider = predictionProvider;
+    }
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, HttpObject msg) throws IOException, ExecutionException, InterruptedException {
+        if (msg instanceof FullHttpRequest) {
+            final FullHttpRequest request = (FullHttpRequest) msg;
+            logger.info("Received request: {}", request);
+
+            if (request.uri().equals(endpoint) && request.method().name().equals("POST")) {
+                final String payload = request.content().toString(CharsetUtil.UTF_8);
+                logger.info("Received payload: {}", payload);
+
+                final List<PredictionInput> predictionInputList = KServeV1HTTPPayloadParser.getInstance().parseRequest(payload);
+                final List<PredictionOutput> predictionOutputs = predictionProvider.predictAsync(predictionInputList).get();
+
+                List<Object> values = new ArrayList<>();
+                for (PredictionOutput predictionOutput : predictionOutputs) {
+                    final List<Output> outputs = predictionOutput.getOutputs();
+                    for (Output output : outputs) {
+                        values.add(output.getValue().asNumber());
+                    }
+                }
+
+                final String response = new ObjectMapper().writeValueAsString(Map.of("predictions", values));
+
+                final FullHttpResponse httpResponse = new DefaultFullHttpResponse(
+                        HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
+                        Unpooled.copiedBuffer(response, CharsetUtil.UTF_8));
+
+                HttpUtil.setContentLength(httpResponse, httpResponse.content().readableBytes());
+                httpResponse.headers().set(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_JSON);
+                ctx.writeAndFlush(httpResponse).addListener(ChannelFutureListener.CLOSE);
+            } else {
+                FullHttpResponse httpResponse = new DefaultFullHttpResponse(
+                        HttpVersion.HTTP_1_1, HttpResponseStatus.NOT_FOUND);
+                ctx.writeAndFlush(httpResponse).addListener(ChannelFutureListener.CLOSE);
+            }
+        }
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        logger.error("Exception caught:", cause);
+        ctx.close();
+    }
+}

--- a/explainability-connectors/src/test/java/org/kie/trustyai/connectors/kserve/v1/KServeV1HTTPMockServer.java
+++ b/explainability-connectors/src/test/java/org/kie/trustyai/connectors/kserve/v1/KServeV1HTTPMockServer.java
@@ -1,0 +1,81 @@
+package org.kie.trustyai.connectors.kserve.v1;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.kie.trustyai.explainability.model.PredictionProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+
+public class KServeV1HTTPMockServer {
+    private static final Logger logger = LoggerFactory.getLogger(KServeV1HTTPMockServer.class);
+
+    private final int port;
+    private final String endpoint;
+    private final AtomicBoolean running = new AtomicBoolean(false);
+    private PredictionProvider predictionProvider;
+    private EventLoopGroup bossGroup;
+    private EventLoopGroup workerGroup;
+    private ChannelFuture channelFuture;
+
+    public KServeV1HTTPMockServer(int port, String endpoint, PredictionProvider predictionProvider) {
+        this.port = port;
+        this.endpoint = endpoint;
+        this.predictionProvider = predictionProvider;
+    }
+
+    public void start() throws Exception {
+        bossGroup = new NioEventLoopGroup();
+        workerGroup = new NioEventLoopGroup();
+
+        try {
+            ServerBootstrap bootstrap = new ServerBootstrap()
+                    .group(bossGroup, workerGroup)
+                    .channel(NioServerSocketChannel.class)
+                    .handler(new LoggingHandler(LogLevel.INFO))
+                    .childHandler(new ChannelInitializer<SocketChannel>() {
+                        @Override
+                        protected void initChannel(SocketChannel ch) throws Exception {
+                            ChannelPipeline pipeline = ch.pipeline();
+                            pipeline.addLast(new HttpServerCodec());
+                            pipeline.addLast(new HttpObjectAggregator(65536));
+                            pipeline.addLast(new JsonRequestHandler(endpoint, predictionProvider));
+                        }
+                    });
+
+            channelFuture = bootstrap.bind(port).sync();
+            logger.info("Starting mock server started on port " + port);
+            running.set(true);
+        } catch (Exception e) {
+            throw new Exception("Failed to start server", e);
+        }
+    }
+
+    public void stop() throws InterruptedException {
+        if (running.compareAndSet(true, false)) {
+            try {
+                channelFuture.channel().close().sync();
+            } finally {
+                bossGroup.shutdownGracefully();
+                workerGroup.shutdownGracefully();
+            }
+        }
+    }
+
+    public void setPredictionProvider(PredictionProvider predictionProvider) {
+        this.predictionProvider = predictionProvider;
+    }
+
+}

--- a/explainability-connectors/src/test/java/org/kie/trustyai/connectors/kserve/v1/KServeV1HTTPMockServer.java
+++ b/explainability-connectors/src/test/java/org/kie/trustyai/connectors/kserve/v1/KServeV1HTTPMockServer.java
@@ -47,7 +47,7 @@ public class KServeV1HTTPMockServer {
                     .handler(new LoggingHandler(LogLevel.INFO))
                     .childHandler(new ChannelInitializer<SocketChannel>() {
                         @Override
-                        protected void initChannel(SocketChannel ch) throws Exception {
+                        protected void initChannel(SocketChannel ch) {
                             ChannelPipeline pipeline = ch.pipeline();
                             pipeline.addLast(new HttpServerCodec());
                             pipeline.addLast(new HttpObjectAggregator(65536));

--- a/explainability-connectors/src/test/java/org/kie/trustyai/connectors/kserve/v1/KServeV1HTTPServerPayloadTest.java
+++ b/explainability-connectors/src/test/java/org/kie/trustyai/connectors/kserve/v1/KServeV1HTTPServerPayloadTest.java
@@ -1,0 +1,127 @@
+package org.kie.trustyai.connectors.kserve.v1;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.kie.trustyai.explainability.model.PredictionOutput;
+import org.kie.trustyai.explainability.utils.models.TestModels;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class KServeV1HTTPServerPayloadTest {
+
+    private static final String endpoint = "/v1/model/infer";
+    private static int port = 50081;
+    private KServeV1HTTPMockServer server;
+
+    private static String generateRequestPayload(List<Object> values) throws JsonProcessingException {
+        // Convert the payload to JSON string
+        final ObjectMapper objectMapper = new ObjectMapper();
+
+        return objectMapper.writeValueAsString(Map.of("instances", values));
+    }
+
+    private static HttpResponse<String> getResponse(String payload) throws IOException, InterruptedException {
+        final HttpClient client = HttpClient.newHttpClient();
+
+        final HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("http://127.0.0.1:" + port + endpoint))
+                .POST(HttpRequest.BodyPublishers.ofString(payload))
+                .header(HttpHeaderNames.CONTENT_TYPE.toString(), HttpHeaderValues.APPLICATION_JSON.toString())
+                .build();
+
+        return client.send(request, HttpResponse.BodyHandlers.ofString());
+    }
+
+    private static int getFreePort() {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to find an available port", e);
+        }
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        port = getFreePort();
+        server = new KServeV1HTTPMockServer(port, endpoint, null);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        server.stop();
+    }
+
+    @Test
+    void testSingleInput() throws Exception {
+        server.setPredictionProvider(TestModels.getSumSkipModel(1));
+        server.start();
+
+        final String payload = generateRequestPayload(List.of(List.of(1.0, 2.0, 3.0)));
+        final HttpResponse<String> response = getResponse(payload);
+
+        assertEquals(200, response.statusCode());
+
+        final List<PredictionOutput> predictionOutputs = KServeV1HTTPPayloadParser.getInstance().parseResponse(response.body());
+
+        assertEquals(1, predictionOutputs.size());
+        assertEquals(1, predictionOutputs.get(0).getOutputs().size());
+        assertEquals(4.0, predictionOutputs.get(0).getOutputs().get(0).getValue().asNumber());
+    }
+
+    @Test
+    void testMultiInput() throws Exception {
+        server.setPredictionProvider(TestModels.getSumSkipModel(1));
+        server.start();
+
+        final String payload = generateRequestPayload(List.of(List.of(1.0, 2.0, 3.0), List.of(2.0, 1.0, 1.0)));
+        final HttpResponse<String> response = getResponse(payload);
+
+        assertEquals(200, response.statusCode());
+
+        final List<PredictionOutput> predictionOutputs = KServeV1HTTPPayloadParser.getInstance().parseResponse(response.body());
+
+        assertEquals(2, predictionOutputs.size());
+        assertEquals(1, predictionOutputs.get(0).getOutputs().size());
+        assertEquals(4.0, predictionOutputs.get(0).getOutputs().get(0).getValue().asNumber());
+        assertEquals(3.0, predictionOutputs.get(1).getOutputs().get(0).getValue().asNumber());
+
+        server.stop();
+    }
+
+    @Test
+    void testMultiOutput() throws Exception {
+        server.setPredictionProvider(TestModels.getFeatureSkipModel(1));
+        server.start();
+
+        final String payload = generateRequestPayload(List.of(List.of(1.0, 2.0, 3.0), List.of(2.0, 1.0, 1.0)));
+        final HttpResponse<String> response = getResponse(payload);
+
+        assertEquals(200, response.statusCode());
+
+        final List<PredictionOutput> predictionOutputs = KServeV1HTTPPayloadParser.getInstance().parseResponse(response.body(), 2);
+
+        assertEquals(2, predictionOutputs.size());
+        assertEquals(Set.of(2), predictionOutputs.stream().map(po -> po.getOutputs().size()).collect(Collectors.toSet()));
+        assertEquals(1.0, predictionOutputs.get(0).getOutputs().get(0).getValue().asNumber());
+        assertEquals(2.0, predictionOutputs.get(1).getOutputs().get(0).getValue().asNumber());
+    }
+
+}

--- a/explainability-connectors/src/test/java/org/kie/trustyai/connectors/kserve/v1/KServeV1HTTPServerPayloadTest.java
+++ b/explainability-connectors/src/test/java/org/kie/trustyai/connectors/kserve/v1/KServeV1HTTPServerPayloadTest.java
@@ -59,7 +59,7 @@ public class KServeV1HTTPServerPayloadTest {
     }
 
     @BeforeEach
-    void setUp() throws Exception {
+    void setUp() {
         port = getFreePort();
         server = new KServeV1HTTPMockServer(port, endpoint, null);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
         <formatter.plugin.version>2.13.0</formatter.plugin.version>
         <impsort.plugin.version>1.9.0</impsort.plugin.version>
 
+        <version.io.netty>4.1.100.Final</version.io.netty>
         <nexus.staging.plugin.version>1.6.6</nexus.staging.plugin.version>
 
         <formatter.skip>false</formatter.skip>


### PR DESCRIPTION
This PR adds:

- KServe v1 HTTP mock server for unit tests
- Additional unit tests to `KServeV1HTTPPredictionProvider`
- Optional outputSize for KServe V1 HTTP payload parser
