### PR TITLE
fix: Add support for listing metric request subsets

### DIFF
--- a/explainability-service/src/main/resources/application-dev.properties
+++ b/explainability-service/src/main/resources/application-dev.properties
@@ -1,0 +1,6 @@
+service.storage-format=MEMORY
+service.data-format=CSV
+service.metrics-schedule=5s
+storage.data-filename=data.csv
+storage.data-folder=/inputs
+service.batch-size=5000

--- a/explainability-service/src/main/resources/application.properties
+++ b/explainability-service/src/main/resources/application.properties
@@ -31,12 +31,6 @@ quarkus.openshift.pvc-volumes.volume.claim-name=trustyai-service-pvc
 
 # Dev
 quarkus.kubernetes.deployment-target=openshift
-%dev.service.storage-format=memory
-%dev.service.data-format=csv
-%dev.service.metrics-schedule=5s
-%dev.storage.data-filename=data.csv
-%dev.storage.data-folder=/inputs
-%dev.service.batch-size=5000
 # Development/testing options
 quarkus.kubernetes.image-pull-policy=Never
 quarkus.kubernetes.env.vars.model-name=example

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/RequestPayloadGenerator.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/RequestPayloadGenerator.java
@@ -28,6 +28,14 @@ public class RequestPayloadGenerator {
         return request;
     }
 
