### PR TITLE
refactor: Refactor Tier 1/2 tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -66,7 +66,7 @@ jobs:
           fail_if_no_tests: false
       - name: Upload Test Results
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v6
         with:
           name: test-results-${{ matrix.os }}-java${{ matrix.java-version }}-maven${{ matrix.maven-version }}
           path: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,16 +1,14 @@
-name: TrustyAI Explainability - Build
+name: Tier 1 - Unit tests
 on: [ push, pull_request ]
 jobs:
-  build:
-    # Only run on the main repository, not on forks
-    if: github.repository == 'trustyai-explainability/trustyai-explainability'
+  unit-tests:
     env:
       MAVEN_OPTS: "-Dhttps.protocols=TLSv1.2 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Dorg.slf4j.simpleLogger.showDateTime=true -Djava.awt.headless=true"
       MAVEN_ARGS: "-nsu -fae -e"
     concurrency:
-      group: build-${{ github.event_name }}-${{ github.head_ref }}-${{ matrix.os }}-${{ matrix.java-version }}-${{ matrix.maven-version }}
+      group: tests-${{ github.event_name }}-${{ github.head_ref }}-${{ matrix.os }}-${{ matrix.java-version }}-${{ matrix.maven-version }}
       cancel-in-progress: true
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       matrix:
         # configure with [ 'ubuntu-latest', 'windows-latest' ] to enable Windows builds
@@ -25,7 +23,7 @@ jobs:
       run:
         shell: ${{ matrix.shell }} {0}
     runs-on: ${{ matrix.os }}
-    name: ${{ matrix.os }} - Java ${{ matrix.java-version }} - Maven ${{ matrix.maven-version }} - Build
+    name: ${{ matrix.os }} - Java ${{ matrix.java-version }} - Maven ${{ matrix.maven-version }} - Unit Tests
     steps:
       - name: Disk space report before modification
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -54,9 +52,23 @@ jobs:
         with:
           java-version: ${{ matrix.java-version }}
           maven-version: ${{ matrix.maven-version }}
-      - name: Run mvn package
-        run: mvn package -Dmaven.test.skip=true -Dformatter.skip=true
-      - name: Validate Formatting
-        # execute formatting validation only on Ubuntu to avoid issues with CR LF
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: mvn net.revelc.code.formatter:formatter-maven-plugin:validate
+      - name: Build project for testing
+        run: mvn compile test-compile -Dformatter.skip=true
+      - name: Run Test Suite
+        run: mvn test
+      - name: Generate Test Report
+        if: ${{ always() }}
+        uses: scacap/action-surefire-report@v1.0.10
+        with:
+          skip_publishing: false
+          check_name: Test Results - Java ${{ matrix.java-version }} Maven ${{ matrix.maven-version }}
+          fail_on_test_failures: true
+          fail_if_no_tests: false
+      - name: Upload Test Results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results-${{ matrix.os }}-java${{ matrix.java-version }}-maven${{ matrix.maven-version }}
+          path: |
+            **/target/surefire-reports/*.xml
+            **/target/failsafe-reports/*.xml

--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -1,4 +1,4 @@
-name: Trivy Security Scan
+name: Tier 1 - Security scan
 on:
   push:
     branches:
@@ -6,6 +6,10 @@ on:
     tags:
       - v*
   pull_request:
+    branches:
+      - main
+      - incubation
+      - stable
     types: [opened, synchronize, reopened]
 
 jobs:


### PR DESCRIPTION
This PR refactors the GitHub Actions workflows:

Trivy Security Scan
- Now only runs on PRs targeting main, incubation, and stable branches

Split CI Workflow
- Separated build and testing into two workflows (CI.yaml and test.yaml)
- Build and tests can now run in parallel
- Build workflow only runs on the main repository, not forks

## Summary by Sourcery

Split CI into separate build and unit test workflows and tighten security scan triggers.

Enhancements:
- Rename and restrict the main CI workflow to run only build jobs on the primary repository.
- Introduce a dedicated Tier 1 unit test workflow that runs tests and publishes reports in parallel with the build.
- Scope the Trivy (Tier 1 security) scan to only run on pull requests targeting main, incubation, and stable branches.