### PR TITLE
feat(service): Set maximum concurrent request to gRPC

### DIFF
--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/KServeConfig.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/KServeConfig.java
@@ -1,26 +1,46 @@
 package org.kie.trustyai.connectors.kserve.v2;
 
+/**
+ * Configuration class for a remote Open Inference model server
+ */
 public class KServeConfig {
 
-    private static final CodecParameter DEFAULT_CODEC = CodecParameter.NP;
+    public static final CodecParameter DEFAULT_CODEC = CodecParameter.NP;
+
+    public static final int DEFAULT_MAXIMUM_CONCURRENT_REQUESTS = 5;
+
     private final String target;
     private final String modelId;
     private final String version;
     private final CodecParameter codec;
+    private final int maximumConcurrentRequests;
 
-    private KServeConfig(String target, String modelId, String version, CodecParameter codec) {
+    /**
+     * Create a configuration class for a remote Open Inference model server
+     * @param target The model's URI, typically a DNS name and port
+     * @param modelId The model's ID
+     * @param version The model version
+     * @param codec The codec to use
+     * @param maximumConcurrentRequests Maximum number of simultaneous request
+     */
+    private KServeConfig(String target, String modelId, String version, CodecParameter codec, int maximumConcurrentRequests) {
         this.target = target;
         this.modelId = modelId;
         this.version = version;
         this.codec = codec;
+        this.maximumConcurrentRequests = maximumConcurrentRequests;
     }
 
     public static KServeConfig create(String target, String modelId, String version) {
-        return new KServeConfig(target, modelId, version, DEFAULT_CODEC);
+        return new KServeConfig(target, modelId, version, DEFAULT_CODEC, DEFAULT_MAXIMUM_CONCURRENT_REQUESTS);
     }
 
     public static KServeConfig create(String target, String modelId, String version, CodecParameter codec) {
-        return new KServeConfig(target, modelId, version, codec);
+        return new KServeConfig(target, modelId, version, codec, DEFAULT_MAXIMUM_CONCURRENT_REQUESTS);
+    }
+
+    public static KServeConfig create(String target, String modelId, String version, CodecParameter codec, int maximumConcurrentRequests) {
+        return new KServeConfig(target, modelId, version, codec, maximumConcurrentRequests);
     }
 
     public String getTarget() {
@@ -37,5 +57,9 @@ public class KServeConfig {
 
     public CodecParameter getCodec() {
         return codec;
+    }
+
+    public int getMaximumConcurrentRequests() {
+        return maximumConcurrentRequests;
     }
 }

--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/KServeV2GRPCPredictionProvider.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/KServeV2GRPCPredictionProvider.java
@@ -120,7 +120,7 @@ public class KServeV2GRPCPredictionProvider extends AbstractKServePredictionProv
             semaphore.acquire();
         } catch (InterruptedException e) {
             CompletableFuture<List<PredictionOutput>> future = new CompletableFuture<>();
-            future.completeExceptionally(new RuntimeException("Failed to acquire semaphore", e));
+            future.completeExceptionally(new RuntimeException("gRPC inference request failed while waiting for concurrent connection thread", e));
             return future;
         }
 

--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/KServeV2GRPCPredictionProvider.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/KServeV2GRPCPredictionProvider.java
@@ -2,6 +2,7 @@ package org.kie.trustyai.connectors.kserve.v2;
 
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Semaphore;
 
 import org.kie.trustyai.connectors.kserve.AbstractKServePredictionProvider;
 import org.kie.trustyai.connectors.kserve.v2.grpc.GRPCInferenceServiceGrpc;
@@ -30,12 +31,14 @@ public class KServeV2GRPCPredictionProvider extends AbstractKServePredictionProv
 
     private final KServeConfig kServeConfig;
     private final Map<String, String> optionalParameters;
+    private final Semaphore semaphore;
 
     private KServeV2GRPCPredictionProvider(KServeConfig kServeConfig, String inputName, List<String> outputNames, Map<String, String> optionalParameters) {
 
         super(outputNames, inputName);
         this.kServeConfig = kServeConfig;
         this.optionalParameters = optionalParameters;
+        this.semaphore = new Semaphore(kServeConfig.getMaximumConcurrentRequests());
     }
 
     /**
@@ -113,6 +116,14 @@ public class KServeV2GRPCPredictionProvider extends AbstractKServePredictionProv
             throw new IllegalArgumentException("Prediction inputs must have at least one feature.");
         }
 
+        try {
+            semaphore.acquire();
+        } catch (InterruptedException e) {
+            CompletableFuture<List<PredictionOutput>> future = new CompletableFuture<>();
+            future.completeExceptionally(new RuntimeException("Failed to acquire semaphore", e));
+            return future;
+        }
+
         // Create a new channel for each prediction request
         final ManagedChannel localChannel = ManagedChannelBuilder.forTarget(kServeConfig.getTarget())
                 .usePlaintext()
@@ -132,16 +143,18 @@ public class KServeV2GRPCPredictionProvider extends AbstractKServePredictionProv
                     .thenApply(response -> TensorConverter.parseKserveModelInferResponse(response, inputs.size(), Objects.isNull(this.outputNames) ? Optional.empty() : Optional.of(this.outputNames)))
                     .exceptionally(ex -> {
                         logger.error("Error during model inference: " + ex.getMessage());
-                        // Shutdown the channel
-                        localChannel.shutdown();
                         throw new RuntimeException("Failed to get inference", ex);
                     })
                     .whenComplete((response, throwable) -> {
+                        // Release the semaphore permit after request is complete
+                        semaphore.release();
                         if (!localChannel.isShutdown()) { // In case channel already closed in .exceptionally()
                             localChannel.shutdown();
                         }
                     });
         } catch (Exception e) {
+            // Release the semaphore permit if an exception occurs
+            semaphore.release();
             if (!localChannel.isShutdown()) { // In case channel already closed in .exceptionally()
                 localChannel.shutdown();
             }

--- a/explainability-connectors/src/test/java/org/kie/trustyai/connectors/kserve/v2/KServeV2HTTPPayloadParserTest.java
+++ b/explainability-connectors/src/test/java/org/kie/trustyai/connectors/kserve/v2/KServeV2HTTPPayloadParserTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 import org.kie.trustyai.connectors.kserve.KServeDatatype;
 import org.kie.trustyai.connectors.kserve.v1.KServeV1HTTPPayloadParser;
 import org.kie.trustyai.connectors.kserve.v1.KServeV1RequestPayload;
-import org.kie.trustyai.connectors.kserve.v1.KServeV1ResponsePayload;
 import org.kie.trustyai.explainability.model.PredictionInput;
 import org.kie.trustyai.explainability.model.PredictionOutput;
 

--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/consumer/ConsumerEndpoint.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/consumer/ConsumerEndpoint.java
@@ -21,7 +21,8 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
 @Path("/consumer/kserve/v2")
-@Tag(name = "{Internal Only} Inference Consumer", description = "This endpoint consumes inference payloads produced by ModelMesh-served models. While it's possible to manually interact with this endpoint, it is not recommended.")
+@Tag(name = "{Internal Only} Inference Consumer",
+        description = "This endpoint consumes inference payloads produced by ModelMesh-served models. While it's possible to manually interact with this endpoint, it is not recommended.")
 public class ConsumerEndpoint {
 
     private static final Logger LOG = Logger.getLogger(ConsumerEndpoint.class);

--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/explainers/ExplainerEndpoint.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/explainers/ExplainerEndpoint.java
@@ -29,7 +29,12 @@ public abstract class ExplainerEndpoint {
         if (!LocalServiceURLValidator.isValidUrl(target)) {
             throw new IllegalArgumentException("Invalid target URL: " + modelConfig.getTarget());
         }
-        final KServeConfig kServeConfig = KServeConfig.create(target, modelConfig.getName(), modelConfig.getVersion());
+        final KServeConfig kServeConfig = KServeConfig.create(
+                target,
+                modelConfig.getName(),
+                modelConfig.getVersion(),
+                KServeConfig.DEFAULT_CODEC,
+                1);
         return KServeV2GRPCPredictionProvider.forTarget(kServeConfig, inputTensorName, null, map);
     }
 

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/consumer/cloudevent/CloudEventConsumerBaseTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/consumer/cloudevent/CloudEventConsumerBaseTest.java
@@ -76,7 +76,6 @@ abstract public class CloudEventConsumerBaseTest {
 
         InferenceLoggerOutput ilo = new InferenceLoggerOutput();
         ilo.setPredictions(List.of(1.0));
-
         CloudEvent<InferenceLoggerOutput> mockOutput = MockKServeOutputPayload.create(id, ilo, MODEL_NAME);
         consumer.get().consumeKubeflowResponse(mockOutput);
 


### PR DESCRIPTION
See [RHOAIENG-10505](https://issues.redhat.com/browse/RHOAIENG-10505).

Set maximum concurrent request to gRPC model server to avoid too many request with explainer inferences.