+    public static IdentityMetricRequest identityCorrect() {
+        IdentityMetricRequest request = new IdentityMetricRequest();
+        request.setColumnName("gender");
+        request.setModelId(MODEL_ID);
+
+        return request;
+    }
+
     // multi valued requests disabled until better integrated with ODH UI
     //    public static GroupMetricRequest multiValueCorrect() {
     //        GroupMetricRequest request = new GroupMetricRequest();

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/UniversalListingEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/UniversalListingEndpointTest.java
@@ -72,7 +72,7 @@ class UniversalListingEndpointTest {
                 .post("/metrics/dir/request")
                 .then().statusCode(200).extract().body().as(BaseScheduledResponse.class);
         assertNotNull(firstRequest.getRequestId());
-        UUID first = firstRequest.getRequestId();
+        final UUID first = firstRequest.getRequestId();
 
         final BaseScheduledResponse secondRequest = given()
                 .contentType(ContentType.JSON)
@@ -81,11 +81,108 @@ class UniversalListingEndpointTest {
                 .post("/metrics/spd/request")
                 .then().statusCode(200).extract().body().as(BaseScheduledResponse.class);
         assertNotNull(secondRequest.getRequestId());
-        UUID second = secondRequest.getRequestId();
+        final UUID second = secondRequest.getRequestId();
+
+        // Create an identity metric request
+        final BaseScheduledResponse thirdRequest = given()
+                .contentType(ContentType.JSON)
+                .body(RequestPayloadGenerator.identityCorrect())
+                .when()
+                .post("/metrics/identity/request")
+                .then().statusCode(200).extract().body().as(BaseScheduledResponse.class);
+        assertNotNull(thirdRequest.getRequestId());
+        final UUID third = thirdRequest.getRequestId();
+
 
         ScheduleList scheduleList = given()
                 .when()
                 .get("/metrics/all/requests").peek()
+                .then().statusCode(200).extract().body().as(ScheduleList.class);
+        for (ScheduleRequest sr : scheduleList.requests) {
+            if (sr.id.equals(first)) {
+                assertEquals("DIR", sr.request.getMetricName());
+                GroupMetricRequest gmr = (GroupMetricRequest) sr.request;
+                assertFalse(gmr.privilegedAttribute.isMultipleValued());
+            } else if (sr.id.equals(second)) {
+                assertEquals("SPD", sr.request.getMetricName());
+            }  else if (sr.id.equals(third)) {
+                assertEquals("IDENTITY", sr.request.getMetricName());
+            }
+
+            else {
+                fail();
+            }
+        }
+
+        // ?type=all has the same effect as not query parameter
+        scheduleList = given()
+                .when()
+                .get("/metrics/all/requests?type=all").peek()
+                .then().statusCode(200).extract().body().as(ScheduleList.class);
+        for (ScheduleRequest sr : scheduleList.requests) {
+            if (sr.id.equals(first)) {
+                assertEquals("DIR", sr.request.getMetricName());
+                GroupMetricRequest gmr = (GroupMetricRequest) sr.request;
+                assertFalse(gmr.privilegedAttribute.isMultipleValued());
+            } else if (sr.id.equals(second)) {
+                assertEquals("SPD", sr.request.getMetricName());
+            }  else if (sr.id.equals(third)) {
+                assertEquals("IDENTITY", sr.request.getMetricName());
+            }
+
+            else {
+                fail();
+            }
+        }
+
+        // Correct number of active requests
+        assertEquals(3, scheduleList.requests.size());
+    }
+
+    @DisplayName("Check multi-metrics requests are returned for fairness type")
+    @Test
+    void requestMultipleMetricsFairnessSize() {
+        // No schedule request made yet
+        final ScheduleList emptyList = given()
+                .when()
+                .get("/metrics/all/requests")
+                .then().statusCode(200).extract().body().as(ScheduleList.class);
+        assertEquals(0, emptyList.requests.size());
+
+        // Perform multiple schedule requests
+        final GroupMetricRequest payload = RequestPayloadGenerator.correct();
+        final BaseScheduledResponse firstRequest = given()
+                .contentType(ContentType.JSON)
+                .body(payload)
+                .when()
+                .post("/metrics/dir/request")
+                .then().statusCode(200).extract().body().as(BaseScheduledResponse.class);
+        assertNotNull(firstRequest.getRequestId());
+        final UUID first = firstRequest.getRequestId();
+
+        final BaseScheduledResponse secondRequest = given()
+                .contentType(ContentType.JSON)
+                .body(payload)
+                .when()
+                .post("/metrics/spd/request")
+                .then().statusCode(200).extract().body().as(BaseScheduledResponse.class);
+        assertNotNull(secondRequest.getRequestId());
+        final UUID second = secondRequest.getRequestId();
+
+        // Create an identity metric request
+        final BaseScheduledResponse thirdRequest = given()
+                .contentType(ContentType.JSON)
+                .body(RequestPayloadGenerator.identityCorrect())
+                .when()
+                .post("/metrics/identity/request")
+                .then().statusCode(200).extract().body().as(BaseScheduledResponse.class);
+        assertNotNull(thirdRequest.getRequestId());
+        final UUID third = thirdRequest.getRequestId();
+
+
+        ScheduleList scheduleList = given()
+                .when()
+                .get("/metrics/all/requests?type=fairness").peek()
                 .then().statusCode(200).extract().body().as(ScheduleList.class);
         for (ScheduleRequest sr : scheduleList.requests) {
             if (sr.id.equals(first)) {
@@ -101,6 +198,50 @@ class UniversalListingEndpointTest {
 
         // Correct number of active requests
         assertEquals(2, scheduleList.requests.size());
+    }
+
+    @DisplayName("Check multi-metrics requests with incorrect type")
+    @Test
+    void requestMultipleMetricsIncorrectType() {
+        // No schedule request made yet
+        final ScheduleList emptyList = given()
+                .when()
+                .get("/metrics/all/requests")
+                .then().statusCode(200).extract().body().as(ScheduleList.class);
+        assertEquals(0, emptyList.requests.size());
+
+        // Perform multiple schedule requests
+        final GroupMetricRequest payload = RequestPayloadGenerator.correct();
+        final BaseScheduledResponse firstRequest = given()
+                .contentType(ContentType.JSON)
+                .body(payload)
+                .when()
+                .post("/metrics/dir/request")
+                .then().statusCode(200).extract().body().as(BaseScheduledResponse.class);
+        assertNotNull(firstRequest.getRequestId());
+
+        final BaseScheduledResponse secondRequest = given()
+                .contentType(ContentType.JSON)
+                .body(payload)
+                .when()
+                .post("/metrics/spd/request")
+                .then().statusCode(200).extract().body().as(BaseScheduledResponse.class);
+        assertNotNull(secondRequest.getRequestId());
+
+        // Create an identity metric request
+        final BaseScheduledResponse thirdRequest = given()
+                .contentType(ContentType.JSON)
+                .body(RequestPayloadGenerator.identityCorrect())
+                .when()
+                .post("/metrics/identity/request")
+                .then().statusCode(200).extract().body().as(BaseScheduledResponse.class);
+        assertNotNull(thirdRequest.getRequestId());
+
+        given()
+                .when()
+                .get("/metrics/all/requests?type=foo").peek()
+                .then().statusCode(400);
+
     }
 
 }


### PR DESCRIPTION
This fixes the problem in #554 by adding the ability to filter the metric requests by type. The currently accepted values are:

- `metrics/all/requests` - all requests, working as previously
- `metrics/all/requests?type=all` - same result as `metrics/all/requests`
- `metrics/all/requests?type=fairness` - returns only the fairness/bias (i.e. DIR and SPD)
- All other values produce an HTTP 400 error

