### PR TITLE
RHOAIENG-4962: Add HTTPS connection support

### DIFF
--- a/explainability-service/src/main/resources/application.properties
+++ b/explainability-service/src/main/resources/application.properties
@@ -1,5 +1,10 @@
 quarkus.http.host=0.0.0.0
 quarkus.http.http2=false
+# Enable HTTPS
+quarkus.http.ssl-port=4443
+# Set the path to the certificate and key files
+quarkus.http.ssl.certificate.files=/etc/tls/internal/tls.crt
+quarkus.http.ssl.certificate.key-files=/etc/tls/internal/tls.key
 quarkus.container-image.builder=docker
 quarkus.container-image.build=false
 quarkus.container-image.group=trustyai
@@ -28,7 +33,6 @@ quarkus.openshift.env.mapping.service-batch-size.from-configmap=trustyai-config
 quarkus.openshift.env.mapping.service-batch-size.with-key=service_batch_size
 quarkus.openshift.mounts.volume.path=/inputs
 quarkus.openshift.pvc-volumes.volume.claim-name=trustyai-service-pvc
-
 # Dev
 quarkus.kubernetes.deployment-target=openshift
 # Development/testing options
@@ -38,26 +42,21 @@ quarkus.kubernetes.env.vars.storage-format=RANDOM_TEST
 quarkus.kubernetes-client.devservices.enabled=false
 # Misc
 quarkus.banner.path=banner.txt
-
 # HTTP
 quarkus.http.handle-100-continue-automatically=true
-
 # Feature flags
 # odh endpoints
 %odh.endpoints.fairness=enable
 %odh.endpoints.drift=enable
 %odh.endpoints.explainers.local=enable
 %odh.endpoints.explainers.global=enable
-
 # rhoai endpoints
 %rhoai.endpoints.fairness=disable
 %rhoai.endpoints.drift=enable
 %rhoai.endpoints.explainers.local=disable
 %rhoai.endpoints.explainers.global=disable
-
 # test profile endpoint overrides
 %test.endpoints.data.download=enable
-
 # defaults
 endpoints.fairness=enable
 endpoints.drift=enable

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/explainers/ExplainersEndpointTestProfile.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/explainers/ExplainersEndpointTestProfile.java
@@ -23,6 +23,8 @@ public class ExplainersEndpointTestProfile implements QuarkusTestProfile {
         overrides.put("service.metrics-schedule", "5s");
         overrides.put("storage.data-filename", "data.csv");
         overrides.put("storage.data-folder", "/inputs");
+        overrides.put("quarkus.http.ssl.certificate.files", "");
+        overrides.put("quarkus.http.ssl.certificate.key-files", "");
         return overrides;
     }
 

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/MetricsEndpointTestProfile.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/MetricsEndpointTestProfile.java
@@ -23,6 +23,8 @@ public class MetricsEndpointTestProfile implements QuarkusTestProfile {
         overrides.put("storage.data-filename", "data.csv");
         overrides.put("storage.data-folder", "/inputs");
         overrides.put("service.batch-size", "5000");
+        overrides.put("quarkus.http.ssl.certificate.files", "");
+        overrides.put("quarkus.http.ssl.certificate.key-files", "");
         return overrides;
     }
 

--- a/explainability-service/src/test/java/org/kie/trustyai/service/profiles/MemoryTestProfile.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/profiles/MemoryTestProfile.java
@@ -23,6 +23,8 @@ public class MemoryTestProfile implements QuarkusTestProfile {
         overrides.put("storage.data-filename", "data.csv");
         overrides.put("storage.data-folder", "/inputs");
         overrides.put("service.batch-size", "5000");
+        overrides.put("quarkus.http.ssl.certificate.files", "");
+        overrides.put("quarkus.http.ssl.certificate.key-files", "");
         return overrides;
     }
 

--- a/explainability-service/src/test/java/org/kie/trustyai/service/profiles/PVCTestProfile.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/profiles/PVCTestProfile.java
@@ -23,6 +23,8 @@ public class PVCTestProfile implements QuarkusTestProfile {
         overrides.put("storage.data-filename", "data.csv");
         overrides.put("storage.data-folder", "/inputs");
         overrides.put("service.batch-size", "5000");
+        overrides.put("quarkus.http.ssl.certificate.files", "");
+        overrides.put("quarkus.http.ssl.certificate.key-files", "");
         return overrides;
     }
 


### PR DESCRIPTION
See [RHOAIENG-4962](https://issues.redhat.com/browse/RHOAIENG-4962).

Add HTTPS endpoint support for the TrustyAI service.