### PR TITLE
Bug Fix: Fix 1-row and very large cloudevent consumption

### DIFF
--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/KServePayloadConverters.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/KServePayloadConverters.java
@@ -85,7 +85,7 @@ public class KServePayloadConverters {
         final ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
         JsonNode rootNode = objectMapper.readTree(payload.getData());
-        
+
         ModelInferRequestPayload payloadInfer = new ModelInferRequestPayload();
         payloadInfer.setId(payload.getId());
         if (rootNode.has("instances")) {

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/KServePayloadConverters.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/KServePayloadConverters.java
@@ -3,8 +3,11 @@ package org.kie.trustyai.service.data.utils;
 import java.util.Collection;
 import java.util.List;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import org.jboss.logging.Logger;
 import org.kie.trustyai.connectors.kserve.v2.TensorConverterUtils;
 import org.kie.trustyai.explainability.model.SerializableObject;
+import org.kie.trustyai.service.endpoints.consumer.ConsumerEndpoint;
 import org.kie.trustyai.service.payloads.consumer.InferenceLoggerGeneral;
 import org.kie.trustyai.service.payloads.consumer.InferenceLoggerInput;
 import org.kie.trustyai.service.payloads.consumer.InferenceLoggerOutput;
@@ -19,6 +22,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class KServePayloadConverters {
+
+    private static final Logger LOG = Logger.getLogger(KServePayloadConverters.class);
 
     public static boolean isV1(InferenceLoggerOutput inferenceLoggerOutput) {
         boolean predExist = inferenceLoggerOutput.getRawPredictions() != null;
@@ -78,7 +83,11 @@ public class KServePayloadConverters {
 
     public static ModelInferRequestPayload toRequestPayload(KServeInputPayload payload) throws JsonProcessingException {
         final ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
+
+        LOG.info("in request payload function");
         JsonNode rootNode = objectMapper.readTree(payload.getData());
+
 
         ModelInferRequestPayload payloadInfer = new ModelInferRequestPayload();
         payloadInfer.setId(payload.getId());

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/KServePayloadConverters.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/utils/KServePayloadConverters.java
@@ -84,11 +84,8 @@ public class KServePayloadConverters {
     public static ModelInferRequestPayload toRequestPayload(KServeInputPayload payload) throws JsonProcessingException {
         final ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
-
-        LOG.info("in request payload function");
         JsonNode rootNode = objectMapper.readTree(payload.getData());
-
-
+        
         ModelInferRequestPayload payloadInfer = new ModelInferRequestPayload();
         payloadInfer.setId(payload.getId());
         if (rootNode.has("instances")) {

--- a/explainability-service/src/main/resources/application.properties
+++ b/explainability-service/src/main/resources/application.properties
@@ -43,6 +43,10 @@ quarkus.openshift.env.mapping.service-batch-size.from-configmap=trustyai-config
 quarkus.openshift.env.mapping.service-batch-size.with-key=service_batch_size
 quarkus.openshift.mounts.volume.path=/inputs
 quarkus.openshift.pvc-volumes.volume.claim-name=trustyai-service-pvc
+#quarkus.http.limits.max-chunk-size=32M
+quarkus.http.limits.max-form-buffered-bytes=64M
+#quarkus.http.limits.max-form-attribute-size=32M
+
 # Dev
 quarkus.kubernetes.deployment-target=openshift
 

--- a/explainability-service/src/main/resources/application.properties
+++ b/explainability-service/src/main/resources/application.properties
@@ -43,9 +43,9 @@ quarkus.openshift.env.mapping.service-batch-size.from-configmap=trustyai-config
 quarkus.openshift.env.mapping.service-batch-size.with-key=service_batch_size
 quarkus.openshift.mounts.volume.path=/inputs
 quarkus.openshift.pvc-volumes.volume.claim-name=trustyai-service-pvc
-#quarkus.http.limits.max-chunk-size=32M
+
+# HTTP Server Limits
 quarkus.http.limits.max-form-buffered-bytes=64M
-#quarkus.http.limits.max-form-attribute-size=32M
 
 # Dev
 quarkus.kubernetes.deployment-target=openshift


### PR DESCRIPTION
Fixes:
- 1-row payloads not being correctly parsed by the service
- Increases the maximum inbound application-encoded byte buffer to 64MB, which is above the maximum HTTP form size. In this scenario, payloads above the HTTP form size will throw an informative 413 Request Too Large error.


Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `FAI-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.3.x] FAI-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

