### PR TITLE
Move termination log in /tmp in test profile

### DIFF
--- a/explainability-service/src/main/resources/application.properties
+++ b/explainability-service/src/main/resources/application.properties
@@ -89,6 +89,7 @@ quarkus.hibernate-orm.jdbc.statement-batch-size=50
 quarkus.log.handler.file.termination-log.enable=true
 quarkus.log.handler.file.termination-log.level=ERROR
 quarkus.log.handler.file.termination-log.path=/dev/termination-log
+%test.quarkus.log.handler.file.termination-log.path=/tmp/dev/termination-log
 quarkus.log.handler.file.termination-log.format=%d{yyyy-MM-dd HH:mm:ss} %-5p [%c{2.}] (%t) %s%xEx{message}%n
 quarkus.log.handlers=console,termination-log
 


### PR DESCRIPTION
When running in a non-container environment, the TrustyAI service does not necessarily have permissions to write to `/dev`, resulting in the following warning being spammed:

```
LogManager error of type OPEN_FAILURE: Failed to set log file
java.io.FileNotFoundException: /dev/termination-log (Permission denied)
	at java.base/java.io.FileOutputStream.open0(Native Method)
	at java.base/java.io.FileOutputStream.open(FileOutputStream.java:293)
...
```

This PR sets the termination log to write to `/tmp/dev` when in the `%test` profile, clearing the warning.


Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `FAI-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.3.x] FAI-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

