### PR TITLE
ROHAIENG-7437: Add SHAP streaming background generator

### DIFF
--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/shap/background/StreamingGenerator.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/shap/background/StreamingGenerator.java
@@ -1,0 +1,160 @@
+package org.kie.trustyai.explainability.local.shap.background;
+
+import org.apache.commons.math3.distribution.MultivariateNormalDistribution;
+import org.apache.commons.math3.linear.ArrayRealVector;
+import org.apache.commons.math3.linear.MatrixUtils;
+import org.apache.commons.math3.linear.RealMatrix;
+import org.apache.commons.math3.linear.RealVector;
+import org.kie.trustyai.explainability.model.Feature;
+import org.kie.trustyai.explainability.model.FeatureFactory;
+import org.kie.trustyai.explainability.model.PredictionInput;
+import org.kie.trustyai.statistics.MultivariateOnlineEstimator;
+import org.kie.trustyai.statistics.distributions.gaussian.MultivariateGaussianParameters;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Streaming background generator for SHAP.
+ * <p>
+ * This generator fill a queue with observation and uses an online estimator for the underlying distribution,
+ * assumed Gaussian.
+ * Missing observations are filled with synthetic data from the distribution and an extra set of samples
+ * is produced for diversity.
+ */
+public class StreamingGenerator implements BackgroundGenerator {
+
+    private final int queueSize;
+    private final RealMatrix queue;
+    private final int diversitySize;
+    private final MultivariateOnlineEstimator<MultivariateGaussianParameters> estimator;
+    private final Random random;
+    private final ReplacementType replacementType;
+    private final List<String> featureNames;
+    private int counter = 0;
+
+    /**
+     * Creates a SHAP streaming background generator.
+     * The replacement method use is random.
+     *
+     * @param dimensions    The observation's dimension
+     * @param queueSize     The required number of real observations
+     * @param diversitySize The required number of diversity samples
+     * @param estimator     The estimator to use as a {@link MultivariateOnlineEstimator}
+     */
+    public StreamingGenerator(int dimensions,
+                              int queueSize,
+                              int diversitySize,
+                              MultivariateOnlineEstimator<MultivariateGaussianParameters> estimator) {
+        this(dimensions, queueSize, diversitySize, estimator, ReplacementType.RANDOM, null);
+    }
+
+    /**
+     * Creates a SHAP streaming background generator.
+     *
+     * @param dimensions      The observation's dimension
+     * @param queueSize       The required number of real observations
+     * @param diversitySize   The required number of diversity samples
+     * @param estimator       The estimator to use as a {@link MultivariateOnlineEstimator}
+     * @param replacementType The replacement type as a {@link ReplacementType}
+     * @param featureNames    The list of feature names. If {@code null} a default set of names will be created.
+     */
+    public StreamingGenerator(int dimensions,
+                              int queueSize,
+                              int diversitySize,
+                              MultivariateOnlineEstimator<MultivariateGaussianParameters> estimator,
+                              ReplacementType replacementType,
+                              List<String> featureNames) {
+        if (dimensions <= 0) {
+            throw new IllegalArgumentException("Data dimension must be positive.");
+        }
+        if (queueSize <= 0) {
+            throw new IllegalArgumentException("Queue size must be positive.");
+        }
+
+        this.replacementType = replacementType;
+        this.queueSize = queueSize;
+        this.diversitySize = diversitySize;
+        this.queue = MatrixUtils.createRealMatrix(queueSize, dimensions);
+        this.estimator = estimator;
+        if (Objects.isNull(featureNames)) {
+            this.featureNames = IntStream.range(0, dimensions).mapToObj(i -> "inputs-" + i).collect(Collectors.toUnmodifiableList());
+        } else {
+            this.featureNames = featureNames;
+        }
+
+        this.random = new Random();
+    }
+
+    private PredictionInput vectorToPredictionInput(RealVector vector) {
+        final int size = vector.getDimension();
+        final List<Feature> features = new ArrayList<>();
+        for (int i = 0; i < size; i++) {
+            final Feature feature = FeatureFactory.newNumericalFeature(featureNames.get(i), vector.getEntry(i));
+            features.add(feature);
+        }
+        return new PredictionInput(features);
+    }
+
+    public synchronized void update(RealVector data) {
+        if (counter < queueSize) {
+            queue.setRowVector(counter, data);
+            counter++;
+        } else {
+            if (replacementType == ReplacementType.RANDOM) {
+                final int randomIndex = random.nextInt(queueSize);
+                queue.setRowVector(randomIndex, data);
+            } else if (replacementType == ReplacementType.FIFO) {
+                final RealMatrix queueFIFO = queue.copy();
+                for (int i = 0; i < queueSize - 1; i++) {
+                    queue.setRow(i, queueFIFO.getRow(i + 1));
+                }
+                queue.setRowVector(queueSize - 1, data);
+            }
+        }
+        estimator.update(data);
+    }
+
+    @Override
+    public List<PredictionInput> generate(int n) {
+        final List<PredictionInput> inputs = new ArrayList<>();
+        final MultivariateGaussianParameters parameters = estimator.getParameters();
+        final MultivariateNormalDistribution dataDistribution = new MultivariateNormalDistribution(
+                parameters.getMean().toArray(), parameters.getCovariance().getData());
+        final int totalSize = Math.max(queueSize + diversitySize, n);
+        final int startIndex;
+        final int endIndex;
+        if (counter < queueSize) {
+            endIndex = counter;
+            startIndex = counter;
+        } else {
+            endIndex = queueSize;
+            startIndex = queueSize;
+        }
+        for (int i = 0; i < endIndex; i++) {
+            final RealVector row = queue.getRowVector(i);
+            inputs.add(vectorToPredictionInput(row));
+        }
+        for (int i = startIndex; i < totalSize; i++) {
+            final RealVector syntheticData = new ArrayRealVector(dataDistribution.sample());
+            inputs.add(vectorToPredictionInput(syntheticData));
+        }
+
+
+        return inputs;
+    }
+
+    /**
+     * Generator's replacement type, for when the queue is full.
+     * {@code RANDOM} replaces a previous observation at random.
+     * {@code FIFO} replaces the oldest observation, allowing forgetting.
+     */
+    public enum ReplacementType {
+        RANDOM,
+        FIFO
+    }
+}

