### PR TITLE
fix: Add gzip decompression filter for KServe agent uploads

### DIFF
--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/service/GzipRequestFilter.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/service/GzipRequestFilter.java
@@ -1,0 +1,54 @@
+package org.kie.trustyai.service.endpoints.service;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.GZIPInputStream;
+
+import org.jboss.logging.Logger;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.ext.Provider;
+
+/**
+ * JAX-RS filter that automatically decompresses gzip-encoded request bodies.
+ *
+ * This filter checks for the "Content-Encoding: gzip" header and transparently
+ * decompresses the request body before it reaches the endpoint handlers.
+ *
+ * This is necessary because the KServe agent sidecar automatically gzip-compresses
+ * CloudEvent payloads when logging to TrustyAI in RawDeployment mode.
+ */
+@Provider
+@Priority(Priorities.HEADER_DECORATOR)
+public class GzipRequestFilter implements ContainerRequestFilter {
+
+    private static final Logger LOG = Logger.getLogger(GzipRequestFilter.class);
+    private static final String CONTENT_ENCODING = "Content-Encoding";
+    private static final String GZIP = "gzip";
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        String contentEncoding = requestContext.getHeaderString(CONTENT_ENCODING);
+
+        if (contentEncoding != null && contentEncoding.equalsIgnoreCase(GZIP)) {
+            LOG.debugf("Decompressing gzip-encoded request body for path: %s", requestContext.getUriInfo().getPath());
+
+            try {
+                InputStream originalStream = requestContext.getEntityStream();
+                GZIPInputStream gzipStream = new GZIPInputStream(originalStream);
+                requestContext.setEntityStream(gzipStream);
+
+                // Remove the Content-Encoding header since we've decompressed the body
+                requestContext.getHeaders().remove(CONTENT_ENCODING);
+
+                LOG.debugf("Successfully decompressed gzip request for path: %s", requestContext.getUriInfo().getPath());
+            } catch (IOException e) {
+                LOG.errorf(e, "Failed to decompress gzip-encoded request body for path: %s", requestContext.getUriInfo().getPath());
+                throw e;
+            }
+        }
+    }
+}

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/data/UploadEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/data/UploadEndpointTest.java
@@ -1,6 +1,8 @@
 package org.kie.trustyai.service.endpoints.data;
 
+import java.io.ByteArrayOutputStream;
 import java.util.List;
+import java.util.zip.GZIPOutputStream;
 
 import org.jboss.resteasy.reactive.RestResponse;
 import org.junit.jupiter.api.BeforeEach;
@@ -9,11 +11,11 @@ import org.kie.trustyai.explainability.model.dataframe.Dataframe;
 import org.kie.trustyai.service.mocks.flatfile.MockCSVDatasource;
 import org.kie.trustyai.service.mocks.flatfile.MockMemoryStorage;
 import org.kie.trustyai.service.payloads.data.upload.ModelInferJointPayload;
-import org.kie.trustyai.service.payloads.data.upload.ModelInferRequestPayload;
 import org.kie.trustyai.service.profiles.flatfile.MemoryTestProfile;
 import org.kie.trustyai.service.utils.KserveRestPayloads;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
@@ -309,7 +311,7 @@ class UploadEndpointTest {
     }
 
     @Test
