### PR TITLE
Add Kubernetes namespace validator for model targets

### DIFF
--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/explainers/ExplainerEndpoint.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/explainers/ExplainerEndpoint.java
@@ -8,23 +8,28 @@ import org.kie.trustyai.connectors.kserve.v2.KServeV2GRPCPredictionProvider;
 import org.kie.trustyai.explainability.model.PredictionProvider;
 import org.kie.trustyai.explainability.model.dataframe.DataframeMetadata;
 import org.kie.trustyai.service.payloads.explainers.config.ModelConfig;
+import org.kie.trustyai.service.validators.serviceRequests.LocalServiceURLValidator;
 
 public abstract class ExplainerEndpoint {
 
     public static final String BIAS_IGNORE_PARAM = "bias-ignore";
 
-    protected PredictionProvider getModel(ModelConfig modelConfig) {
+    protected PredictionProvider getModel(ModelConfig modelConfig) throws IllegalArgumentException {
         return getModel(modelConfig, DataframeMetadata.DEFAULT_INPUT_TENSOR_NAME);
     }
 
-    protected PredictionProvider getModel(ModelConfig modelConfig, String inputTensorName) {
+    protected PredictionProvider getModel(ModelConfig modelConfig, String inputTensorName) throws IllegalArgumentException {
         return getModel(modelConfig, inputTensorName, null);
     }
 
-    protected PredictionProvider getModel(ModelConfig modelConfig, String inputTensorName, String outputTensorName) {
+    protected PredictionProvider getModel(ModelConfig modelConfig, String inputTensorName, String outputTensorName) throws IllegalArgumentException {
         final Map<String, String> map = new HashMap<>();
         map.put(BIAS_IGNORE_PARAM, "true");
-        final KServeConfig kServeConfig = KServeConfig.create(modelConfig.getTarget(), modelConfig.getName(), modelConfig.getVersion());
+        final String target = modelConfig.getTarget();
+        if (!LocalServiceURLValidator.isValidUrl(target)) {
+            throw new IllegalArgumentException("Invalid target URL: " + modelConfig.getTarget());
+        }
+        final KServeConfig kServeConfig = KServeConfig.create(target, modelConfig.getName(), modelConfig.getVersion());
         return KServeV2GRPCPredictionProvider.forTarget(kServeConfig, inputTensorName, null, map);
     }
 

--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/explainers/local/SHAPEndpoint.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/explainers/local/SHAPEndpoint.java
@@ -65,10 +65,9 @@ public class SHAPEndpoint extends ExplainerEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Generate a SHAP explanation", description = "Generate a SHAP explanation for a given model and inference id")
     public Response explain(SHAPExplanationRequest request) {
-        final String modelId = request.getConfig().getModelConfig().getName();
         final String inferenceId = request.getPredictionId();
         try {
-
+            final String modelId = request.getConfig().getModelConfig().getName();
             final Dataframe dataframe = dataSource.get().getDataframe(modelId);
             final PredictionProvider model = getModel(request.getConfig().getModelConfig(), dataframe.getInputTensorName(),
                     dataframe.getOutputTensorName());

--- a/explainability-service/src/main/java/org/kie/trustyai/service/validators/serviceRequests/LocalServiceURLValidator.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/validators/serviceRequests/LocalServiceURLValidator.java
@@ -1,0 +1,36 @@
+package org.kie.trustyai.service.validators.serviceRequests;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.regex.Pattern;
+
+/**
+ * Validator class to allow only local Kubernetes Service URLs.
+ */
+public class LocalServiceURLValidator {
+    private static final Pattern URL_PATTERN = Pattern.compile("^(http|https)://[a-zA-Z0-9-]+(:[0-9]{1,5})?$|^[a-zA-Z0-9-]+(:[0-9]{1,5})?$");
+
+    /**
+     * Method to validate local Kubernetes Service URLs.
+     * http[s]://service is allowed, but FQN, such as http[s]://service.namespace.svc.cluster.local are not.
+     * URLs without protocol are also allowed.
+     *
+     * @param url The service's location
+     * @return Whether the service has a local URL or not
+     */
+    public static boolean isValidUrl(String url) {
+        String formattedUrl = url;
+        if (!url.startsWith("http://") && !url.startsWith("https://")) {
+            formattedUrl = "http://" + url;
+        }
+
+        try {
+            final URL parsedUrl = new URL(formattedUrl);
+            final String host = parsedUrl.getHost();
+
+            return URL_PATTERN.matcher(url).matches() && host != null && host.indexOf('.') == -1;
+        } catch (MalformedURLException e) {
+            return false;
+        }
+    }
+}

--- a/explainability-service/src/main/resources/application.properties
+++ b/explainability-service/src/main/resources/application.properties
@@ -15,6 +15,7 @@ quarkus.container-image.build=false
 quarkus.container-image.group=trustyai
 quarkus.container-image.name=trustyai-service
 quarkus.log.level=${LOG_LEVEL:INFO}
+quarkus.smallrye-openapi.store-schema-directory=target/generated/
 %test.quarkus.log.level=INFO
 %test.quarkus.log.min-level=DEBUG
 quarkus.smallrye-openapi.store-schema-directory=target/generated/

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/explainers/global/AggregatedLimeEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/explainers/global/AggregatedLimeEndpointTest.java
@@ -62,6 +62,6 @@ class AggregatedLimeEndpointTest {
         given().contentType(ContentType.JSON).body(payload)
                 .when().post()
                 .then()
-                .statusCode(Response.Status.OK.getStatusCode());
+                .statusCode(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
     }
 }

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/explainers/local/CounterfactualEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/explainers/local/CounterfactualEndpointTest.java
@@ -74,6 +74,6 @@ class CounterfactualEndpointTest {
         given().contentType(ContentType.JSON).body(payload)
                 .when().post()
                 .then()
-                .statusCode(Response.Status.NOT_FOUND.getStatusCode());
+                .statusCode(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
     }
 }

--- a/explainability-service/src/test/java/org/kie/trustyai/service/validators/LocalServiceURLValidatorTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/validators/LocalServiceURLValidatorTest.java
@@ -1,0 +1,86 @@
+package org.kie.trustyai.service.validators;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.kie.trustyai.service.validators.serviceRequests.LocalServiceURLValidator;
+
+public class LocalServiceURLValidatorTest {
+
+    @Test
+    public void testValidHttpUrls() {
+        Assertions.assertTrue(LocalServiceURLValidator.isValidUrl("http://foo"));
+        Assertions.assertTrue(LocalServiceURLValidator.isValidUrl("http://foo:8080"));
+        Assertions.assertTrue(LocalServiceURLValidator.isValidUrl("http://bar"));
+        Assertions.assertTrue(LocalServiceURLValidator.isValidUrl("http://bar:9090"));
+    }
+
+    @Test
+    public void testValidHttpsUrls() {
+        Assertions.assertTrue(LocalServiceURLValidator.isValidUrl("https://foo"));
+        Assertions.assertTrue(LocalServiceURLValidator.isValidUrl("https://foo:8443"));
+        Assertions.assertTrue(LocalServiceURLValidator.isValidUrl("https://bar"));
+        Assertions.assertTrue(LocalServiceURLValidator.isValidUrl("https://bar:9443"));
+    }
+
+    @Test
+    public void testValidNoProtocolUrls() {
+        Assertions.assertTrue(LocalServiceURLValidator.isValidUrl("foo"));
+        Assertions.assertTrue(LocalServiceURLValidator.isValidUrl("foo:8080"));
+        Assertions.assertTrue(LocalServiceURLValidator.isValidUrl("bar"));
+        Assertions.assertTrue(LocalServiceURLValidator.isValidUrl("bar:9090"));
+    }
+
+    @Test
+    public void testInvalidUrlsWithNamespace() {
+        Assertions.assertFalse(LocalServiceURLValidator.isValidUrl("http://foo.test.svc.cluster.local"));
+        Assertions.assertFalse(LocalServiceURLValidator.isValidUrl("https://foo.test.svc.cluster.local"));
+        Assertions.assertFalse(LocalServiceURLValidator.isValidUrl("foo.test.svc.cluster.local"));
+    }
+
+    @Test
+    public void testInvalidUrlsWithPath() {
+        Assertions.assertFalse(LocalServiceURLValidator.isValidUrl("http://foo/some/path"));
+        Assertions.assertFalse(LocalServiceURLValidator.isValidUrl("https://foo/some/path"));
+        Assertions.assertFalse(LocalServiceURLValidator.isValidUrl("foo/some/path"));
+    }
+
+    @Test
+    public void testInvalidUrlsWithQuery() {
+        Assertions.assertFalse(LocalServiceURLValidator.isValidUrl("http://foo?query=param"));
+        Assertions.assertFalse(LocalServiceURLValidator.isValidUrl("https://foo?query=param"));
+        Assertions.assertFalse(LocalServiceURLValidator.isValidUrl("foo?query=param"));
+    }
+
+    @Test
+    public void testInvalidUrlsWithFragment() {
+        Assertions.assertFalse(LocalServiceURLValidator.isValidUrl("http://foo#fragment"));
+        Assertions.assertFalse(LocalServiceURLValidator.isValidUrl("https://foo#fragment"));
+        Assertions.assertFalse(LocalServiceURLValidator.isValidUrl("foo#fragment"));
+    }
+
+    @Test
+    public void testInvalidUrlsWithMultipleDots() {
+        Assertions.assertFalse(LocalServiceURLValidator.isValidUrl("http://foo..bar"));
+        Assertions.assertFalse(LocalServiceURLValidator.isValidUrl("https://foo..bar"));
+        Assertions.assertFalse(LocalServiceURLValidator.isValidUrl("foo..bar"));
+        Assertions.assertFalse(LocalServiceURLValidator.isValidUrl("http://foo.bar."));
+        Assertions.assertFalse(LocalServiceURLValidator.isValidUrl("https://foo.bar."));
+        Assertions.assertFalse(LocalServiceURLValidator.isValidUrl("foo.bar."));
+    }
+
+    @Test
+    public void testInvalidUrlsWithNoHost() {
+        Assertions.assertFalse(LocalServiceURLValidator.isValidUrl("http://:8080"));
+        Assertions.assertFalse(LocalServiceURLValidator.isValidUrl("https://:8443"));
+        Assertions.assertFalse(LocalServiceURLValidator.isValidUrl(":8080"));
+    }
+
+    @Test
+    public void testInvalidMalformedUrls() {
+        Assertions.assertFalse(LocalServiceURLValidator.isValidUrl("http:/foo"));
+        Assertions.assertFalse(LocalServiceURLValidator.isValidUrl("https:/foo"));
+        Assertions.assertFalse(LocalServiceURLValidator.isValidUrl("http://"));
+        Assertions.assertFalse(LocalServiceURLValidator.isValidUrl("https://"));
+        Assertions.assertFalse(LocalServiceURLValidator.isValidUrl("/foo"));
+    }
+}


### PR DESCRIPTION
See [RHOAIENG-10005](https://issues.redhat.com/browse/RHOAIENG-10005).

Explainer endpoint payloads allow to specify a FQN for a model server at the moment.
This PR adds a Service name validator that only allows Kubernetes local names to be passed, i.e. model server in the same namespace as the TrustyAI service.

Allowed model URLs are:

- `service[:port]` (no protocol, with or without port)
- `http[s]://service[:port]` (protocol, with or without port)

Everything else (FQN, paths, fragments) is not allowed.
