### PR TITLE
Bug Fix: Added tag validation to drift metrics, ensured name mappings are exposed to Prometheus

### DIFF
--- a/explainability-core/src/main/java/org/kie/trustyai/metrics/drift/kstest/ApproxKSTest.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/metrics/drift/kstest/ApproxKSTest.java
@@ -71,7 +71,7 @@ public class ApproxKSTest {
                                     testNames.get(i)));
                 }
                 if (dfTest.getRowDimension() < 2 || trainGKSketches.get(colName).size() < 2) {
-                    result.put(colName, new HypothesisTestResult(0, 1, false));
+                    result.put(dfTest.getColumnNames().get(i), new HypothesisTestResult(0, 1, false));
                 } else {
                     GKSketch testSketch = new GKSketch(eps);
                     GKSketch trainSketch = trainGKSketches.get(colName);
@@ -84,7 +84,7 @@ public class ApproxKSTest {
                     }
                     double pValue = computePvalue(d, trainSketch.getNumx(), testSketch.getNumx()); //compute pvalue
                     boolean reject = pValue <= signif;
-                    result.put(colName, new HypothesisTestResult(d, pValue, reject));
+                    result.put(dfTest.getColumnNames().get(i), new HypothesisTestResult(d, pValue, reject));
                 }
             }
         }

--- a/explainability-core/src/main/java/org/kie/trustyai/metrics/drift/kstest/KSTest.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/metrics/drift/kstest/KSTest.java
@@ -34,7 +34,7 @@ public class KSTest {
                                     testNames.get(i)));
                 }
                 if (dfTrain.getRowDimension() < 2 || (dfTest.getRowDimension() < 2)) {
-                    result.put(colName, new HypothesisTestResult(0, 1, false));
+                    result.put(dfTest.getColumnNames().get(i), new HypothesisTestResult(0, 1, false));
                 } else {
                     double[] trainArray = dfTrain.getColumn(i).stream().mapToDouble(Value::asNumber).toArray();
                     double[] testArray = dfTest.getColumn(i).stream().mapToDouble(Value::asNumber).toArray();
@@ -43,7 +43,7 @@ public class KSTest {
                     d = ks_test.kolmogorovSmirnovStatistic(trainArray, testArray);
                     double pValue = ks_test.kolmogorovSmirnovTest(trainArray, testArray);
                     boolean reject = pValue <= signif;
-                    result.put(colName, new HypothesisTestResult(d, pValue, reject));
+                    result.put(dfTest.getColumnNames().get(i), new HypothesisTestResult(d, pValue, reject));
                 }
             }
         }

--- a/explainability-core/src/main/java/org/kie/trustyai/metrics/drift/meanshift/Meanshift.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/metrics/drift/meanshift/Meanshift.java
@@ -47,13 +47,13 @@ public class Meanshift extends PerColumnStatisticalAnalysis {
                 }
 
                 if (dfTest.getRowDimension() < 2) {
-                    result.put(colName, new MeanshiftResult(0, 1, false));
+                    result.put(dfTest.getColumnNames().get(i), new MeanshiftResult(0, 1, false));
                 } else {
                     StatisticalSummaryValues testStats = getColumnStats(dfTest.getColumn(i));
                     double tStat = tTest.t(this.getFitStats().get(colName), testStats);
                     double pValue = (1 - tDistribution.cumulativeProbability(Math.abs(tStat))) * 2;
                     boolean reject = pValue <= alpha;
-                    result.put(colName, new MeanshiftResult(tStat, pValue, reject));
+                    result.put(dfTest.getColumnNames().get(i), new MeanshiftResult(tStat, pValue, reject));
                 }
             }
         }

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/datasources/CSVDataSource.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/datasources/CSVDataSource.java
@@ -453,6 +453,16 @@ public class CSVDataSource extends DataSource {
         return getDataframe(modelId, numObs).getTags();
     }
 
+    @Override
+    public Map<String, Long> getTagCounts(String modelId) {
+        List<String> tags = getTags(modelId);
+        Map<String, Long> counts = new HashMap<>();
+        for (String tag : tags) {
+            counts.put(tag, counts.computeIfAbsent(tag, t -> 0L) + 1);
+        }
+        return counts;
+    }
+
     // NAME MAPPING OPERATIONS =========================================================================================
     /**
      * Apply a name mapping to a dataframe

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/datasources/DataSource.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/datasources/DataSource.java
@@ -1,6 +1,7 @@
 package org.kie.trustyai.service.data.datasources;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -387,6 +388,11 @@ public abstract class DataSource {
      * @return the tag column of the requested dataframe
      */
     public abstract List<String> getTags(String modelId);
