### PR TITLE
RHOAIENG-9828: Update jandex plugin

### DIFF
--- a/explainability-core/pom.xml
+++ b/explainability-core/pom.xml
@@ -113,9 +113,9 @@
     <plugins>
       <!-- The entity classes need to be indexed -->
       <plugin>
-        <groupId>org.jboss.jandex</groupId>
+        <groupId>io.smallrye</groupId>
         <artifactId>jandex-maven-plugin</artifactId>
-        <version>1.1.0</version>
+        <version>3.2.0</version>
         <executions>
           <execution>
             <id>make-index</id>

--- a/explainability-core/pom.xml
+++ b/explainability-core/pom.xml
@@ -115,7 +115,7 @@
       <plugin>
         <groupId>io.smallrye</groupId>
         <artifactId>jandex-maven-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.1.8</version>
         <executions>
           <execution>
             <id>make-index</id>


### PR DESCRIPTION
See [RHOAIENG-9828](https://issues.redhat.com/browse/RHOAIENG-9828).

Update to a Quarkus friendlier jandex and recent version (using compatible version according to [jandex's matrix](https://smallrye.io/jandex/jandex/3.2.0/index.html#persistent_index_format_versions)).