### PR TITLE
RHOAIENG-8993: Support for KServe v2 HTTP protocol as a PredictionProvider 

### DIFF
--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v1/KServeV1ResponsePayload.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v1/KServeV1ResponsePayload.java
@@ -2,14 +2,20 @@ package org.kie.trustyai.connectors.kserve.v1;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class KServeV1ResponsePayload {
     @JsonProperty("predictions")
     private List<Object> predictions;
 
     public List<Object> getPredictions() {
         return predictions;
+    }
+
+    public KServeV1ResponsePayload() {
+        // NO-OP
     }
 
     public void setPredictions(List<Object> predictions) {

--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/KServeV2HTTPPayloadParser.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/KServeV2HTTPPayloadParser.java
@@ -1,0 +1,79 @@
+package org.kie.trustyai.connectors.kserve.v2;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kie.trustyai.connectors.kserve.PayloadParser;
+import org.kie.trustyai.explainability.model.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class KServeV2HTTPPayloadParser extends PayloadParser<String> {
+    private static final Logger logger = LoggerFactory.getLogger(KServeV2HTTPPayloadParser.class);
+    private static KServeV2HTTPPayloadParser instance;
+    private final ObjectMapper mapper;
+
+    private KServeV2HTTPPayloadParser() {
+        this.mapper = new ObjectMapper();
+    }
+
+    public static synchronized KServeV2HTTPPayloadParser getInstance() {
+        if (instance == null) {
+            instance = new KServeV2HTTPPayloadParser();
+        }
+        return instance;
+    }
+
+    @Override
+    public List<PredictionInput> parseRequest(String json) throws IOException {
+        final KServeV2RequestPayload payload = mapper.readValue(json, KServeV2RequestPayload.class);
+        final List<PredictionInput> predictionInputs = new ArrayList<>();
+
+        // Process each list of instances as a separate PredictionInput
+        for (List<Double> featureValues : payload.inputs.get(0).data) {
+            final List<Feature> features = new ArrayList<>();
+            for (int i = 0; i < featureValues.size(); i++) {
+                features.add(new Feature(DEFAULT_INPUT_PREFIX + "-" + i, Type.NUMBER, new Value(featureValues.get(i))));
+            }
+            predictionInputs.add(new PredictionInput(features));
+        }
+
+        return predictionInputs;
+    }
+
+    @Override
+    public List<PredictionOutput> parseResponse(String jsonResponse, int outputShape) throws JsonProcessingException {
+        logger.debug("Parsing response " + jsonResponse);
+        final KServeV2ResponsePayload response = mapper.readValue(jsonResponse, KServeV2ResponsePayload.class);
+        final List<PredictionOutput> predictionOutputs = new ArrayList<>();
+
+        final KServeV2ResponsePayload.Outputs koutput = response.getOutputs().get(0);
+
+        final List<?> predictions = koutput.data;
+        final int shape = koutput.shape.get(1);
+        final int numPredictions = predictions.size();
+
+        for (int i = 0; i < numPredictions; i += shape) {
+            final List<Output> outputs = new ArrayList<>();
+
+            for (int j = 0; j < outputShape && i + j < numPredictions; j++) {
+                final Object value = predictions.get(i + j);
+
+                if (value instanceof Integer) {
+                    outputs.add(new Output(DEFAULT_OUTPUT_PREFIX + "-" + j, Type.NUMBER, new Value(value), 1.0));
+                } else {
+                    outputs.add(new Output(DEFAULT_OUTPUT_PREFIX + "-" + j, Type.NUMBER, new Value(value), 1.0));
+                }
+            }
+
+            predictionOutputs.add(new PredictionOutput(outputs));
+        }
+
+        return predictionOutputs;
+    }
+
+}

--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/KServeV2HTTPPredictionProvider.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/KServeV2HTTPPredictionProvider.java
@@ -1,0 +1,93 @@
+package org.kie.trustyai.connectors.kserve.v2;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.stream.Collectors;
+
+import org.kie.trustyai.connectors.kserve.AbstractKServePredictionProvider;
+import org.kie.trustyai.connectors.kserve.KServeDatatype;
+import org.kie.trustyai.explainability.model.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Wraps a KServe v2-compatible HTTP model server as a TrustyAI {@link PredictionProvider}
+ */
+public class KServeV2HTTPPredictionProvider extends AbstractKServePredictionProvider implements PredictionProvider {
+
+    private static final Logger logger = LoggerFactory.getLogger(KServeV2HTTPPredictionProvider.class);
+    private final HttpClient httpClient;
+    private final String endpointUrl;
+    private final int outputShape;
+
+    public KServeV2HTTPPredictionProvider(String inputName, List<String> outputNames, String endpointUrl) {
+        this(inputName, outputNames, endpointUrl, 1);
+    }
+
+    public KServeV2HTTPPredictionProvider(String inputName, List<String> outputNames, String endpointUrl, int outputShape) {
+        super(outputNames, inputName);
+        this.httpClient = HttpClient.newHttpClient();
+        this.endpointUrl = endpointUrl;
+        this.outputShape = outputShape;
+    }
+
+
+    public CompletableFuture<List<PredictionOutput>> predictAsync(List<PredictionInput> inputs) {
+        final ObjectMapper mapper = new ObjectMapper();
+
+        final List<List<Double>> instances = inputs.stream()
+                .map(input -> input.getFeatures().stream()
+                        .map(Feature::getValue).map(Value::asNumber)
+                        .collect(Collectors.toList()))
+                .collect(Collectors.toList());
+
+        final KServeV2RequestPayload.Inputs kinputs = new KServeV2RequestPayload.Inputs();
+        kinputs.data = instances;
+        kinputs.name = this.inputName;
+        kinputs.shape = List.of(instances.size(), instances.get(0).size());
+        kinputs.datatype = KServeDatatype.FP64;
+        final KServeV2RequestPayload wrapper = new KServeV2RequestPayload(List.of(kinputs));
+
+        // Convert to JSON
+        try {
+            final String json = mapper.writeValueAsString(wrapper);
+            logger.debug("Sending " + json + " to " + endpointUrl);
+            final HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(endpointUrl))
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(json))
+                    .build();
+
+            return httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                    .thenApply(HttpResponse::body)
+                    .thenApply(response -> {
+                        try {
+                            return KServeV2HTTPPayloadParser.getInstance().parseResponse(response, outputShape);
+                        } catch (JsonProcessingException e) {
+                            throw new CompletionException(e);
+                        }
+                    })
+                    .handle((result, throwable) -> {
+                        if (throwable != null) {
+                            logger.error("Error processing response: " + throwable.getMessage());
+                            throw new RuntimeException("Error parsing server response", throwable);
+                        }
+                        return result;
+                    });
+
+        } catch (JsonProcessingException e) {
+            final CompletableFuture<List<PredictionOutput>> future = new CompletableFuture<>();
+            future.completeExceptionally(e);
+            return future;
+        }
+    }
+
+}