+
+    /**
+     * Return a map of tag count in a particular dataframe, keyed by tag name
+     */
+    public abstract Map<String, Long> getTagCounts(String modelId);
 
     // NAME MAPPING OPERATIONS =========================================================================================
     /**

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/datasources/HibernateDataSource.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/datasources/HibernateDataSource.java
@@ -2,6 +2,7 @@ package org.kie.trustyai.service.data.datasources;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.kie.trustyai.explainability.model.dataframe.Dataframe;
@@ -359,6 +360,15 @@ public class HibernateDataSource extends DataSource {
             return getStorage().getTags(modelId);
         } catch (Exception e) {
             throw DataSourceErrors.getGenericReadError(modelId, e.getMessage(), "retrieving tags");
+        }
+    }
+
+    @Override
+    public Map<String, Long> getTagCounts(String modelId) {
+        try {
+            return getStorage().getTagCounts(modelId);
+        } catch (Exception e) {
+            throw DataSourceErrors.getGenericReadError(modelId, e.getMessage(), "retrieving tag counts");
         }
     }
 

--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/storage/hibernate/HibernateStorage.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/storage/hibernate/HibernateStorage.java
@@ -560,6 +560,28 @@ public class HibernateStorage extends Storage<Dataframe, StorageMetadata> {
         }
     }
 
+    @Transactional
+    public Map<String, Long> getTagCounts(String modelId) {
+        if (dataExists(modelId)) {
+            refreshIfDirty();
+            List<List> out = em.createQuery(
+                    "select dr.tag, COUNT(*) from DataframeRow dr " +
+                            "where dr.modelId = ?1" +
+                            " group by dr.tag",
+                    List.class)
+                    .setParameter(1, modelId)
+                    .getResultList();
+
+            Map<String, Long> tagCounts = new HashMap<>();
+            for (List tuple : out) {
+                tagCounts.put((String) tuple.get(0), (Long) tuple.get(1));
+            }
+            return tagCounts;
+        } else {
+            throw new StorageReadException("Error reading tags for model=" + modelId + ": " + NO_DATA_ERROR_MSG);
+        }
+    }
+
     // NAME MAPPING MANIPULATION =======================================================================================
     @Transactional
     public void applyNameMapping(NameMapping nameMapping) {

--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/data/UploadEndpoint.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/data/UploadEndpoint.java
@@ -187,7 +187,7 @@ public class UploadEndpoint {
             dpSource = "";
         } else {
             dpSource = jointPayload.getDataTag();
-            Optional<String> tagValidationErrorMessage = GenericValidationUtils.validateDataTag(dpSource);
+            Optional<String> tagValidationErrorMessage = GenericValidationUtils.validateNewDataTag(dpSource);
             if (tagValidationErrorMessage.isPresent()) {
                 return Optional.of(Response.serverError().entity(tagValidationErrorMessage.get()).status(Response.Status.BAD_REQUEST).build());
             }

--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupEndpoint.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/GroupEndpoint.java
@@ -89,7 +89,6 @@ public abstract class GroupEndpoint extends BaseEndpoint<GroupMetricRequest> {
         }
         if (metricValue.isSingle()) {
             final String metricDefinition = this.getSpecificDefinition(metricValue, request);
-
             MetricThreshold thresholds = thresholdFunction(request.getThresholdDelta(), metricValue);
             final BaseMetricResponse dirObj = new BaseMetricResponse(metricValue, metricDefinition, thresholds, super.getMetricName());
             return Response.ok(dirObj).build();

--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/service/ServiceMetadataEndpoint.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/service/ServiceMetadataEndpoint.java
@@ -119,7 +119,7 @@ public class ServiceMetadataEndpoint {
             HashMap<String, List<List<Integer>>> tagMapping = new HashMap<>();
             List<String> tagErrors = new ArrayList<>();
             for (String tag : dataTagging.getDataTagging().keySet()) {
-                Optional<String> tagValidationErrorMessage = GenericValidationUtils.validateDataTag(tag);
+                Optional<String> tagValidationErrorMessage = GenericValidationUtils.validateNewDataTag(tag);
                 tagValidationErrorMessage.ifPresent(tagErrors::add);
                 tagMapping.put(tag, dataTagging.getDataTagging().get(tag));
             }

--- a/explainability-service/src/main/java/org/kie/trustyai/service/validators/generic/GenericValidationUtils.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/validators/generic/GenericValidationUtils.java
@@ -2,6 +2,7 @@ package org.kie.trustyai.service.validators.generic;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -147,7 +148,7 @@ public class GenericValidationUtils {
     }
 
     // if tag is invalid, return error string. Else return nothing
-    public static Optional<String> validateDataTag(String dataTag) {
+    public static Optional<String> validateNewDataTag(String dataTag) {
         if (dataTag.startsWith(Dataframe.TRUSTYAI_INTERNAL_TAG_PREFIX)) {
             return Optional.of(String.format(
                     "The tag prefix '%s' is reserved for internal TrustyAI use only. Provided tag '%s' violates this restriction.",
@@ -155,6 +156,21 @@ public class GenericValidationUtils {
                     dataTag));
         }
         return Optional.empty();
+    }
+
+    public static Optional<String> validateAgainstExistingDataTags(String modelName, Map<String, Long> tagCounts, String dataTag) {
+        if (dataTag.startsWith(Dataframe.TRUSTYAI_INTERNAL_TAG_PREFIX)) {
+            return Optional.of(String.format(
+                    "The tag prefix '%s' is reserved for internal TrustyAI use only. Provided tag '%s' violates this restriction.",
+                    Dataframe.TRUSTYAI_INTERNAL_TAG_PREFIX,
+                    dataTag));
+        }
+
+        if (tagCounts.containsKey(dataTag) && tagCounts.get(dataTag) > 0) {
+            return Optional.empty();
+        } else {
+            return Optional.of(String.format("No tag named '%s' found in data for model=%s. %s", dataTag, modelName, getEnumerateMessage(tagCounts.keySet(), "tag")));
+        }
     }
 
     // validate actual dataframe columns, not mapping

--- a/explainability-service/src/main/java/org/kie/trustyai/service/validators/metrics/drift/DriftMetricRequestValidator.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/validators/metrics/drift/DriftMetricRequestValidator.java
@@ -50,7 +50,7 @@ public class DriftMetricRequestValidator implements ConstraintValidator<ValidDri
 
             boolean tagValidation = true;
             if (Objects.nonNull(request.getReferenceTag())) {
-                Optional<String> tagValidationErrorMessage = GenericValidationUtils.validateDataTag(request.getReferenceTag());
+                Optional<String> tagValidationErrorMessage = GenericValidationUtils.validateAgainstExistingDataTags(modelId, dataSource.get().getTagCounts(modelId), request.getReferenceTag());
                 if (tagValidationErrorMessage.isPresent()) {
                     context.buildConstraintViolationWithTemplate(tagValidationErrorMessage.get())
                             .addConstraintViolation();

--- a/explainability-service/src/test/java/org/kie/trustyai/service/data/datasources/DataSourceBaseTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/data/datasources/DataSourceBaseTest.java
@@ -290,6 +290,29 @@ abstract class DataSourceBaseTest {
     }
 
     @Test
+    void testReadingTagCount() {
+        int nrows = 100;
+        int ncols = 10;
+
+        Dataframe original = DataframeGenerators.generateRandomNColumnDataframe(nrows, ncols);
+        HashMap<String, List<List<Integer>>> tagMap = new HashMap<>();
+        tagMap.put("A", List.of(List.of(0, 10)));
+        tagMap.put("B", List.of(List.of(20, 31)));
+        tagMap.put("C", List.of(List.of(40, 52)));
+
+        DataTagging dataTagging = new DataTagging(MODEL_ID, tagMap);
+        datasource.get().saveDataframe(original, MODEL_ID);
+        datasource.get().tagDataframeRows(dataTagging);
+
+        // not tags
+        Map<String, Long> tagCounts = datasource.get().getTagCounts(MODEL_ID);
+        assertEquals(10, tagCounts.get("A"));
+        assertEquals(11, tagCounts.get("B"));
+        assertEquals(12, tagCounts.get("C"));
+        assertEquals(67, tagCounts.get("_trustyai_unlabeled"));
+    }
+
+    @Test
     void testReadingIdFilteringLargerThanBatch() {
         final int nrows = 10000;
         final int ncols = 10;


### PR DESCRIPTION
Fixes the following bugs:
1) Drift metrics could be set up with nonexistent data tags, causing TrustyAI to crash
2) Drift metrics were not exposed the name mappings to Prometheus

Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `FAI-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.3.x] FAI-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

