### PR TITLE
feat(service): Add timeout support for explainer endpoints

### DIFF
--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/explainers/BaseExplainerConfig.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/explainers/BaseExplainerConfig.java
@@ -1,0 +1,41 @@
+package org.kie.trustyai.service.payloads.explainers;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.kie.trustyai.explainability.local.lime.LimeConfig;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static org.kie.trustyai.explainability.Config.DEFAULT_ASYNC_TIMEOUT;
+
+/**
+ * Common properties across all explainer configuration payloads
+ */
+public abstract class BaseExplainerConfig {
+    @Schema(required = false, description = "Number of samples to be generated for the local linear model training", defaultValue = "300", example = "300")
+    @JsonProperty(value = "n_samples")
+    private int nSamples = LimeConfig.DEFAULT_NO_OF_SAMPLES;
+
+    @Schema(required = false, description = "Timeout (in seconds) for the LIME explainer", defaultValue = "10", example = "10")
+    @JsonProperty(value = "timeout")
+    private long timeout = DEFAULT_ASYNC_TIMEOUT;
+
+    public long getTimeout() {
+        return timeout;
+    }
+
+    public void setTimeout(long timeout) {
+        this.timeout = timeout;
+    }
+
+    public int getnSamples() {
+        return nSamples;
+    }
+
+    public void setnSamples(int nSamples) {
+        if (nSamples <= 0) {
+            throw new IllegalArgumentException("Number of samples must be > 0");
+        }
+        this.nSamples = nSamples;
+    }
+
+}

--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/explainers/lime/LimeExplainerConfig.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/explainers/lime/LimeExplainerConfig.java
@@ -3,16 +3,13 @@ package org.kie.trustyai.service.payloads.explainers.lime;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.kie.trustyai.explainability.local.lime.LimeConfig;
+import org.kie.trustyai.service.payloads.explainers.BaseExplainerConfig;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 @Schema(description = "Configuration for the LIME explainer")
 @Tag(name = "Payloads", description = "Payload definitions for the API")
