### PR TITLE
RHOAIENG-11384: Re-enable bias endpoints in service

### DIFF
--- a/explainability-service/src/main/resources/application.properties
+++ b/explainability-service/src/main/resources/application.properties
@@ -108,7 +108,7 @@ quarkus.log.handlers=console,termination-log
 %odh.endpoints.explainers.global=enable
 
 # rhoai endpoints
-%rhoai.endpoints.fairness=disable
+%rhoai.endpoints.fairness=enable
 %rhoai.endpoints.drift=enable
 %rhoai.endpoints.explainers.local.shap=disable
 %rhoai.endpoints.explainers.local.lime=disable


### PR DESCRIPTION
Refers to [RHOAIENG-11384](https://issues.redhat.com/browse/RHOAIENG-11384).

Re-enable bias endpoint in TrustyAI service.