### PR TITLE
chore: Change Trivy scans to filesystem

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -154,8 +154,8 @@ jobs:
       - name: Trivy scan
         uses: aquasecurity/trivy-action@0.28.0
         with:
-          scan-type: 'image'
-          image-ref: "${{ env.IMAGE_NAME }}:${{ env.TAG }}"
+          scan-type: 'fs'
+          scan-ref: '.'
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'MEDIUM,HIGH,CRITICAL'


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update Trivy scan step in GitHub Actions to use scan-type 'fs' with scan-ref '.' instead of scanning the image