--- a/explainability-core/src/main/java/org/kie/trustyai/statistics/MultivariateOnlineEstimator.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/statistics/MultivariateOnlineEstimator.java
@@ -4,5 +4,6 @@ import org.apache.commons.math3.linear.RealVector;
 
 public interface MultivariateOnlineEstimator<T extends DistributionParameters> {
     void update(RealVector data);
+
     T getParameters();
 }

--- a/explainability-core/src/main/java/org/kie/trustyai/statistics/distributions/gaussian/MultivariateGaussianParameters.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/statistics/distributions/gaussian/MultivariateGaussianParameters.java
@@ -27,6 +27,7 @@ public class MultivariateGaussianParameters implements DistributionParameters {
 
     /**
      * Create the parameters of a multivariate Gaussian distribution
+     * 
      * @param mean The mean as a {@link RealVector}
      * @param covariance The covariance as a {@link RealMatrix}
      * @return

--- a/explainability-core/src/main/java/org/kie/trustyai/statistics/estimators/WelfordOnlineEstimator.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/statistics/estimators/WelfordOnlineEstimator.java
@@ -23,6 +23,7 @@ public class WelfordOnlineEstimator implements MultivariateOnlineEstimator<Multi
 
     /**
      * Instantiate a Welford online estimator.
+     * 
      * @param dimension The observation's dimension as a {@code int}
      */
     public WelfordOnlineEstimator(int dimension) {
@@ -56,6 +57,7 @@ public class WelfordOnlineEstimator implements MultivariateOnlineEstimator<Multi
 
     /**
      * Return the estimated parameters of the multivariate Gaussian distribution
+     * 
      * @return Estimated parameters as {@link MultivariateGaussianParameters}
      */
     @Override

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/local/shap/background/StreamingGeneratorTest.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/local/shap/background/StreamingGeneratorTest.java
@@ -1,0 +1,165 @@
+package org.kie.trustyai.explainability.local.shap.background;
+
+import org.apache.commons.math3.distribution.MultivariateNormalDistribution;
+import org.apache.commons.math3.linear.ArrayRealVector;
+import org.apache.commons.math3.linear.MatrixUtils;
+import org.apache.commons.math3.linear.RealMatrix;
+import org.apache.commons.math3.linear.RealVector;
+import org.apache.commons.math3.stat.StatUtils;
+import org.apache.commons.math3.stat.correlation.Covariance;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.kie.trustyai.explainability.model.PredictionInput;
+import org.kie.trustyai.statistics.MultivariateOnlineEstimator;
+import org.kie.trustyai.statistics.distributions.gaussian.MultivariateGaussianParameters;
+import org.kie.trustyai.statistics.estimators.WelfordOnlineEstimator;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class StreamingGeneratorTest {
+
+    static Stream<Arguments> replacementType() {
+        return Stream.of(
+                Arguments.of(StreamingGenerator.ReplacementType.RANDOM),
+                Arguments.of(StreamingGenerator.ReplacementType.FIFO));
+    }
+
+    @DisplayName("Test streaming generator returns correct values")
+    @ParameterizedTest
+    @MethodSource("replacementType")
+    void testGenerate(StreamingGenerator.ReplacementType type) {
+        final int queueSize = 200;
+        final int diversitySize = 50;
+        final int dimension = 4;
+        final int nObs = 1000;
+
+        final MultivariateOnlineEstimator<MultivariateGaussianParameters> estimator = new WelfordOnlineEstimator(
+                dimension);
+
+        final RealVector mean = new ArrayRealVector(new double[]{1.0, 123.0, 90.0, 90000.0});
+        final RealMatrix covariance = MatrixUtils.createRealMatrix(new double[][]{
+                {10.0, 0.0, 0.0, 0.0},
+                {0.0, 52.0, 0.0, 0.0},
+                {0.0, 0.0, 13.9, 0.0},
+                {0.0, 0.0, 0.0, 30.0}
+        });
+
+        final MultivariateNormalDistribution dist = new MultivariateNormalDistribution(mean.toArray(),
+                covariance.getData());
+
+        final double[][] truth = dist.sample(nObs);
+
+        final StreamingGenerator generator = new StreamingGenerator(dimension, queueSize, diversitySize, estimator, type, null);
+
+        final List<PredictionInput> initialBackground = generator.generate(250);
+
+        final RealMatrix bgMatrix = MatrixUtils.createRealMatrix(queueSize + diversitySize, dimension);
+
+        for (int i = 0; i < queueSize + diversitySize; i++) {
+            final double[] values = initialBackground.get(i).getFeatures().stream().mapToDouble(f -> f.getValue().asNumber())
+                    .toArray();
+            bgMatrix.setRow(i, values);
+        }
+
+        final Covariance initialCov = new Covariance(bgMatrix.getData());
+        final RealMatrix initialCalculatedCovariance = initialCov.getCovarianceMatrix();
+        for (int i = 0; i < dimension; i++) {
+            final double calculatedMean = StatUtils.mean(bgMatrix.getColumn(i));
+            assertEquals(0.0, calculatedMean, 2.0, "Initial mean [" + i + "] value is wrong");
+            assertEquals(WelfordOnlineEstimator.DEFAULT_VARIANCE, initialCalculatedCovariance.getEntry(i, i),
+                    WelfordOnlineEstimator.DEFAULT_VARIANCE / 3.0, "Initial variance [" + i + "] value is wrong");
+        }
+
+        for (int i = 0; i < nObs; i++) {
+            generator.update(new ArrayRealVector(truth[i]));
+        }
+
+        final List<PredictionInput> finalBackground = generator.generate(250);
+
+        for (int i = 0; i < queueSize + diversitySize; i++) {
+            final double[] values = finalBackground.get(i).getFeatures().stream().mapToDouble(f -> f.getValue().asNumber())
+                    .toArray();
+            bgMatrix.setRow(i, values);
+        }
+        final Covariance finalCov = new Covariance(bgMatrix.getData());
+        final RealMatrix finalcalculatedCovariance = finalCov.getCovarianceMatrix();
+        for (int i = 0; i < dimension; i++) {
+            final double calculatedMean = StatUtils.mean(bgMatrix.getColumn(i));
+            assertEquals(mean.getEntry(i), calculatedMean, mean.getEntry(i) / 3.0, "Final mean [" + i + "] value is wrong");
+            final double trueVariance = covariance.getEntry(i, i);
+            assertEquals(trueVariance, finalcalculatedCovariance.getEntry(i, i), trueVariance / 3.0, "Final variance " + i + " wrong");
+        }
+
+    }
+
+
+    @DisplayName("Test streaming generator returns correct dimensions")
+    @ParameterizedTest
+    @MethodSource("replacementType")
+    void testDimensions(StreamingGenerator.ReplacementType type) {
+        final int queueSize = 200;
+        final int diversitySize = 50;
+        final int dimension = 4;
+        final int nObs = 1000;
+
+        final MultivariateOnlineEstimator<MultivariateGaussianParameters> estimator = new WelfordOnlineEstimator(
+                dimension);
+
+        final RealVector mean = new ArrayRealVector(new double[]{1.0, 123.0, 90.0, 90000.0});
+        final RealMatrix covariance = MatrixUtils.createRealMatrix(new double[][]{
+                {10.0, 0.0, 0.0, 0.0},
+                {0.0, 52.0, 0.0, 0.0},
+                {0.0, 0.0, 13.9, 0.0},
+                {0.0, 0.0, 0.0, 30.0}
+        });
+
+        final MultivariateNormalDistribution dist = new MultivariateNormalDistribution(mean.toArray(),
+                covariance.getData());
+
+        final double[][] truth = dist.sample(nObs);
+
+        final StreamingGenerator generator = new StreamingGenerator(dimension, queueSize, diversitySize, estimator, type, null);
+
+        final List<PredictionInput> initialBackground = generator.generate(250);
+
+        assertEquals(queueSize + diversitySize, initialBackground.size());
+
+        final List<PredictionInput> initialBackgroundB = generator.generate(450);
+
+        assertEquals(450, initialBackgroundB.size());
+
+        for (int i = 0; i < queueSize - 100; i++) {
+            generator.update(new ArrayRealVector(truth[i]));
+        }
+
+        final List<PredictionInput> finalBackground = generator.generate(250);
+
+        for (int i = 0; i < queueSize; i++) {
+            if (i < queueSize - 100) {
+                assertArrayEquals(truth[i], finalBackground.get(i).getFeatures().stream().mapToDouble(f -> f.getValue().asNumber()).toArray());
+            } else {
+                assertFalse(Arrays.equals(truth[i], finalBackground.get(i).getFeatures().stream().mapToDouble(f -> f.getValue().asNumber()).toArray()));
+            }
+
+        }
+
+        for (int i = queueSize - 100; i < queueSize; i++) {
+            generator.update(new ArrayRealVector(truth[i]));
+        }
+
+        final List<PredictionInput> finalBackgroundC = generator.generate(250);
+
+        for (int i = 0; i < queueSize; i++) {
+            assertArrayEquals(truth[i], finalBackgroundC.get(i).getFeatures().stream().mapToDouble(f -> f.getValue().asNumber()).toArray());
+        }
+
+        final List<PredictionInput> finalBackgroundD = generator.generate(1000);
+        assertEquals(1000, finalBackgroundD.size());
+    }
+}


### PR DESCRIPTION
This PR add a streaming background generator for SHAP.

The generator consists of:

- A fixed sized queue to be populated by real observations
- An online distribution parameter estimator (assumed Gaussian)
- If the queue is not full, generate missing background points from the estimated distribution
- Generate additional samples to increase background diversity
- Past observation replacement either randomly or with "forgetting"
