### PR TITLE
fix: Consistent default naming for feature parsing

### DIFF
--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/PayloadParser.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/PayloadParser.java
@@ -9,6 +9,10 @@ import org.kie.trustyai.explainability.model.PredictionOutput;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 public abstract class PayloadParser<T> {
+
+    public static final String DEFAULT_INPUT_PREFIX = "inputs";
+    public static final String DEFAULT_OUTPUT_PREFIX = "outputs";
+
     public abstract List<PredictionInput> parseRequest(T request) throws IOException;
 
     public abstract List<PredictionOutput> parseResponse(T response) throws JsonProcessingException;

--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v1/KServeV1HTTPPayloadParser.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v1/KServeV1HTTPPayloadParser.java
@@ -37,7 +37,7 @@ public class KServeV1HTTPPayloadParser extends PayloadParser<String> {
         for (List<Double> featureValues : payload.instances) {
             final List<Feature> features = new ArrayList<>();
             for (int i = 0; i < featureValues.size(); i++) {
-                features.add(new Feature("Feature" + (i + 1), Type.NUMBER, new Value(featureValues.get(i))));
+                features.add(new Feature(DEFAULT_INPUT_PREFIX + "-" + (i + 1), Type.NUMBER, new Value(featureValues.get(i))));
             }
             predictionInputs.add(new PredictionInput(features));
         }
@@ -57,9 +57,9 @@ public class KServeV1HTTPPayloadParser extends PayloadParser<String> {
                 for (Object value : (List<?>) prediction) {
                     final List<Output> outputs = new ArrayList<>();
                     if (value instanceof Integer) {
-                        outputs.add(new Output("value", Type.NUMBER, new Value((int) value), 1.0));
+                        outputs.add(new Output(DEFAULT_OUTPUT_PREFIX + "-0", Type.NUMBER, new Value((int) value), 1.0));
                     } else {
-                        outputs.add(new Output("value", Type.NUMBER, new Value((double) value), 1.0));
+                        outputs.add(new Output(DEFAULT_OUTPUT_PREFIX + "-0", Type.NUMBER, new Value((double) value), 1.0));
                     }
                     predictionOutputs.add(new PredictionOutput(outputs));
                 }
@@ -67,9 +67,9 @@ public class KServeV1HTTPPayloadParser extends PayloadParser<String> {
                 // Handle non-list single values by creating one PredictionOutput per value
                 final List<Output> outputs = new ArrayList<>();
                 if (prediction instanceof Integer) {
-                    outputs.add(new Output("value", Type.NUMBER, new Value((int) prediction), 1.0));
+                    outputs.add(new Output(DEFAULT_OUTPUT_PREFIX, Type.NUMBER, new Value((int) prediction), 1.0));
                 } else {
-                    outputs.add(new Output("value", Type.NUMBER, new Value((double) prediction), 1.0));
+                    outputs.add(new Output(DEFAULT_OUTPUT_PREFIX, Type.NUMBER, new Value((double) prediction), 1.0));
                 }
                 predictionOutputs.add(new PredictionOutput(outputs));
             }

--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v1/KServeV1HTTPPayloadParser.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v1/KServeV1HTTPPayloadParser.java
@@ -37,7 +37,7 @@ public class KServeV1HTTPPayloadParser extends PayloadParser<String> {
         for (List<Double> featureValues : payload.instances) {
             final List<Feature> features = new ArrayList<>();
             for (int i = 0; i < featureValues.size(); i++) {
-                features.add(new Feature(DEFAULT_INPUT_PREFIX + "-" + (i + 1), Type.NUMBER, new Value(featureValues.get(i))));
+                features.add(new Feature(DEFAULT_INPUT_PREFIX + "-" + i, Type.NUMBER, new Value(featureValues.get(i))));
             }
             predictionInputs.add(new PredictionInput(features));
         }
@@ -61,9 +61,9 @@ public class KServeV1HTTPPayloadParser extends PayloadParser<String> {
                 final Object value = predictions.get(i + j);
 
                 if (value instanceof Integer) {
-                    outputs.add(new Output("value", Type.NUMBER, new Value((int) value), 1.0));
+                    outputs.add(new Output(DEFAULT_OUTPUT_PREFIX + "-" + j, Type.NUMBER, new Value((int) value), 1.0));
                 } else {
-                    outputs.add(new Output("value", Type.NUMBER, new Value((double) value), 1.0));
+                    outputs.add(new Output(DEFAULT_OUTPUT_PREFIX + "-" + j, Type.NUMBER, new Value((double) value), 1.0));
                 }
             }
 

--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v1/KServeV1RequestPayload.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v1/KServeV1RequestPayload.java
@@ -1,10 +1,15 @@
 package org.kie.trustyai.connectors.kserve.v1;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
+import org.kie.trustyai.explainability.model.Feature;
 import org.kie.trustyai.explainability.model.FeatureFactory;
 import org.kie.trustyai.explainability.model.PredictionInput;
+
+import static org.kie.trustyai.connectors.kserve.PayloadParser.DEFAULT_INPUT_PREFIX;
 
 public class KServeV1RequestPayload {
 
@@ -19,8 +24,16 @@ public class KServeV1RequestPayload {
     }
 
     public List<PredictionInput> toPredictionInputs() {
-        return instances.stream().map(values -> values.stream().map(value -> FeatureFactory.newNumericalFeature("f", value))
-                .collect(Collectors.toList())).map(PredictionInput::new).collect(Collectors.toList());
+
+        final List<PredictionInput> predictionInputs = new ArrayList<>();
+        for (List<Double> instance : instances) {
+            final int size = instance.size();
+            final List<Feature> features = IntStream.range(0, size)
+                    .mapToObj(i -> FeatureFactory.newNumericalFeature(DEFAULT_INPUT_PREFIX + "-" + i, instance.get(i)))
+                    .collect(Collectors.toUnmodifiableList());
+            predictionInputs.add(new PredictionInput(features));
+        }
+        return predictionInputs;
     }
 
     @Override

--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/PayloadParser.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/PayloadParser.java
@@ -12,6 +12,9 @@ import org.kie.trustyai.explainability.model.*;
 
 import com.google.protobuf.ByteString;
 
+import static org.kie.trustyai.connectors.kserve.PayloadParser.DEFAULT_INPUT_PREFIX;
+import static org.kie.trustyai.connectors.kserve.PayloadParser.DEFAULT_OUTPUT_PREFIX;
+
 public class PayloadParser {
 
     public static PredictionInput requestToInput(ModelInferRequest request, List<String> inputNames) throws IllegalArgumentException {
@@ -200,7 +203,7 @@ public class PayloadParser {
 
     public static PredictionOutput outputFromContentList(List<?> values, Type type, List<String> outputNames) {
         final int size = values.size();
-        List<String> names = outputNames == null ? IntStream.range(0, size).mapToObj(i -> "outputs-" + i).collect(Collectors.toList()) : outputNames;
+        List<String> names = outputNames == null ? IntStream.range(0, size).mapToObj(i -> DEFAULT_OUTPUT_PREFIX + "-" + i).collect(Collectors.toList()) : outputNames;
         if (names.size() != size) {
             throw new IllegalArgumentException("Output names list has an incorrect size (" + names.size() + ", when it should be " + size + ")");
         }
@@ -212,7 +215,7 @@ public class PayloadParser {
 
     public static PredictionInput inputFromContentList(List<?> values, Type type, List<String> outputNames) {
         final int size = values.size();
-        List<String> names = outputNames == null ? IntStream.range(0, size).mapToObj(i -> "inputs-" + i).collect(Collectors.toList()) : outputNames;
+        List<String> names = outputNames == null ? IntStream.range(0, size).mapToObj(i -> DEFAULT_INPUT_PREFIX + "-" + i).collect(Collectors.toList()) : outputNames;
         if (names.size() != size) {
             throw new IllegalArgumentException("Input names list has an incorrect size (" + names.size() + ", when it should be " + size + ")");
         }


### PR DESCRIPTION
This PR adds consistent default feature naming across KServe v1 HTTP and v2 gRPC payload parsers.