--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/KServeV2HTTPPredictionProvider.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/KServeV2HTTPPredictionProvider.java
@@ -43,9 +43,9 @@ public class KServeV2HTTPPredictionProvider extends AbstractKServePredictionProv
     public CompletableFuture<List<PredictionOutput>> predictAsync(List<PredictionInput> inputs) {
         final ObjectMapper mapper = new ObjectMapper();
 
-        final List<List<Double>> instances = inputs.stream()
+        final List<List<Object>> instances = inputs.stream()
                 .map(input -> input.getFeatures().stream()
-                        .map(Feature::getValue).map(Value::asNumber)
+                        .map(Feature::getValue).map(Value::getUnderlyingObject)
                         .collect(Collectors.toList()))
                 .collect(Collectors.toList());
 

--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/KServeV2RequestPayload.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/KServeV2RequestPayload.java
@@ -28,10 +28,10 @@ public class KServeV2RequestPayload {
 
         final List<PredictionInput> predictionInputs = new ArrayList<>();
         final Inputs inputs = this.inputs.get(0);
-        for (List<Double> values : inputs.data) {
+        for (List<Object> values : inputs.data) {
             final int size = values.size();
             final List<Feature> features = IntStream.range(0, size)
-                    .mapToObj(i -> FeatureFactory.newNumericalFeature(DEFAULT_INPUT_PREFIX + "-" + i, values.get(i)))
+                    .mapToObj(i -> KServeV2HTTPPayloadParser.getFeature(inputs.datatype, i, values.get(i)))
                     .collect(Collectors.toUnmodifiableList());
             predictionInputs.add(new PredictionInput(features));
         }
@@ -47,7 +47,7 @@ public class KServeV2RequestPayload {
 
     public static class Inputs {
         public String name;
-        public List<List<Double>> data;
+        public List<List<Object>> data;
         public KServeDatatype datatype;
         public List<Integer> shape;
     }

--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/KServeV2RequestPayload.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/KServeV2RequestPayload.java
@@ -7,10 +7,7 @@ import java.util.stream.IntStream;
 
 import org.kie.trustyai.connectors.kserve.KServeDatatype;
 import org.kie.trustyai.explainability.model.Feature;
-import org.kie.trustyai.explainability.model.FeatureFactory;
 import org.kie.trustyai.explainability.model.PredictionInput;
-
-import static org.kie.trustyai.connectors.kserve.PayloadParser.DEFAULT_INPUT_PREFIX;
 
 public class KServeV2RequestPayload {
 

--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/KServeV2RequestPayload.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/KServeV2RequestPayload.java
@@ -1,0 +1,54 @@
+package org.kie.trustyai.connectors.kserve.v2;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.kie.trustyai.connectors.kserve.KServeDatatype;
+import org.kie.trustyai.explainability.model.Feature;
+import org.kie.trustyai.explainability.model.FeatureFactory;
+import org.kie.trustyai.explainability.model.PredictionInput;
+
+import static org.kie.trustyai.connectors.kserve.PayloadParser.DEFAULT_INPUT_PREFIX;
+
+public class KServeV2RequestPayload {
+
+    public List<Inputs> inputs;
+
+    public KServeV2RequestPayload() {
+        // NO OP - Required for JSON deserialisation
+    }
+
+    public KServeV2RequestPayload(List<Inputs> inputs) {
+        this.inputs = inputs;
+    }
+
+    public List<PredictionInput> toPredictionInputs() {
+
+        final List<PredictionInput> predictionInputs = new ArrayList<>();
+        final Inputs inputs = this.inputs.get(0);
+        for (List<Double> values : inputs.data) {
+            final int size = values.size();
+            final List<Feature> features = IntStream.range(0, size)
+                    .mapToObj(i -> FeatureFactory.newNumericalFeature(DEFAULT_INPUT_PREFIX + "-" + i, values.get(i)))
+                    .collect(Collectors.toUnmodifiableList());
+            predictionInputs.add(new PredictionInput(features));
+        }
+        return predictionInputs;
+    }
+
+    @Override
+    public String toString() {
+        return "KServeV1RequestPayload{" +
+                "inputs=" + inputs +
+                '}';
+    }
+
+    public static class Inputs {
+        public String name;
+        public List<List<Double>> data;
+        public KServeDatatype datatype;
+        public List<Integer> shape;
+    }
+}

--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/KServeV2ResponsePayload.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/KServeV2ResponsePayload.java
@@ -37,7 +37,7 @@ public class KServeV2ResponsePayload {
         public String name;
         public List<Integer> shape;
         public KServeDatatype datatype;
-        public List<Double> data;
+        public List<Object> data;
 
         @Override
         public String toString() {

--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/KServeV2ResponsePayload.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/KServeV2ResponsePayload.java
@@ -1,0 +1,52 @@
+package org.kie.trustyai.connectors.kserve.v2;
+
+import java.util.List;
+
+import org.kie.trustyai.connectors.kserve.KServeDatatype;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KServeV2ResponsePayload {
+
+    @JsonProperty("model_name")
+    public String modelName;
+    @JsonProperty("model_version")
+    public String modelVersion;
+    public String id;
+    private List<Outputs> outputs;
+
+    public List<Outputs> getOutputs() {
+        return outputs;
+    }
+
+    public void setOutputs(List<Outputs> outputs) {
+        this.outputs = outputs;
+    }
+
+    @Override
+    public String toString() {
+        return "KServeV1ResponsePayload{" +
+                "outputs=" + outputs +
+                '}';
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Outputs {
+        public String name;
+        public List<Integer> shape;
+        public KServeDatatype datatype;
+        public List<Double> data;
+
+        @Override
+        public String toString() {
+            return "Outputs{" +
+                    "name='" + name + '\'' +
+                    ", shape=" + shape +
+                    ", datatype=" + datatype +
+                    ", data=" + data +
+                    '}';
+        }
+    }
+}

--- a/explainability-connectors/src/test/java/org/kie/trustyai/connectors/kserve/v1/KServeV1HTTPPayloadParserTest.java
+++ b/explainability-connectors/src/test/java/org/kie/trustyai/connectors/kserve/v1/KServeV1HTTPPayloadParserTest.java
@@ -1,16 +1,17 @@
 package org.kie.trustyai.connectors.kserve.v1;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.Test;
-import org.kie.trustyai.explainability.model.PredictionInput;
-import org.kie.trustyai.explainability.model.PredictionOutput;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.kie.trustyai.explainability.model.PredictionInput;
+import org.kie.trustyai.explainability.model.PredictionOutput;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.kie.trustyai.connectors.kserve.PayloadParser.DEFAULT_INPUT_PREFIX;
@@ -113,7 +114,6 @@ class KServeV1HTTPPayloadParserTest {
         }
     }
 
-
     @Test
     void modelSingleToRequestToPredictionInput() throws IOException {
 
@@ -186,13 +186,12 @@ class KServeV1HTTPPayloadParserTest {
 
         assertEquals(3, predictionOutput.size());
         assertEquals(2, predictionOutput.get(0).getOutputs().size());
-        for (int i = 0 ; i < 3 ; i++) {
+        for (int i = 0; i < 3; i++) {
             for (int j = 0; j < 2; j++) {
-                assertEquals(values.get(i*2 + j), predictionOutput.get(i).getOutputs().get(j).getValue().asNumber());
+                assertEquals(values.get(i * 2 + j), predictionOutput.get(i).getOutputs().get(j).getValue().asNumber());
                 assertEquals(DEFAULT_OUTPUT_PREFIX + "-" + j, predictionOutput.get(i).getOutputs().get(j).getName());
             }
         }
     }
-
 
 }

--- a/explainability-connectors/src/test/java/org/kie/trustyai/connectors/kserve/v2/KServeV2HTTPPayloadParserTest.java
+++ b/explainability-connectors/src/test/java/org/kie/trustyai/connectors/kserve/v2/KServeV2HTTPPayloadParserTest.java
@@ -26,7 +26,7 @@ class KServeV2HTTPPayloadParserTest {
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
-    public static String toJson(List<Double> predictions, Optional<Integer> shape) {
+    public static String toJson(List<Object> predictions, Optional<Integer> shape) {
         try {
             KServeV2ResponsePayload payload = new KServeV2ResponsePayload();
             final KServeV2ResponsePayload.Outputs outputs = new KServeV2ResponsePayload.Outputs();
@@ -76,7 +76,7 @@ class KServeV2HTTPPayloadParserTest {
     void modelResponseToPredictionOutputMulti() throws JsonProcessingException {
 
         final Random random = new Random(0);
-        final List<Double> values = random.doubles(3).boxed().collect(Collectors.toList());
+        final List<Object> values = random.doubles(3).boxed().collect(Collectors.toList());
 
         final String json = toJson(values, Optional.of(1));
 
@@ -111,7 +111,7 @@ class KServeV2HTTPPayloadParserTest {
     void modelResponseToPredictionOutputFp64() throws JsonProcessingException {
 
         final Random random = new Random(0);
-        final List<Double> values = List.of(random.nextDouble(), random.nextDouble(), random.nextDouble());
+        final List<Object> values = List.of(random.nextDouble(), random.nextDouble(), random.nextDouble());
         final String json = toJson(values, Optional.of(1));
 
         final List<PredictionOutput> predictionOutput = KServeV2HTTPPayloadParser.getInstance().parseResponse(json);
@@ -169,7 +169,7 @@ class KServeV2HTTPPayloadParserTest {
 
         final Random random = new Random(0);
         final int OUTPUT_SHAPE = 6;
-        final List<Double> values = random.doubles(OUTPUT_SHAPE).boxed().collect(Collectors.toList());
+        final List<Object> values = random.doubles(OUTPUT_SHAPE).boxed().collect(Collectors.toList());
 
         final String json = toJson(values, Optional.empty());
 
@@ -188,7 +188,7 @@ class KServeV2HTTPPayloadParserTest {
 
         final Random random = new Random(0);
         final int OUTPUT_SHAPE = 6;
-        final List<Double> values = random.doubles(OUTPUT_SHAPE).boxed().collect(Collectors.toList());
+        final List<Object> values = random.doubles(OUTPUT_SHAPE).boxed().collect(Collectors.toList());
 
         final String json = toJson(values, Optional.of(2));
 

--- a/explainability-connectors/src/test/java/org/kie/trustyai/connectors/kserve/v2/KServeV2HTTPPayloadParserTest.java
+++ b/explainability-connectors/src/test/java/org/kie/trustyai/connectors/kserve/v2/KServeV2HTTPPayloadParserTest.java
@@ -90,22 +90,22 @@ class KServeV2HTTPPayloadParserTest {
         }
     }
 
-//    @Test
-//    void modelResponseToPredictionOutputFp32() throws JsonProcessingException {
-//
-//        final Random random = new Random(0);
-//        final List<Float> values = List.of(random.nextFloat(), random.nextFloat(), random.nextFloat());
-//        final String json = toJson(values);
-//
-//        final List<PredictionOutput> predictionOutput = KServeV1HTTPPayloadParser.getInstance().parseResponse(json);
-//
-//        assertEquals(3, predictionOutput.size());
-//        assertEquals(1, predictionOutput.get(0).getOutputs().size());
-//        for (int i = 0; i < 3; i++) {
-//            assertEquals(values.get(i), Double.valueOf(predictionOutput.get(i).getOutputs().get(0).getValue().asNumber()).floatValue());
-//            assertEquals(DEFAULT_OUTPUT_PREFIX + "-0", predictionOutput.get(i).getOutputs().get(0).getName());
-//        }
-//    }
+    @Test
+    void modelResponseToPredictionOutputFp32() throws JsonProcessingException {
+
+        final Random random = new Random(0);
+        final List<Object> values = List.of(random.nextFloat(), random.nextFloat(), random.nextFloat());
+        final String json = toJson(values, Optional.of(1));
+
+        final List<PredictionOutput> predictionOutput = KServeV2HTTPPayloadParser.getInstance().parseResponse(json);
+
+        assertEquals(3, predictionOutput.size());
+        assertEquals(1, predictionOutput.get(0).getOutputs().size());
+        for (int i = 0; i < 3; i++) {
+            assertEquals(values.get(i), Double.valueOf(predictionOutput.get(i).getOutputs().get(0).getValue().asNumber()).floatValue());
+            assertEquals(DEFAULT_OUTPUT_PREFIX + "-0", predictionOutput.get(i).getOutputs().get(0).getName());
+        }
+    }
 
     @Test
     void modelResponseToPredictionOutputFp64() throws JsonProcessingException {

--- a/explainability-connectors/src/test/java/org/kie/trustyai/connectors/kserve/v2/KServeV2HTTPPayloadParserTest.java
+++ b/explainability-connectors/src/test/java/org/kie/trustyai/connectors/kserve/v2/KServeV2HTTPPayloadParserTest.java
@@ -1,0 +1,207 @@
+package org.kie.trustyai.connectors.kserve.v2;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.kie.trustyai.connectors.kserve.KServeDatatype;
+import org.kie.trustyai.connectors.kserve.v1.KServeV1HTTPPayloadParser;
+import org.kie.trustyai.connectors.kserve.v1.KServeV1RequestPayload;
+import org.kie.trustyai.connectors.kserve.v1.KServeV1ResponsePayload;
+import org.kie.trustyai.explainability.model.PredictionInput;
+import org.kie.trustyai.explainability.model.PredictionOutput;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.kie.trustyai.connectors.kserve.PayloadParser.DEFAULT_INPUT_PREFIX;
+import static org.kie.trustyai.connectors.kserve.PayloadParser.DEFAULT_OUTPUT_PREFIX;
+
+class KServeV2HTTPPayloadParserTest {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public static String toJson(List<Double> predictions, Optional<Integer> shape) {
+        try {
+            KServeV2ResponsePayload payload = new KServeV2ResponsePayload();
+            final KServeV2ResponsePayload.Outputs outputs = new KServeV2ResponsePayload.Outputs();
+            outputs.data = predictions;
+            outputs.name = "outputs";
+            outputs.shape = shape.map(integer -> List.of(1, integer)).orElseGet(() -> List.of(1, predictions.size()));
+            outputs.datatype = KServeDatatype.FP64;
+            payload.setOutputs(List.of(outputs));
+            return objectMapper.writeValueAsString(payload);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to serialize predictions to JSON", e);
+        }
+    }
+
+    public static String generateJSONInputs(int inputs, int features) throws JsonProcessingException {
+        final Random random = new Random(0);
+
+        final List<List<Double>> inputList = new ArrayList<>();
+        for (int i = 0; i < inputs; i++) {
+            final List<Double> featureList = new ArrayList<>();
+            for (int j = 0; j < features; j++) {
+                featureList.add(random.nextDouble());
+            }
+            inputList.add(featureList);
+        }
+        final KServeV1RequestPayload payload = new KServeV1RequestPayload(inputList);
+
+        return objectMapper.writeValueAsString(payload);
+    }
+
+    @Test
+    void modelResponseToPredictionOutputSingle() throws JsonProcessingException {
+
+        final Random random = new Random(0);
+        final double value = random.nextDouble();
+
+        final String json = toJson(List.of(value), Optional.empty());
+
+        final List<PredictionOutput> predictionOutput = KServeV2HTTPPayloadParser.getInstance().parseResponse(json);
+
+        assertEquals(1, predictionOutput.size());
+        assertEquals(1, predictionOutput.get(0).getOutputs().size());
+        assertEquals(DEFAULT_OUTPUT_PREFIX + "-0", predictionOutput.get(0).getOutputs().get(0).getName());
+    }
+
+    @Test
+    void modelResponseToPredictionOutputMulti() throws JsonProcessingException {
+
+        final Random random = new Random(0);
+        final List<Double> values = random.doubles(3).boxed().collect(Collectors.toList());
+
+        final String json = toJson(values, Optional.of(1));
+
+        final List<PredictionOutput> predictionOutput = KServeV2HTTPPayloadParser.getInstance().parseResponse(json);
+
+        assertEquals(3, predictionOutput.size());
+        assertEquals(1, predictionOutput.get(0).getOutputs().size());
+        for (int i = 0; i < 3; i++) {
+            assertEquals(values.get(i), predictionOutput.get(i).getOutputs().get(0).getValue().asNumber());
+            assertEquals(DEFAULT_OUTPUT_PREFIX + "-0", predictionOutput.get(i).getOutputs().get(0).getName());
+        }
+    }
+
+//    @Test
+//    void modelResponseToPredictionOutputFp32() throws JsonProcessingException {
+//
+//        final Random random = new Random(0);
+//        final List<Float> values = List.of(random.nextFloat(), random.nextFloat(), random.nextFloat());
+//        final String json = toJson(values);
+//
+//        final List<PredictionOutput> predictionOutput = KServeV1HTTPPayloadParser.getInstance().parseResponse(json);
+//
+//        assertEquals(3, predictionOutput.size());
+//        assertEquals(1, predictionOutput.get(0).getOutputs().size());
+//        for (int i = 0; i < 3; i++) {
+//            assertEquals(values.get(i), Double.valueOf(predictionOutput.get(i).getOutputs().get(0).getValue().asNumber()).floatValue());
+//            assertEquals(DEFAULT_OUTPUT_PREFIX + "-0", predictionOutput.get(i).getOutputs().get(0).getName());
+//        }
+//    }
+
+    @Test
+    void modelResponseToPredictionOutputFp64() throws JsonProcessingException {
+
+        final Random random = new Random(0);
+        final List<Double> values = List.of(random.nextDouble(), random.nextDouble(), random.nextDouble());
+        final String json = toJson(values, Optional.of(1));
+
+        final List<PredictionOutput> predictionOutput = KServeV2HTTPPayloadParser.getInstance().parseResponse(json);
+
+        assertEquals(3, predictionOutput.size());
+        assertEquals(1, predictionOutput.get(0).getOutputs().size());
+        for (int i = 0; i < 3; i++) {
+            assertEquals(values.get(i), predictionOutput.get(i).getOutputs().get(0).getValue().asNumber());
+            assertEquals(DEFAULT_OUTPUT_PREFIX + "-0", predictionOutput.get(i).getOutputs().get(0).getName());
+        }
+    }
+
+    @Test
+    void modelSingleToRequestToPredictionInput() throws IOException {
+
+        final String json = generateJSONInputs(1, 1);
+
+        final List<PredictionInput> inputs = KServeV1HTTPPayloadParser.getInstance().parseRequest(json);
+
+        assertEquals(1, inputs.size());
+        assertEquals(1, inputs.get(0).getFeatures().size());
+        assertEquals(DEFAULT_INPUT_PREFIX + "-0", inputs.get(0).getFeatures().get(0).getName());
+    }
+
+    @Test
+    void modelRequestToPredictionInputMulti() throws IOException {
+
+        final String json = generateJSONInputs(1, 3);
+
+        final List<PredictionInput> inputs = KServeV1HTTPPayloadParser.getInstance().parseRequest(json);
+
+        assertEquals(1, inputs.size());
+        assertEquals(3, inputs.get(0).getFeatures().size());
+        for (int i = 0; i < 3; i++) {
+            assertEquals(DEFAULT_INPUT_PREFIX + "-" + i, inputs.get(0).getFeatures().get(i).getName());
+        }
+    }
+
+    @Test
+    void modelRequestToPredictionInputFp32() throws IOException {
+
+        final String json = generateJSONInputs(3, 1);
+
+        final List<PredictionInput> inputs = KServeV1HTTPPayloadParser.getInstance().parseRequest(json);
+
+        assertEquals(3, inputs.size());
+        assertEquals(1, inputs.get(0).getFeatures().size());
+        for (int i = 0; i < 3; i++) {
+            assertEquals(DEFAULT_INPUT_PREFIX + "-0", inputs.get(i).getFeatures().get(0).getName());
+        }
+    }
+
+    @Test
+    void modelResponseToSinglePredictionOutputMulti() throws JsonProcessingException {
+
+        final Random random = new Random(0);
+        final int OUTPUT_SHAPE = 6;
+        final List<Double> values = random.doubles(OUTPUT_SHAPE).boxed().collect(Collectors.toList());
+
+        final String json = toJson(values, Optional.empty());
+
+        final List<PredictionOutput> predictionOutput = KServeV2HTTPPayloadParser.getInstance().parseResponse(json, OUTPUT_SHAPE);
+
+        assertEquals(1, predictionOutput.size());
+        assertEquals(OUTPUT_SHAPE, predictionOutput.get(0).getOutputs().size());
+        for (int i = 0; i < OUTPUT_SHAPE; i++) {
+            assertEquals(values.get(i), predictionOutput.get(0).getOutputs().get(i).getValue().asNumber());
+            assertEquals(DEFAULT_OUTPUT_PREFIX + "-" + i, predictionOutput.get(0).getOutputs().get(i).getName());
+        }
+    }
+
+    @Test
+    void modelResponseToMultiPredictionOutputMulti() throws JsonProcessingException {
+
+        final Random random = new Random(0);
+        final int OUTPUT_SHAPE = 6;
+        final List<Double> values = random.doubles(OUTPUT_SHAPE).boxed().collect(Collectors.toList());
+
+        final String json = toJson(values, Optional.of(2));
+
+        final List<PredictionOutput> predictionOutput = KServeV2HTTPPayloadParser.getInstance().parseResponse(json, 2);
+
+        assertEquals(3, predictionOutput.size());
+        assertEquals(2, predictionOutput.get(0).getOutputs().size());
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 2; j++) {
+                assertEquals(values.get(i * 2 + j), predictionOutput.get(i).getOutputs().get(j).getValue().asNumber());
+                assertEquals(DEFAULT_OUTPUT_PREFIX + "-" + j, predictionOutput.get(i).getOutputs().get(j).getName());
+            }
+        }
+    }
+
+}

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/local/shap/background/StreamingGeneratorTest.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/local/shap/background/StreamingGeneratorTest.java
@@ -115,7 +115,7 @@ class StreamingGeneratorTest {
         final StreamingGenerator generator = new StreamingGenerator(data.length, queueSize, diversitySize, estimator, type, null);
         generator.update(new ArrayRealVector(data));
 
-       assertNotNull(generator.generate(queueSize + diversitySize));
+        assertNotNull(generator.generate(queueSize + diversitySize));
     }
 
     @DisplayName("Test streaming generator returns correct dimensions")


### PR DESCRIPTION
Add support for KServe v2 HTTP protocol as a PredictionProvider ([RHOAIENG-8993](https://issues.redhat.com/browse/RHOAIENG-8993)).

