### PR TITLE
fix: Fix starting index for covariance update

### DIFF
--- a/explainability-core/pom.xml
+++ b/explainability-core/pom.xml
@@ -65,6 +65,23 @@
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <!-- adds support to test listener -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/CounterfactualConfig.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/CounterfactualConfig.java
@@ -16,7 +16,7 @@
 package org.kie.trustyai.explainability.local.counterfactual;
 
 import java.util.UUID;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
 import java.util.function.Function;
 
@@ -27,11 +27,12 @@ import org.optaplanner.core.config.solver.SolverManagerConfig;
 /**
  * Counterfactual explainer configuration parameters.
  */
+
 public class CounterfactualConfig {
 
     private static final double DEFAULT_GOAL_THRESHOLD = 0.01;
 
-    private Executor executor = ForkJoinPool.commonPool();
+    private ExecutorService executor = ForkJoinPool.commonPool();;
     private SolverConfig solverConfig = SolverConfigBuilder.builder().build();
     private double goalThreshold = DEFAULT_GOAL_THRESHOLD;
     private Function<SolverConfig, SolverManager<CounterfactualSolution, UUID>> solverManagerFactory =
@@ -47,11 +48,11 @@ public class CounterfactualConfig {
         return this;
     }
 
-    public Executor getExecutor() {
+    public ExecutorService getExecutor() {
         return executor;
     }
 
-    public CounterfactualConfig withExecutor(Executor executor) {
+    public CounterfactualConfig withExecutor(ExecutorService executor) {
         this.executor = executor;
         return this;
     }

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/CounterfactualExplainer.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/CounterfactualExplainer.java
@@ -127,6 +127,9 @@ public class CounterfactualExplainer implements LocalExplainer<CounterfactualRes
             final CounterfactualGoalCriteria goalCriteria,
             final Long maxRunningTimeSeconds,
             final Consumer<CounterfactualResult> intermediateResultsConsumer) {
+
+        logger.debug("executor in use: " + this.counterfactualConfig.getExecutor());
+
         final AtomicLong sequenceId = new AtomicLong(0);
         Function<UUID, CounterfactualSolution> initial =
                 uuid -> new CounterfactualSolution(entities, originalFeatures, model, UUID.randomUUID(), executionId,

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/score/DefaultCounterfactualScoreCalculator.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/score/DefaultCounterfactualScoreCalculator.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Counterfactual score calculator.
- * The score is implementabled as a {@link BendableBigDecimalScore} with two hard levels and one soft level.
+ * The score is implementable as a {@link BendableBigDecimalScore} with two hard levels and one soft level.
  * The primary hard level penalizes solutions which do not meet the required outcome.
  * The second hard level penalizes solutions which change constrained {@link CounterfactualEntity}.
  * The soft level penalizes solutions according to their distance from the original prediction inputs.

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/shap/background/StreamingGenerator.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/shap/background/StreamingGenerator.java
@@ -1,5 +1,12 @@
 package org.kie.trustyai.explainability.local.shap.background;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import org.apache.commons.math3.distribution.MultivariateNormalDistribution;
 import org.apache.commons.math3.linear.ArrayRealVector;
 import org.apache.commons.math3.linear.MatrixUtils;
@@ -11,20 +18,11 @@ import org.kie.trustyai.explainability.model.PredictionInput;
 import org.kie.trustyai.statistics.MultivariateOnlineEstimator;
 import org.kie.trustyai.statistics.distributions.gaussian.MultivariateGaussianParameters;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Random;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
 /**
  * Streaming background generator for SHAP.
  * <p>
- * This generator fill a queue with observation and uses an online estimator for the underlying distribution,
- * assumed Gaussian.
- * Missing observations are filled with synthetic data from the distribution and an extra set of samples
- * is produced for diversity.
+ * This generator fill a queue with observation and uses an online estimator for the underlying distribution, assumed Gaussian. Missing observations are filled with synthetic data from the
+ * distribution and an extra set of samples is produced for diversity.
  */
 public class StreamingGenerator implements BackgroundGenerator {
 
@@ -38,37 +36,36 @@ public class StreamingGenerator implements BackgroundGenerator {
     private int counter = 0;
 
     /**
-     * Creates a SHAP streaming background generator.
-     * The replacement method use is random.
+     * Creates a SHAP streaming background generator. The replacement method use is random.
      *
-     * @param dimensions    The observation's dimension
-     * @param queueSize     The required number of real observations
+     * @param dimensions The observation's dimension
+     * @param queueSize The required number of real observations
      * @param diversitySize The required number of diversity samples
-     * @param estimator     The estimator to use as a {@link MultivariateOnlineEstimator}
+     * @param estimator The estimator to use as a {@link MultivariateOnlineEstimator}
      */
     public StreamingGenerator(int dimensions,
-                              int queueSize,
-                              int diversitySize,
-                              MultivariateOnlineEstimator<MultivariateGaussianParameters> estimator) {
+            int queueSize,
+            int diversitySize,
+            MultivariateOnlineEstimator<MultivariateGaussianParameters> estimator) {
         this(dimensions, queueSize, diversitySize, estimator, ReplacementType.RANDOM, null);
     }
 
     /**
      * Creates a SHAP streaming background generator.
      *
-     * @param dimensions      The observation's dimension
-     * @param queueSize       The required number of real observations
-     * @param diversitySize   The required number of diversity samples
-     * @param estimator       The estimator to use as a {@link MultivariateOnlineEstimator}
+     * @param dimensions The observation's dimension
+     * @param queueSize The required number of real observations
+     * @param diversitySize The required number of diversity samples
+     * @param estimator The estimator to use as a {@link MultivariateOnlineEstimator}
      * @param replacementType The replacement type as a {@link ReplacementType}
-     * @param featureNames    The list of feature names. If {@code null} a default set of names will be created.
+     * @param featureNames The list of feature names. If {@code null} a default set of names will be created.
      */
     public StreamingGenerator(int dimensions,
-                              int queueSize,
-                              int diversitySize,
-                              MultivariateOnlineEstimator<MultivariateGaussianParameters> estimator,
-                              ReplacementType replacementType,
-                              List<String> featureNames) {
+            int queueSize,
+            int diversitySize,
+            MultivariateOnlineEstimator<MultivariateGaussianParameters> estimator,
+            ReplacementType replacementType,
+            List<String> featureNames) {
         if (dimensions <= 0) {
             throw new IllegalArgumentException("Data dimension must be positive.");
         }
@@ -144,14 +141,11 @@ public class StreamingGenerator implements BackgroundGenerator {
             inputs.add(vectorToPredictionInput(syntheticData));
         }
 
-
         return inputs;
     }
 
     /**
-     * Generator's replacement type, for when the queue is full.
-     * {@code RANDOM} replaces a previous observation at random.
-     * {@code FIFO} replaces the oldest observation, allowing forgetting.
+     * Generator's replacement type, for when the queue is full. {@code RANDOM} replaces a previous observation at random. {@code FIFO} replaces the oldest observation, allowing forgetting.
      */
     public enum ReplacementType {
         RANDOM,

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/shap/background/StreamingGenerator.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/shap/background/StreamingGenerator.java
@@ -1,5 +1,12 @@
 package org.kie.trustyai.explainability.local.shap.background;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import org.apache.commons.math3.distribution.MultivariateNormalDistribution;
 import org.apache.commons.math3.linear.ArrayRealVector;
 import org.apache.commons.math3.linear.MatrixUtils;
@@ -10,13 +17,6 @@ import org.kie.trustyai.explainability.model.FeatureFactory;
 import org.kie.trustyai.explainability.model.PredictionInput;
 import org.kie.trustyai.statistics.MultivariateOnlineEstimator;
 import org.kie.trustyai.statistics.distributions.gaussian.MultivariateGaussianParameters;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Random;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 /**
  * Streaming background generator for SHAP.
@@ -41,34 +41,34 @@ public class StreamingGenerator implements BackgroundGenerator {
      * Creates a SHAP streaming background generator.
      * The replacement method use is random.
      *
-     * @param dimensions    The observation's dimension
-     * @param queueSize     The required number of real observations
+     * @param dimensions The observation's dimension
+     * @param queueSize The required number of real observations
      * @param diversitySize The required number of diversity samples
-     * @param estimator     The estimator to use as a {@link MultivariateOnlineEstimator}
+     * @param estimator The estimator to use as a {@link MultivariateOnlineEstimator}
      */
     public StreamingGenerator(int dimensions,
-                              int queueSize,
-                              int diversitySize,
-                              MultivariateOnlineEstimator<MultivariateGaussianParameters> estimator) {
+            int queueSize,
+            int diversitySize,
+            MultivariateOnlineEstimator<MultivariateGaussianParameters> estimator) {
         this(dimensions, queueSize, diversitySize, estimator, ReplacementType.RANDOM, null);
     }
 
     /**
      * Creates a SHAP streaming background generator.
      *
-     * @param dimensions      The observation's dimension
-     * @param queueSize       The required number of real observations
-     * @param diversitySize   The required number of diversity samples
-     * @param estimator       The estimator to use as a {@link MultivariateOnlineEstimator}
+     * @param dimensions The observation's dimension
+     * @param queueSize The required number of real observations
+     * @param diversitySize The required number of diversity samples
+     * @param estimator The estimator to use as a {@link MultivariateOnlineEstimator}
      * @param replacementType The replacement type as a {@link ReplacementType}
-     * @param featureNames    The list of feature names. If {@code null} a default set of names will be created.
+     * @param featureNames The list of feature names. If {@code null} a default set of names will be created.
      */
     public StreamingGenerator(int dimensions,
-                              int queueSize,
-                              int diversitySize,
-                              MultivariateOnlineEstimator<MultivariateGaussianParameters> estimator,
-                              ReplacementType replacementType,
-                              List<String> featureNames) {
+            int queueSize,
+            int diversitySize,
+            MultivariateOnlineEstimator<MultivariateGaussianParameters> estimator,
+            ReplacementType replacementType,
+            List<String> featureNames) {
         if (dimensions <= 0) {
             throw new IllegalArgumentException("Data dimension must be positive.");
         }
@@ -143,7 +143,6 @@ public class StreamingGenerator implements BackgroundGenerator {
             final RealVector syntheticData = new ArrayRealVector(dataDistribution.sample());
             inputs.add(vectorToPredictionInput(syntheticData));
         }
-
 
         return inputs;
     }

--- a/explainability-core/src/main/java/org/kie/trustyai/statistics/estimators/WelfordOnlineEstimator.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/statistics/estimators/WelfordOnlineEstimator.java
@@ -1,6 +1,5 @@
 package org.kie.trustyai.statistics.estimators;
 
-import org.apache.commons.math3.linear.Array2DRowRealMatrix;
 import org.apache.commons.math3.linear.ArrayRealVector;
 import org.apache.commons.math3.linear.MatrixUtils;
 import org.apache.commons.math3.linear.RealMatrix;
@@ -15,11 +14,11 @@ import org.kie.trustyai.statistics.distributions.gaussian.MultivariateGaussianPa
  */
 public class WelfordOnlineEstimator implements MultivariateOnlineEstimator<MultivariateGaussianParameters> {
 
+    public static double DEFAULT_VARIANCE = 100.0; // Default variance element for the initial estimation
+    private final RealMatrix DEFAULT_COVARIANCE; // Default element for the initial estimation
     private int counter = 0;
     private RealVector mean;
     private RealMatrix covariance;
-    public static double DEFAULT_VARIANCE = 100.0; // Default variance element for the initial estimation
-    private final RealMatrix DEFAULT_COVARIANCE; // Default element for the initial estimation
 
     /**
      * Instantiate a Welford online estimator.
@@ -28,7 +27,7 @@ public class WelfordOnlineEstimator implements MultivariateOnlineEstimator<Multi
      */
     public WelfordOnlineEstimator(int dimension) {
         mean = new ArrayRealVector(dimension);
-        covariance = new Array2DRowRealMatrix(dimension, dimension);
+        covariance = MatrixUtils.createRealIdentityMatrix(dimension).scalarMultiply(DEFAULT_VARIANCE);
         DEFAULT_COVARIANCE = MatrixUtils.createRealIdentityMatrix(dimension).scalarMultiply(DEFAULT_VARIANCE);
     }
 
@@ -62,7 +61,7 @@ public class WelfordOnlineEstimator implements MultivariateOnlineEstimator<Multi
      */
     @Override
     public MultivariateGaussianParameters getParameters() {
-        if (counter < 1) {
+        if (counter < 2) {
             return MultivariateGaussianParameters.create(mean, DEFAULT_COVARIANCE);
         } else {
             return MultivariateGaussianParameters.create(mean, covariance.scalarMultiply(counter / (counter - 1.0)));

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/ThreadDumpOnTimeoutExtension.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/ThreadDumpOnTimeoutExtension.java
@@ -1,0 +1,29 @@
+package org.kie.trustyai.explainability;
+
+import java.io.InputStream;
+import java.lang.management.ManagementFactory;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
+
+import io.micrometer.core.instrument.util.IOUtils;
+
+/**
+ * This Annotation is intended to be used on test cases that might be having timeout issues
+ * To use just annotate the test class with @ExtendWith(ThreadDumpOnTimeoutExtension.class)
+ */
+public class ThreadDumpOnTimeoutExtension implements TestExecutionExceptionHandler {
+
+    @Override
+    public void handleTestExecutionException(ExtensionContext context,
+            Throwable throwable) throws Throwable {
+
+        System.out.println("Thread dump after test execution, PID: " + ManagementFactory.getRuntimeMXBean().getPid());
+        long pid = ManagementFactory.getRuntimeMXBean().getPid();
+        System.out.println("PID: " + pid);
+        InputStream in = Runtime.getRuntime().exec("jstack" + " " + pid).getInputStream();
+        System.out.println(IOUtils.toString(in));
+        System.out.println("################## finished");
+        throw throwable;
+    }
+}

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/local/counterfactual/CounterfactualExplainerTest.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/local/counterfactual/CounterfactualExplainerTest.java
@@ -33,9 +33,11 @@ import java.util.stream.Stream;
 import org.apache.commons.math3.distribution.NormalDistribution;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.kie.trustyai.explainability.Config;
+import org.kie.trustyai.explainability.ThreadDumpOnTimeoutExtension;
 import org.kie.trustyai.explainability.local.counterfactual.entities.CategoricalNumericalEntity;
 import org.kie.trustyai.explainability.local.counterfactual.entities.CounterfactualEntity;
 import org.kie.trustyai.explainability.local.counterfactual.goal.CounterfactualGoalCriteria;
@@ -87,6 +89,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(ThreadDumpOnTimeoutExtension.class)
 class CounterfactualExplainerTest {
 
     private static final Logger logger =
@@ -147,6 +150,7 @@ class CounterfactualExplainerTest {
     @ParameterizedTest
     @ValueSource(ints = { 0, 1, 2 })
     void testCounterfactualMatch(int seed) throws ExecutionException, InterruptedException, TimeoutException {
+
         Random random = new Random();
         random.setSeed(seed);
 

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/local/shap/background/CounterfactualGeneratorTest.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/local/shap/background/CounterfactualGeneratorTest.java
@@ -22,9 +22,11 @@ import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.kie.trustyai.explainability.ThreadDumpOnTimeoutExtension;
+import org.kie.trustyai.explainability.local.counterfactual.CounterfactualUtils;
 import org.kie.trustyai.explainability.model.Feature;
 import org.kie.trustyai.explainability.model.Output;
 import org.kie.trustyai.explainability.model.PredictionInput;
@@ -37,13 +39,14 @@ import org.kie.trustyai.explainability.utils.models.TestModels;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(ThreadDumpOnTimeoutExtension.class)
 class CounterfactualGeneratorTest {
     int N_COUNTERFACTUALS_TO_GENERATE = 10;
 
     @ParameterizedTest
     @ValueSource(ints = { 0, 1 })
-    @Disabled("https://github.com/trustyai-explainability/trustyai-explainability/issues/474")
     void testDefaultGeneration(int seed) throws ExecutionException, InterruptedException, TimeoutException {
+
         List<PredictionInput> seeds = new ArrayList<>();
         Random rn = new Random(seed);
 
@@ -59,16 +62,19 @@ class CounterfactualGeneratorTest {
             }
             seeds.add(new PredictionInput(features));
         }
-
         // given some arbitrary linear model
         PredictionProvider model = TestModels.getLinearModel(new double[] { 5., 0., 1., 25., -5. });
 
         // generate a background such that f(bg) == 0 for all bg in the backgrounds
         PredictionOutput goal = new PredictionOutput(
                 List.of(new Output("linear-sum", Type.NUMBER, new Value(0.), 0d)));
-        List<PredictionInput> background = CounterfactualGenerator.builder()
+        List<PredictionInput> background;
+
+        background = CounterfactualGenerator.builder()
                 .withModel(model)
-                .withTimeoutSeconds(5)
+                // Run the counterfactual on a different thread pool
+                .withCounterfactualConfig(CounterfactualUtils.getCounterfactualConfig((long) seed, 10_000L))
+                .withTimeoutSeconds(10)
                 .withStepCount(10_000L)
                 .withGoalThreshold(.01)
                 .withRandom(rn)
@@ -77,10 +83,12 @@ class CounterfactualGeneratorTest {
         assertEquals(N_COUNTERFACTUALS_TO_GENERATE, background.size());
 
         List<PredictionOutput> fnull = model.predictAsync(background).get();
+
         // make sure the fnull is within the default goal of .01
         for (PredictionOutput output : fnull) {
             assertEquals(0., output.getOutputs().get(0).getValue().asNumber(), .05);
         }
+
     }
 
     @ParameterizedTest
@@ -111,7 +119,9 @@ class CounterfactualGeneratorTest {
         }
         List<PredictionInput> background = CounterfactualGenerator.builder()
                 .withModel(model)
-                .withTimeoutSeconds(5)
+                // Run the counterfactual on a different thread pool
+                .withCounterfactualConfig(CounterfactualUtils.getCounterfactualConfig((long) seed, 30_000L))
+                .withTimeoutSeconds(10)
                 .withStepCount(30_000L)
                 .withGoalThreshold(0.01)
                 .withRandom(rn)
@@ -151,7 +161,9 @@ class CounterfactualGeneratorTest {
         }
         List<PredictionInput> background = CounterfactualGenerator.builder()
                 .withModel(model)
-                .withTimeoutSeconds(5)
+                // Run the counterfactual on a different thread pool
+                .withCounterfactualConfig(CounterfactualUtils.getCounterfactualConfig((long) seed, 30_000L))
+                .withTimeoutSeconds(10)
                 .withStepCount(30_000L)
                 .withGoalThreshold(0.01)
                 .withRandom(rn)

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/local/shap/background/StreamingGeneratorTest.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/local/shap/background/StreamingGeneratorTest.java
@@ -1,5 +1,9 @@
 package org.kie.trustyai.explainability.local.shap.background;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
 import org.apache.commons.math3.distribution.MultivariateNormalDistribution;
 import org.apache.commons.math3.linear.ArrayRealVector;
 import org.apache.commons.math3.linear.MatrixUtils;
@@ -15,10 +19,6 @@ import org.kie.trustyai.explainability.model.PredictionInput;
 import org.kie.trustyai.statistics.MultivariateOnlineEstimator;
 import org.kie.trustyai.statistics.distributions.gaussian.MultivariateGaussianParameters;
 import org.kie.trustyai.statistics.estimators.WelfordOnlineEstimator;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -42,12 +42,12 @@ class StreamingGeneratorTest {
         final MultivariateOnlineEstimator<MultivariateGaussianParameters> estimator = new WelfordOnlineEstimator(
                 dimension);
 
-        final RealVector mean = new ArrayRealVector(new double[]{1.0, 123.0, 90.0, 90000.0});
-        final RealMatrix covariance = MatrixUtils.createRealMatrix(new double[][]{
-                {10.0, 0.0, 0.0, 0.0},
-                {0.0, 52.0, 0.0, 0.0},
-                {0.0, 0.0, 13.9, 0.0},
-                {0.0, 0.0, 0.0, 30.0}
+        final RealVector mean = new ArrayRealVector(new double[] { 1.0, 123.0, 90.0, 90000.0 });
+        final RealMatrix covariance = MatrixUtils.createRealMatrix(new double[][] {
+                { 10.0, 0.0, 0.0, 0.0 },
+                { 0.0, 52.0, 0.0, 0.0 },
+                { 0.0, 0.0, 13.9, 0.0 },
+                { 0.0, 0.0, 0.0, 30.0 }
         });
 
         final MultivariateNormalDistribution dist = new MultivariateNormalDistribution(mean.toArray(),
@@ -98,6 +98,23 @@ class StreamingGeneratorTest {
 
     }
 
+    @DisplayName("Test streaming generator with non-convergent values returns correct values ")
+    @ParameterizedTest
+    @MethodSource("replacementType")
+    void testGenerateNonConvergent(StreamingGenerator.ReplacementType type) {
+        final int queueSize = 200;
+        final int diversitySize = 50;
+
+        final double[] data = new double[] { 404, 1, 1, 20, 1, 144481.56, 1, 56482.48, 1, 372, 0, 0, 1, 2 };
+
+        final MultivariateOnlineEstimator<MultivariateGaussianParameters> estimator = new WelfordOnlineEstimator(
+                data.length);
+
+        final StreamingGenerator generator = new StreamingGenerator(data.length, queueSize, diversitySize, estimator, type, null);
+        generator.update(new ArrayRealVector(data));
+
+       assertNotNull(generator.generate(queueSize + diversitySize));
+    }
 
     @DisplayName("Test streaming generator returns correct dimensions")
     @ParameterizedTest
@@ -111,12 +128,12 @@ class StreamingGeneratorTest {
         final MultivariateOnlineEstimator<MultivariateGaussianParameters> estimator = new WelfordOnlineEstimator(
                 dimension);
 
-        final RealVector mean = new ArrayRealVector(new double[]{1.0, 123.0, 90.0, 90000.0});
-        final RealMatrix covariance = MatrixUtils.createRealMatrix(new double[][]{
-                {10.0, 0.0, 0.0, 0.0},
-                {0.0, 52.0, 0.0, 0.0},
-                {0.0, 0.0, 13.9, 0.0},
-                {0.0, 0.0, 0.0, 30.0}
+        final RealVector mean = new ArrayRealVector(new double[] { 1.0, 123.0, 90.0, 90000.0 });
+        final RealMatrix covariance = MatrixUtils.createRealMatrix(new double[][] {
+                { 10.0, 0.0, 0.0, 0.0 },
+                { 0.0, 52.0, 0.0, 0.0 },
+                { 0.0, 0.0, 13.9, 0.0 },
+                { 0.0, 0.0, 0.0, 30.0 }
         });
 
         final MultivariateNormalDistribution dist = new MultivariateNormalDistribution(mean.toArray(),

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/local/shap/background/StreamingGeneratorTest.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/local/shap/background/StreamingGeneratorTest.java
@@ -20,6 +20,10 @@ import org.kie.trustyai.statistics.MultivariateOnlineEstimator;
 import org.kie.trustyai.statistics.distributions.gaussian.MultivariateGaussianParameters;
 import org.kie.trustyai.statistics.estimators.WelfordOnlineEstimator;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class StreamingGeneratorTest {
@@ -97,6 +101,7 @@ class StreamingGeneratorTest {
         }
 
     }
+
 
     @DisplayName("Test streaming generator returns correct dimensions")
     @ParameterizedTest

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/local/shap/background/StreamingGeneratorTest.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/local/shap/background/StreamingGeneratorTest.java
@@ -1,5 +1,9 @@
 package org.kie.trustyai.explainability.local.shap.background;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
 import org.apache.commons.math3.distribution.MultivariateNormalDistribution;
 import org.apache.commons.math3.linear.ArrayRealVector;
 import org.apache.commons.math3.linear.MatrixUtils;
@@ -15,10 +19,6 @@ import org.kie.trustyai.explainability.model.PredictionInput;
 import org.kie.trustyai.statistics.MultivariateOnlineEstimator;
 import org.kie.trustyai.statistics.distributions.gaussian.MultivariateGaussianParameters;
 import org.kie.trustyai.statistics.estimators.WelfordOnlineEstimator;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -42,12 +42,12 @@ class StreamingGeneratorTest {
         final MultivariateOnlineEstimator<MultivariateGaussianParameters> estimator = new WelfordOnlineEstimator(
                 dimension);
 
-        final RealVector mean = new ArrayRealVector(new double[]{1.0, 123.0, 90.0, 90000.0});
-        final RealMatrix covariance = MatrixUtils.createRealMatrix(new double[][]{
-                {10.0, 0.0, 0.0, 0.0},
-                {0.0, 52.0, 0.0, 0.0},
-                {0.0, 0.0, 13.9, 0.0},
-                {0.0, 0.0, 0.0, 30.0}
+        final RealVector mean = new ArrayRealVector(new double[] { 1.0, 123.0, 90.0, 90000.0 });
+        final RealMatrix covariance = MatrixUtils.createRealMatrix(new double[][] {
+                { 10.0, 0.0, 0.0, 0.0 },
+                { 0.0, 52.0, 0.0, 0.0 },
+                { 0.0, 0.0, 13.9, 0.0 },
+                { 0.0, 0.0, 0.0, 30.0 }
         });
 
         final MultivariateNormalDistribution dist = new MultivariateNormalDistribution(mean.toArray(),
@@ -98,7 +98,6 @@ class StreamingGeneratorTest {
 
     }
 
-
     @DisplayName("Test streaming generator returns correct dimensions")
     @ParameterizedTest
     @MethodSource("replacementType")
@@ -111,12 +110,12 @@ class StreamingGeneratorTest {
         final MultivariateOnlineEstimator<MultivariateGaussianParameters> estimator = new WelfordOnlineEstimator(
                 dimension);
 
-        final RealVector mean = new ArrayRealVector(new double[]{1.0, 123.0, 90.0, 90000.0});
-        final RealMatrix covariance = MatrixUtils.createRealMatrix(new double[][]{
-                {10.0, 0.0, 0.0, 0.0},
-                {0.0, 52.0, 0.0, 0.0},
-                {0.0, 0.0, 13.9, 0.0},
-                {0.0, 0.0, 0.0, 30.0}
+        final RealVector mean = new ArrayRealVector(new double[] { 1.0, 123.0, 90.0, 90000.0 });
+        final RealMatrix covariance = MatrixUtils.createRealMatrix(new double[][] {
+                { 10.0, 0.0, 0.0, 0.0 },
+                { 0.0, 52.0, 0.0, 0.0 },
+                { 0.0, 0.0, 13.9, 0.0 },
+                { 0.0, 0.0, 0.0, 30.0 }
         });
 
         final MultivariateNormalDistribution dist = new MultivariateNormalDistribution(mean.toArray(),

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/utils/ValidationUtilsTest.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/utils/ValidationUtilsTest.java
@@ -25,7 +25,15 @@ import org.junit.jupiter.api.Test;
 import org.kie.trustyai.explainability.TestConfig;
 import org.kie.trustyai.explainability.local.lime.LimeConfig;
 import org.kie.trustyai.explainability.local.lime.LimeExplainer;
-import org.kie.trustyai.explainability.model.*;
+import org.kie.trustyai.explainability.model.Feature;
+import org.kie.trustyai.explainability.model.FeatureFactory;
+import org.kie.trustyai.explainability.model.PerturbationContext;
+import org.kie.trustyai.explainability.model.Prediction;
+import org.kie.trustyai.explainability.model.PredictionInput;
+import org.kie.trustyai.explainability.model.PredictionOutput;
+import org.kie.trustyai.explainability.model.PredictionProvider;
+import org.kie.trustyai.explainability.model.SimplePrediction;
+import org.kie.trustyai.explainability.model.Type;
 import org.kie.trustyai.explainability.utils.models.TestModels;
 
 class ValidationUtilsTest {

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/UniversalListingEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/UniversalListingEndpointTest.java
@@ -93,7 +93,6 @@ class UniversalListingEndpointTest {
         assertNotNull(thirdRequest.getRequestId());
         final UUID third = thirdRequest.getRequestId();
 
-
         ScheduleList scheduleList = given()
                 .when()
                 .get("/metrics/all/requests").peek()
@@ -105,7 +104,7 @@ class UniversalListingEndpointTest {
                 assertFalse(gmr.privilegedAttribute.isMultipleValued());
             } else if (sr.id.equals(second)) {
                 assertEquals("SPD", sr.request.getMetricName());
-            }  else if (sr.id.equals(third)) {
+            } else if (sr.id.equals(third)) {
                 assertEquals("IDENTITY", sr.request.getMetricName());
             }
 
@@ -126,7 +125,7 @@ class UniversalListingEndpointTest {
                 assertFalse(gmr.privilegedAttribute.isMultipleValued());
             } else if (sr.id.equals(second)) {
                 assertEquals("SPD", sr.request.getMetricName());
-            }  else if (sr.id.equals(third)) {
+            } else if (sr.id.equals(third)) {
                 assertEquals("IDENTITY", sr.request.getMetricName());
             }
 
@@ -178,7 +177,6 @@ class UniversalListingEndpointTest {
                 .then().statusCode(200).extract().body().as(BaseScheduledResponse.class);
         assertNotNull(thirdRequest.getRequestId());
         final UUID third = thirdRequest.getRequestId();
-
 
         ScheduleList scheduleList = given()
                 .when()

--- a/pom.xml
+++ b/pom.xml
@@ -39,12 +39,13 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-        <version.org.slf4j>1.7.30</version.org.slf4j>
+        <version.org.slf4j>1.7.36</version.org.slf4j>
         <version.com.fasterxml.jackson.databind>2.13.4.2</version.com.fasterxml.jackson.databind>
         <version.org.apache.commons.commons-lang3>3.12.0</version.org.apache.commons.commons-lang3>
         <version.org.apache.commons.commons-csv>1.9.0</version.org.apache.commons.commons-csv>
         <version.org.apache.opennlp>1.9.2</version.org.apache.opennlp>
         <version.org.junit.jupiter>5.9.1</version.org.junit.jupiter>
+        <version.org.junit.platform>1.9.0</version.org.junit.platform>
         <version.org.mockito>4.8.0</version.org.mockito>
         <version.org.assertj>3.22.0</version.org.assertj>
         <version.org.awaitility>4.2.0</version.org.awaitility>
@@ -52,7 +53,7 @@
         <version.org.optaplanner>8.30.0.Final</version.org.optaplanner>
         <version.org.kie.kogito>1.30.0.Final</version.org.kie.kogito>
 
-        <version.surefire.plugin>2.22.2</version.surefire.plugin> <!-- minimum required by JUnit 5 -->
+        <version.surefire.plugin>3.0.0</version.surefire.plugin> <!-- minimum required by JUnit 5 -->
         <version.shade.plugin>3.4.0</version.shade.plugin> <!-- minimum required by JUnit 5 -->
 
         <kogito.formatter.version>${version.org.kie.kogito}</kogito.formatter.version>
@@ -108,7 +109,16 @@
                 <version>${version.org.junit.jupiter}</version>
                 <scope>test</scope>
             </dependency>
-
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>${version.org.junit.jupiter}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-launcher</artifactId>
+                <version>${version.org.junit.platform}</version>
+            </dependency>
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>


### PR DESCRIPTION
See [RHOAIENG-8257](https://issues.redhat.com/browse/RHOAIENG-8257).

This PR fixes a problem where a non-convergence error would occur when sampling the synthetic background with only one sample.
This was caused:
- Initial covariance not properly initialised
- Covariance calculation should start only when n=2