### PR TITLE
RHOAIENG-7036: Add more detail to invalid feature/output name errors

### DIFF
--- a/explainability-service/src/main/java/org/kie/trustyai/service/validators/generic/GenericValidationUtils.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/validators/generic/GenericValidationUtils.java
@@ -75,8 +75,10 @@ public class GenericValidationUtils {
     public static boolean validateColumnName(ConstraintValidatorContext context, Metadata metadata, String modelId, String columnName) {
         String objectName = "feature or output";
         if (!metadata.getOutputSchema().getNameMappedItems().containsKey(columnName) && !metadata.getInputSchema().getNameMappedItems().containsKey(columnName)) {
+            Set<String> nameSet = metadata.getInputSchema().getNameMappedItems().keySet();
+            nameSet.addAll(metadata.getOutputSchema().getNameMappedItems().keySet());
             context.buildConstraintViolationWithTemplate(String.format(
-                    "No %s found with name=%s. %s", objectName, columnName, getEnumerateMessage(metadata.getInputSchema().getNameMappedItems().keySet(), objectName)))
+                    "No %s found with name=%s. %s", objectName, columnName, getEnumerateMessage(nameSet, objectName)))
                     .addPropertyNode(modelId)
                     .addPropertyNode(columnName)
                     .addConstraintViolation();

--- a/explainability-service/src/main/java/org/kie/trustyai/service/validators/generic/GenericValidationUtils.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/validators/generic/GenericValidationUtils.java
@@ -1,5 +1,6 @@
 package org.kie.trustyai.service.validators.generic;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -59,7 +60,7 @@ public class GenericValidationUtils {
         if (!metadata.getOutputSchema().getNameMappedItems().containsKey(columnName)) {
             context.buildConstraintViolationWithTemplate(
                     String.format(
-                            "No %s found with name=%s. %s", objectName, columnName, getEnumerateMessage(metadata.getInputSchema().getNameMappedItems().keySet(), objectName)))
+                            "No %s found with name=%s. %s", objectName, columnName, getEnumerateMessage(metadata.getOutputSchema().getNameMappedItems().keySet(), objectName)))
                     .addPropertyNode(modelId)
                     .addPropertyNode(columnName)
                     .addConstraintViolation();
@@ -75,7 +76,7 @@ public class GenericValidationUtils {
     public static boolean validateColumnName(ConstraintValidatorContext context, Metadata metadata, String modelId, String columnName) {
         String objectName = "feature or output";
         if (!metadata.getOutputSchema().getNameMappedItems().containsKey(columnName) && !metadata.getInputSchema().getNameMappedItems().containsKey(columnName)) {
-            Set<String> nameSet = metadata.getInputSchema().getNameMappedItems().keySet();
+            Set<String> nameSet = new HashSet<>(metadata.getInputSchema().getNameMappedItems().keySet());
             nameSet.addAll(metadata.getOutputSchema().getNameMappedItems().keySet());
             context.buildConstraintViolationWithTemplate(String.format(
                     "No %s found with name=%s. %s", objectName, columnName, getEnumerateMessage(nameSet, objectName)))

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/identity/IdentityEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/identity/IdentityEndpointTest.java
@@ -153,7 +153,25 @@ class IdentityEndpointTest {
                 .when().post()
                 .then()
                 .statusCode(RestResponse.StatusCode.BAD_REQUEST)
-                .body(containsString("No feature or output found with name=THIS_FIELD_DOES_NOT_EXIST"));
+                .body(containsString("No feature or output found with name=THIS_FIELD_DOES_NOT_EXIST. The valid list of feature or output names is as follows: [gender, race, age]"));
+    }
+
+    @Test
+    @DisplayName("IDENTITY request incorrectly typed, many column case")
+    void postIncorrectTypeManyColums() throws JsonProcessingException {
+        datasource.get().reset();
+        storage.get().emptyStorage();
+        final Dataframe dataframe = datasource.get().generateRandomNColumnDataframe(N_SAMPLES, 50);
+        datasource.get().saveDataframe(dataframe, MODEL_ID);
+        final IdentityMetricRequest payload = RequestPayloadGenerator.incorrectIdentityInput();
+
+        given()
+                .contentType(ContentType.JSON)
+                .body(payload)
+                .when().post()
+                .then()
+                .statusCode(RestResponse.StatusCode.BAD_REQUEST)
+                .body(containsString("No feature or output found with name=THIS_FIELD_DOES_NOT_EXIST. The valid list of feature or output names is too long to display (length=50)"));
     }
 
     @Test
@@ -283,9 +301,9 @@ class IdentityEndpointTest {
                 .contentType(ContentType.JSON)
                 .body(wrongPayload)
                 .when()
-                .post("/request")
+                .post("/request").peek()
                 .then().statusCode(RestResponse.StatusCode.BAD_REQUEST)
-                .body(containsString("No feature or output found with name=THIS_FIELD_DOES_NOT_EXIST"));
+                .body(containsString("No feature or output found with name=THIS_FIELD_DOES_NOT_EXIST."));
 
         ScheduleList scheduleList = given()
                 .when()

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/identity/IdentityEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/identity/IdentityEndpointTest.java
@@ -153,7 +153,7 @@ class IdentityEndpointTest {
                 .when().post()
                 .then()
                 .statusCode(RestResponse.StatusCode.BAD_REQUEST)
-                .body(containsString("No feature or output found with name=THIS_FIELD_DOES_NOT_EXIST. The valid list of feature or output names is as follows: [gender, race, age]"));
+                .body(containsString("No feature or output found with name=THIS_FIELD_DOES_NOT_EXIST. The valid list of feature or output names is as follows: [income, gender, race, age]"));
     }
 
     @Test
@@ -168,10 +168,10 @@ class IdentityEndpointTest {
         given()
                 .contentType(ContentType.JSON)
                 .body(payload)
-                .when().post()
+                .when().post().peek()
                 .then()
                 .statusCode(RestResponse.StatusCode.BAD_REQUEST)
-                .body(containsString("No feature or output found with name=THIS_FIELD_DOES_NOT_EXIST. The valid list of feature or output names is too long to display (length=50)"));
+                .body(containsString("No feature or output found with name=THIS_FIELD_DOES_NOT_EXIST. The valid list of feature or output names is too long to display (length=51)"));
     }
 
     @Test


### PR DESCRIPTION
Previously, invalid feature/output messages looked like:

`The supplied metric request details are not valid. No feature or output found with name=THIS_FIELD_DOES_NOT_EXIST.`

They now look like:

`No feature or output found with name=THIS_FIELD_DOES_NOT_EXIST. The valid list of feature or output names is as follows: [gender, race, age]`

or, in the case where the list of names is too long to reasonably enumerate:

`No feature or output found with name=THIS_FIELD_DOES_NOT_EXIST. The valid list of feature or output names is too long to display (length=50), please query TrustyAI's metadata endpoint (/info) to see the list in full.`




Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `FAI-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.3.x] FAI-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