-public class LimeExplainerConfig {
-
-    @Schema(required = false, description = "Number of samples to be generated for the local linear model training", defaultValue = "300", example = "300")
-    @JsonProperty(value = "n_samples")
-    private int nSamples = LimeConfig.DEFAULT_NO_OF_SAMPLES;
+public class LimeExplainerConfig extends BaseExplainerConfig {
 
     @Schema(required = false, description = "Separable dataset ration", defaultValue = "0.9", example = "0.9")
     @JsonProperty(value = "separable_dataset_ratio")
@@ -147,17 +144,6 @@ public class LimeExplainerConfig {
         }
 
         this.retries = retries;
-    }
-
-    public int getnSamples() {
-        return nSamples;
-    }
-
-    public void setnSamples(int nSamples) {
-        if (nSamples <= 0) {
-            throw new IllegalArgumentException("Number of samples must be > 0");
-        }
-        this.nSamples = nSamples;
     }
 
     public boolean isNormalizeWeights() {

--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/explainers/shap/SHAPExplainerConfig.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/explainers/shap/SHAPExplainerConfig.java
@@ -3,16 +3,13 @@ package org.kie.trustyai.service.payloads.explainers.shap;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.kie.trustyai.explainability.local.shap.ShapConfig;
+import org.kie.trustyai.service.payloads.explainers.BaseExplainerConfig;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 @Schema(description = "Configuration for the LIME explainer")
 @Tag(name = "Payloads", description = "Payload definitions for the API")
-public class SHAPExplainerConfig {
-
-    @Schema(required = false, description = "Number of data samples to run when computing SHAP values", defaultValue = "100", example = "100")
-    @JsonProperty(value = "n_samples", required = false, defaultValue = "100")
-    private int nSamples = 100;
+public class SHAPExplainerConfig extends BaseExplainerConfig {
 
     @Schema(required = false, description = "Either LOGIT or IDENTITY. If you want the SHAP values to sum to the exact model output, use IDENTITY" +
             "If your model outputs probabilities and you want the SHAP values to" +
@@ -32,17 +29,6 @@ public class SHAPExplainerConfig {
     @Schema(required = false, description = "Whether to track byproduct counterfactuals generated during explanation", defaultValue = "false", example = "false")
     @JsonProperty(value = "track_counterfactuals", required = false, defaultValue = "false")
     private boolean trackCounterfactuals = false;
-
-    public int getnSamples() {
-        return nSamples;
-    }
-
-    public void setnSamples(int nSamples) {
-        if (nSamples <= 0) {
-            throw new IllegalArgumentException("Number of samples must be > 0");
-        }
-        this.nSamples = nSamples;
-    }
 
     public ShapConfig.LinkType getLinkType() {
         return linkType;

--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/explainers/tssaliency/TSSaliencyExplainerConfig.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/explainers/tssaliency/TSSaliencyExplainerConfig.java
@@ -2,12 +2,13 @@ package org.kie.trustyai.service.payloads.explainers.tssaliency;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.kie.trustyai.service.payloads.explainers.BaseExplainerConfig;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 @Schema(description = "Configuration for the TSSaliency explainer")
 @Tag(name = "Payloads", description = "Payload definitions for the API")
-public class TSSaliencyExplainerConfig {
+public class TSSaliencyExplainerConfig extends BaseExplainerConfig {
 
     @Schema(required = false, description = "Step size for gradient estimation", defaultValue = "0.01", example = "0.01")
     @JsonProperty("mu")
@@ -40,14 +41,6 @@ public class TSSaliencyExplainerConfig {
 
     public void setBaseValues(double[] baseValues) {
         this.baseValues = baseValues;
-    }
-
-    public int getnSamples() {
-        return nSamples;
-    }
-
-    public void setnSamples(int nSamples) {
-        this.nSamples = nSamples;
     }
 
     public double getSigma() {

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/explainers/local/ShapEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/explainers/local/ShapEndpointTest.java
@@ -1,15 +1,24 @@
 package org.kie.trustyai.service.endpoints.explainers.local;
 
+import java.io.IOException;
 import java.util.List;
+import java.util.Random;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.kie.trustyai.explainability.model.PredictionInput;
 import org.kie.trustyai.explainability.model.dataframe.Dataframe;
+import org.kie.trustyai.explainability.utils.models.TestModels;
 import org.kie.trustyai.service.endpoints.explainers.ExplainersEndpointTestProfile;
+import org.kie.trustyai.service.endpoints.explainers.GrpcMockServer;
 import org.kie.trustyai.service.mocks.flatfile.MockCSVDatasource;
 import org.kie.trustyai.service.mocks.flatfile.MockMemoryStorage;
 import org.kie.trustyai.service.payloads.explainers.config.ModelConfig;
+import org.kie.trustyai.service.payloads.explainers.lime.LimeExplainerConfig;
+import org.kie.trustyai.service.payloads.explainers.lime.LimeExplanationRequest;
+import org.kie.trustyai.service.payloads.explainers.shap.SHAPExplainerConfig;
 import org.kie.trustyai.service.payloads.explainers.shap.SHAPExplanationRequest;
 import org.kie.trustyai.service.utils.DataframeGenerators;
 
@@ -39,6 +48,7 @@ class ShapEndpointTest {
     Instance<MockCSVDatasource> datasource;
     @Inject
     Instance<MockMemoryStorage> storage;
+    private GrpcMockServer mockServer;
 
     private void testServiceUrl(String serviceUrl, int expectedStatusCode) throws JsonProcessingException {
         datasource.get().reset();
@@ -56,15 +66,23 @@ class ShapEndpointTest {
     }
 
     @BeforeEach
-    void populateStorage() {
+    void populateStorage() throws IOException {
         storage.get().emptyStorage();
         final Dataframe dataframe = DataframeGenerators.generateRandomDataframe(N_SAMPLES);
         datasource.get().saveDataframe(dataframe, MODEL_ID);
         datasource.get().saveMetadata(datasource.get().createMetadata(dataframe), MODEL_ID);
+        mockServer = new GrpcMockServer(TestModels.getSumSkipModel(1));
+        mockServer.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockServer.stop();
     }
 
     @Test
     void get() {
+        mockServer.stop();
         when().get()
                 .then()
                 .statusCode(Response.Status.METHOD_NOT_ALLOWED.getStatusCode())
@@ -73,6 +91,7 @@ class ShapEndpointTest {
 
     @Test
     void postWithoutKserve() throws JsonProcessingException {
+        mockServer.stop();
         datasource.get().reset();
         Dataframe dataframe = datasource.get().getDataframe(MODEL_ID);
         List<PredictionInput> predictionInputs = dataframe.asPredictionInputs();
@@ -89,6 +108,7 @@ class ShapEndpointTest {
 
     @Test
     void testWithValidServiceUrl() throws JsonProcessingException {
+        mockServer.stop();
         testServiceUrl("http://foo", Response.Status.NOT_FOUND.getStatusCode());
         testServiceUrl("https://bar", Response.Status.NOT_FOUND.getStatusCode());
         testServiceUrl("foo", Response.Status.NOT_FOUND.getStatusCode());
@@ -97,9 +117,33 @@ class ShapEndpointTest {
 
     @Test
     void testWithInvalidServiceUrl() throws JsonProcessingException {
+        mockServer.stop();
         testServiceUrl("http://foo.namespace.svc.cluster.local", Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
         testServiceUrl("foo.namespace.svc.cluster.local", Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
         testServiceUrl("http://foo/some/path", Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
         testServiceUrl("foo/some/path", Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("Test SHAP request timeout")
+    void testTimeout() throws JsonProcessingException {
+        datasource.get().reset();
+
+        final Dataframe dataframe = datasource.get().getDataframe(MODEL_ID);
+
+        final Random random = new Random();
+        int randomIndex = random.nextInt(dataframe.getIds().size());
+        final String id = dataframe.getIds().get(randomIndex);
+        final SHAPExplanationRequest payload = new SHAPExplanationRequest();
+        payload.getConfig().setModelConfig(new ModelConfig("localhost:" + mockServer.getPort(), MODEL_ID, ""));
+        final SHAPExplainerConfig explainerConfig = new SHAPExplainerConfig();
+        explainerConfig.setTimeout(0);
+        payload.getConfig().setExplainerConfig(explainerConfig);
+        payload.setPredictionId(id);
+
+        given().contentType(ContentType.JSON).body(payload)
+                .when().post()
+                .then()
+                .statusCode(Response.Status.REQUEST_TIMEOUT.getStatusCode());
     }
 }

--- a/explainability-service/src/test/java/org/kie/trustyai/service/payloads/explainers/SHAPExplainerConfigTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/payloads/explainers/SHAPExplainerConfigTest.java
@@ -11,7 +11,7 @@ public class SHAPExplainerConfigTest {
     void testDefaultValues() {
         SHAPExplainerConfig config = new SHAPExplainerConfig();
 
-        assertEquals(100, config.getnSamples());
+        assertEquals(300, config.getnSamples());
         assertEquals(ShapConfig.LinkType.IDENTITY, config.getLinkType());
         assertEquals(ShapConfig.RegularizerType.AUTO, config.getRegularizer());
         assertEquals(0.95, config.getConfidence());


### PR DESCRIPTION
See [RHOAIENG-10112](https://issues.redhat.com/browse/RHOAIENG-10112).

Add a timeout option for SHAP and LIME explainers.
Default value is 10 seconds. Custom values can be passed with the `config.explainer.timeout` payload field (value in seconds).

Example:

```json
{
    "predictionId": "$INFERENCE_ID",
    "config": {
        "model": {  
            "target": "modelmesh-serving:8033",
            "name": "explainer-test",
            "version": "v1"
        },
        "explainer": {  
            "n_samples": 100,
            "timeout": 1000,  // <---- timeout, seconds perhaps
        }
    }
}
```

Validation can be performed by adding a `timeout: 0` which will always timeout.