-    void uploadGaussianData(){
+    void uploadGaussianData() {
         String payload = """
                 {
                   "model_name": "gaussian-credit-model",
@@ -363,5 +365,42 @@ class UploadEndpointTest {
                 .statusCode(RestResponse.StatusCode.OK)
                 .body(containsString("2 datapoints"));
 
+    }
+
+    @Test
+    void uploadGzipCompressedData() throws Exception {
+        // Test that gzip-compressed payloads are handled correctly
+        // This simulates KServe agent behavior in RawDeployment mode
+        ModelInferJointPayload payload = KserveRestPayloads.generatePayload(5, 2, 1, "INT64", "COMPRESSED_TEST");
+
+        // Serialize payload to JSON
+        ObjectMapper objectMapper = new ObjectMapper();
+        byte[] jsonBytes = objectMapper.writeValueAsBytes(payload);
+
+        // Compress with gzip
+        ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+        try (GZIPOutputStream gzipStream = new GZIPOutputStream(byteStream)) {
+            gzipStream.write(jsonBytes);
+        }
+        byte[] gzipBytes = byteStream.toByteArray();
+
+        emptyStorage();
+
+        // Send gzip-compressed request
+        given()
+                .contentType(ContentType.JSON)
+                .header("Content-Encoding", "gzip")
+                .body(gzipBytes)
+                .when().post("/upload")
+                .then()
+                .statusCode(RestResponse.StatusCode.OK)
+                .body(containsString("5 datapoints"));
+
+        // Verify data was stored correctly
+        Dataframe df = datasource.get().getDataframe(payload.getModelName());
+        assertEquals(5, df.getRowDimension());
+        assertEquals(3, df.getColumnDimension()); // 2 inputs + 1 output
+
+        emptyStorage();
     }
 }


### PR DESCRIPTION
## Summary

Fixes issue where KServe agent in RawDeployment mode sends gzip-compressed CloudEvent payloads that TrustyAI couldn't parse.

Jira issue: https://redhat.atlassian.net/browse/RHOAIENG-52393

## Problem

- **Root Cause**: KServe agent's Go `http.Transport` automatically enables gzip compression by default
- **Error**: TrustyAI received compressed payloads but attempted to parse as raw JSON
- **Result**: HTTP 400 with `JsonParseException: Unexpected character (CTRL-CHAR, code 31)` (gzip magic byte `0x1f`)
- **Scope**: Only affected RawDeployment mode (KNative's networking layer handled decompression transparently)

## Solution

Added a JAX-RS `ContainerRequestFilter` that:
- Detects `Content-Encoding: gzip` header
- Transparently decompresses gzip request bodies before JSON deserialization
- Runs at `HEADER_DECORATOR` priority (before entity decoding)
- Backward compatible with uncompressed uploads
- Aligns with Seldon Core's solution: https://github.com/SeldonIO/seldon-core/pull/3746

## Changes

- **New File**: `GzipRequestFilter.java` - JAX-RS filter for gzip decompression
- **Modified**: `UploadEndpointTest.java` - Added `uploadGzipCompressedData()` unit test

## Testing

**Unit Tests**: ✅ All passing
```bash
./mvnw test -Dtest=UploadEndpointTest#uploadGzipCompressedData
```

**Manual Verification**: ✅ Tested on live OpenShift cluster
```
Before fix:
- Uncompressed uploads: HTTP 200
- Gzip uploads: HTTP 400 ❌

After fix:
- Uncompressed uploads: HTTP 200 ✅
- Gzip uploads: HTTP 200 ✅
```

**Deployed Image**: `quay.io/rh-ee-sudsinha/trustyai-service:gzip-fix-20260319-114108-amd64`

## Impact

**Fixes**:
- ✅ Gzip parsing failure (main issue)
- ✅ KServe agent compression in RawDeployment mode
- ✅ Unblocks automated payload logging for KServe

**Does NOT fix** (separate issues):
- ⚠️ Proxy timeout issues (requires proxy config changes)
- ⚠️ Large dataset uploads (architectural - needs storage-based approach)

## Additional Context

See related Slack discussion about 502 Bad Gateway and proxy timeouts - those are separate concerns requiring additional work beyond this gzip fix.

---

🤖 Co-Authored-By: Claude Sonnet 4.5

## Summary by Sourcery

Handle gzip-compressed request bodies for upload endpoints to ensure KServe agent payloads are correctly processed.

Bug Fixes:
- Fix handling of gzip-compressed CloudEvent payloads by transparently decompressing requests before JSON deserialization.

Enhancements:
- Introduce a JAX-RS request filter to detect and decompress gzip-encoded request bodies while preserving compatibility with uncompressed requests.

Tests:
- Add an upload endpoint test that verifies gzip-compressed payloads are accepted, stored, and reported correctly.