### PR TITLE
fix: Upgrade commons-lang to 3.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 
         <version.org.slf4j>1.7.36</version.org.slf4j>
         <version.com.fasterxml.jackson.databind>2.15.0</version.com.fasterxml.jackson.databind>
-        <version.org.apache.commons.commons-lang3>3.12.0</version.org.apache.commons.commons-lang3>
+        <version.org.apache.commons.commons-lang3>3.18.0</version.org.apache.commons.commons-lang3>
         <version.org.apache.commons.commons-csv>1.9.0</version.org.apache.commons.commons-csv>
         <version.org.apache.opennlp>1.9.2</version.org.apache.opennlp>
         <version.org.junit.jupiter>5.9.1</version.org.junit.jupiter>


### PR DESCRIPTION
See [RHOAIENG-30134](https://issues.redhat.com/browse/RHOAIENG-30134).

## Summary by Sourcery

Build:
- Bump commons-lang3 dependency from 3.12.0 to 3.18.0 in pom.xml