### PR TITLE
ci: Update trivy-action to version 0.35.0

### DIFF
--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Trivy scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: 'fs'
           scan-ref: '.'

--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/service/GzipRequestFilter.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/service/GzipRequestFilter.java
@@ -2,6 +2,7 @@ package org.kie.trustyai.service.endpoints.service;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Locale;
 import java.util.zip.GZIPInputStream;
 
 import org.jboss.logging.Logger;
@@ -10,6 +11,8 @@ import jakarta.annotation.Priority;
 import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.Provider;
 
 /**
@@ -20,6 +23,12 @@ import jakarta.ws.rs.ext.Provider;
  *
  * This is necessary because the KServe agent sidecar automatically gzip-compresses
  * CloudEvent payloads when logging to TrustyAI in RawDeployment mode.
+ *
+ * The filter handles multiple/stacked encodings (e.g., "gzip, br") by checking if
+ * the Content-Encoding header contains "gzip" rather than requiring an exact match.
+ *
+ * If decompression fails, returns HTTP 400 (Bad Request) with a clear error message
+ * rather than allowing the IOException to surface as a generic 500 error.
  */
 @Provider
 @Priority(Priorities.HEADER_DECORATOR)
@@ -30,10 +39,11 @@ public class GzipRequestFilter implements ContainerRequestFilter {
     private static final String GZIP = "gzip";
 
     @Override
-    public void filter(ContainerRequestContext requestContext) throws IOException {
+    public void filter(ContainerRequestContext requestContext) {
         String contentEncoding = requestContext.getHeaderString(CONTENT_ENCODING);
 
-        if (contentEncoding != null && contentEncoding.equalsIgnoreCase(GZIP)) {
+        // Support multiple/stacked encodings (e.g., "gzip, br") by checking if gzip is present
+        if (contentEncoding != null && contentEncoding.toLowerCase(Locale.ROOT).contains(GZIP)) {
             LOG.debugf("Decompressing gzip-encoded request body for path: %s", requestContext.getUriInfo().getPath());
 
             try {
@@ -47,7 +57,14 @@ public class GzipRequestFilter implements ContainerRequestFilter {
                 LOG.debugf("Successfully decompressed gzip request for path: %s", requestContext.getUriInfo().getPath());
             } catch (IOException e) {
                 LOG.errorf(e, "Failed to decompress gzip-encoded request body for path: %s", requestContext.getUriInfo().getPath());
-                throw e;
+
+                // Return 400 Bad Request with clear message instead of letting it surface as 500
+                Response response = Response.status(Response.Status.BAD_REQUEST)
+                        .type(MediaType.TEXT_PLAIN_TYPE)
+                        .entity("Request body could not be decompressed as gzip: invalid or corrupted content.")
+                        .build();
+
+                requestContext.abortWith(response);
             }
         }
     }

--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/service/GzipRequestFilter.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/service/GzipRequestFilter.java
@@ -1,0 +1,54 @@
+package org.kie.trustyai.service.endpoints.service;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.GZIPInputStream;
+
+import org.jboss.logging.Logger;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.ext.Provider;
+
+/**
+ * JAX-RS filter that automatically decompresses gzip-encoded request bodies.
+ *
+ * This filter checks for the "Content-Encoding: gzip" header and transparently
+ * decompresses the request body before it reaches the endpoint handlers.
+ *
+ * This is necessary because the KServe agent sidecar automatically gzip-compresses
+ * CloudEvent payloads when logging to TrustyAI in RawDeployment mode.
+ */
+@Provider
+@Priority(Priorities.HEADER_DECORATOR)
+public class GzipRequestFilter implements ContainerRequestFilter {
+
+    private static final Logger LOG = Logger.getLogger(GzipRequestFilter.class);
+    private static final String CONTENT_ENCODING = "Content-Encoding";
+    private static final String GZIP = "gzip";
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        String contentEncoding = requestContext.getHeaderString(CONTENT_ENCODING);
+
+        if (contentEncoding != null && contentEncoding.equalsIgnoreCase(GZIP)) {
+            LOG.debugf("Decompressing gzip-encoded request body for path: %s", requestContext.getUriInfo().getPath());
+
+            try {
+                InputStream originalStream = requestContext.getEntityStream();
+                GZIPInputStream gzipStream = new GZIPInputStream(originalStream);
+                requestContext.setEntityStream(gzipStream);
+
+                // Remove the Content-Encoding header since we've decompressed the body
+                requestContext.getHeaders().remove(CONTENT_ENCODING);
+
+                LOG.debugf("Successfully decompressed gzip request for path: %s", requestContext.getUriInfo().getPath());
+            } catch (IOException e) {
+                LOG.errorf(e, "Failed to decompress gzip-encoded request body for path: %s", requestContext.getUriInfo().getPath());
+                throw e;
+            }
+        }
+    }
+}

--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/service/GzipRequestFilter.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/service/GzipRequestFilter.java
@@ -2,7 +2,9 @@ package org.kie.trustyai.service.endpoints.service;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.Locale;
+import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 
 import org.jboss.logging.Logger;
@@ -16,19 +18,22 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.Provider;
 
 /**
- * JAX-RS filter that automatically decompresses gzip-encoded request bodies.
+ * JAX-RS filter that automatically decompresses gzip-encoded request bodies for data upload endpoints.
  *
- * This filter checks for the "Content-Encoding: gzip" header and transparently
- * decompresses the request body before it reaches the endpoint handlers.
+ * This filter is scoped to the /data/upload endpoint to avoid unexpected behavior for other consumers.
+ * It checks for the "Content-Encoding: gzip" header and transparently decompresses the request body
+ * before it reaches the endpoint handlers.
  *
- * This is necessary because the KServe agent sidecar automatically gzip-compresses
- * CloudEvent payloads when logging to TrustyAI in RawDeployment mode.
+ * This is necessary because the KServe agent sidecar automatically gzip-compresses CloudEvent
+ * payloads when logging to TrustyAI in RawDeployment mode.
  *
- * The filter handles multiple/stacked encodings (e.g., "gzip, br") by checking if
- * the Content-Encoding header contains "gzip" rather than requiring an exact match.
+ * The filter handles multiple/stacked encodings (e.g., "gzip, br") by:
+ * 1. Detecting if "gzip" is present in the Content-Encoding header
+ * 2. Decompressing the gzip layer
+ * 3. Removing only "gzip" from the header, preserving other encodings for downstream processing
  *
- * If decompression fails, returns HTTP 400 (Bad Request) with a clear error message
- * rather than allowing the IOException to surface as a generic 500 error.
+ * If decompression fails, returns HTTP 400 (Bad Request) with a clear error message rather than
+ * allowing the IOException to surface as a generic 500 error.
  */
 @Provider
 @Priority(Priorities.HEADER_DECORATOR)
@@ -37,26 +42,33 @@ public class GzipRequestFilter implements ContainerRequestFilter {
     private static final Logger LOG = Logger.getLogger(GzipRequestFilter.class);
     private static final String CONTENT_ENCODING = "Content-Encoding";
     private static final String GZIP = "gzip";
+    private static final String DATA_UPLOAD_PATH = "/data/upload";
 
     @Override
     public void filter(ContainerRequestContext requestContext) {
+        String path = requestContext.getUriInfo().getPath();
         String contentEncoding = requestContext.getHeaderString(CONTENT_ENCODING);
+
+        // Only apply filter to /data/upload endpoint to avoid unexpected behavior for other consumers
+        if (!path.endsWith(DATA_UPLOAD_PATH)) {
+            return;
+        }
 
         // Support multiple/stacked encodings (e.g., "gzip, br") by checking if gzip is present
         if (contentEncoding != null && contentEncoding.toLowerCase(Locale.ROOT).contains(GZIP)) {
-            LOG.debugf("Decompressing gzip-encoded request body for path: %s", requestContext.getUriInfo().getPath());
+            LOG.debugf("Decompressing gzip-encoded request body for path: %s", path);
 
             try {
                 InputStream originalStream = requestContext.getEntityStream();
                 GZIPInputStream gzipStream = new GZIPInputStream(originalStream);
                 requestContext.setEntityStream(gzipStream);
 
-                // Remove the Content-Encoding header since we've decompressed the body
-                requestContext.getHeaders().remove(CONTENT_ENCODING);
+                // Remove only "gzip" from Content-Encoding, preserving other encodings for downstream processing
+                updateContentEncoding(requestContext, contentEncoding);
 
-                LOG.debugf("Successfully decompressed gzip request for path: %s", requestContext.getUriInfo().getPath());
+                LOG.debugf("Successfully decompressed gzip request for path: %s", path);
             } catch (IOException e) {
-                LOG.errorf(e, "Failed to decompress gzip-encoded request body for path: %s", requestContext.getUriInfo().getPath());
+                LOG.errorf(e, "Failed to decompress gzip-encoded request body for path: %s", path);
 
                 // Return 400 Bad Request with clear message instead of letting it surface as 500
                 Response response = Response.status(Response.Status.BAD_REQUEST)
@@ -66,6 +78,25 @@ public class GzipRequestFilter implements ContainerRequestFilter {
 
                 requestContext.abortWith(response);
             }
+        }
+    }
+
+    /**
+     * Removes "gzip" from the Content-Encoding header while preserving other encodings.
+     * For example: "gzip, br" becomes "br", and "gzip" is removed entirely.
+     */
+    private void updateContentEncoding(ContainerRequestContext requestContext, String contentEncoding) {
+        String remainingEncodings = Arrays.stream(contentEncoding.split(","))
+                .map(String::trim)
+                .filter(encoding -> !encoding.equalsIgnoreCase(GZIP))
+                .collect(Collectors.joining(", "));
+
+        if (remainingEncodings.isEmpty()) {
+            // No other encodings remain, remove the header entirely
+            requestContext.getHeaders().remove(CONTENT_ENCODING);
+        } else {
+            // Update header with remaining encodings
+            requestContext.getHeaders().putSingle(CONTENT_ENCODING, remainingEncodings);
         }
     }
 }

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/data/UploadEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/data/UploadEndpointTest.java
@@ -1,6 +1,7 @@
 package org.kie.trustyai.service.endpoints.data;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.zip.GZIPOutputStream;
 
@@ -402,5 +403,21 @@ class UploadEndpointTest {
         assertEquals(3, df.getColumnDimension()); // 2 inputs + 1 output
 
         emptyStorage();
+    }
+
+    @Test
+    void uploadMalformedGzipCompressedData() {
+        // Test that malformed gzip-compressed payloads return a client error (400)
+        // rather than a server error (500)
+        byte[] invalidGzipPayload = "not-a-valid-gzip-stream".getBytes(StandardCharsets.UTF_8);
+
+        given()
+                .contentType(ContentType.JSON)
+                .header("Content-Encoding", "gzip")
+                .body(invalidGzipPayload)
+                .when().post("/upload")
+                .then()
+                .statusCode(RestResponse.StatusCode.BAD_REQUEST)
+                .body(containsString("could not be decompressed"));
     }
 }

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/data/UploadEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/data/UploadEndpointTest.java
@@ -1,6 +1,8 @@
 package org.kie.trustyai.service.endpoints.data;
 
+import java.io.ByteArrayOutputStream;
 import java.util.List;
+import java.util.zip.GZIPOutputStream;
 
 import org.jboss.resteasy.reactive.RestResponse;
 import org.junit.jupiter.api.BeforeEach;
@@ -9,11 +11,11 @@ import org.kie.trustyai.explainability.model.dataframe.Dataframe;
 import org.kie.trustyai.service.mocks.flatfile.MockCSVDatasource;
 import org.kie.trustyai.service.mocks.flatfile.MockMemoryStorage;
 import org.kie.trustyai.service.payloads.data.upload.ModelInferJointPayload;
-import org.kie.trustyai.service.payloads.data.upload.ModelInferRequestPayload;
 import org.kie.trustyai.service.profiles.flatfile.MemoryTestProfile;
 import org.kie.trustyai.service.utils.KserveRestPayloads;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
@@ -309,7 +311,7 @@ class UploadEndpointTest {
     }
 
     @Test
-    void uploadGaussianData(){
+    void uploadGaussianData() {
         String payload = """
                 {
                   "model_name": "gaussian-credit-model",
@@ -363,5 +365,42 @@ class UploadEndpointTest {
                 .statusCode(RestResponse.StatusCode.OK)
                 .body(containsString("2 datapoints"));
 
+    }
+
+    @Test
+    void uploadGzipCompressedData() throws Exception {
+        // Test that gzip-compressed payloads are handled correctly
+        // This simulates KServe agent behavior in RawDeployment mode
+        ModelInferJointPayload payload = KserveRestPayloads.generatePayload(5, 2, 1, "INT64", "COMPRESSED_TEST");
+
+        // Serialize payload to JSON
+        ObjectMapper objectMapper = new ObjectMapper();
+        byte[] jsonBytes = objectMapper.writeValueAsBytes(payload);
+
+        // Compress with gzip
+        ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+        try (GZIPOutputStream gzipStream = new GZIPOutputStream(byteStream)) {
+            gzipStream.write(jsonBytes);
+        }
+        byte[] gzipBytes = byteStream.toByteArray();
+
+        emptyStorage();
+
+        // Send gzip-compressed request
+        given()
+                .contentType(ContentType.JSON)
+                .header("Content-Encoding", "gzip")
+                .body(gzipBytes)
+                .when().post("/upload")
+                .then()
+                .statusCode(RestResponse.StatusCode.OK)
+                .body(containsString("5 datapoints"));
+
+        // Verify data was stored correctly
+        Dataframe df = datasource.get().getDataframe(payload.getModelName());
+        assertEquals(5, df.getRowDimension());
+        assertEquals(3, df.getColumnDimension()); // 2 inputs + 1 output
+
+        emptyStorage();
     }
 }


### PR DESCRIPTION
## Summary
- Updates `aquasecurity/trivy-action` from `0.28.0` to `0.35.0`
- Fixes CI build failures caused by outdated version reference

## Problem
The current workflow references `aquasecurity/trivy-action@0.28.0`, which needs to be updated to the latest stable release to ensure compatibility with current CI infrastructure.

## Solution
Updated to version `0.35.0` (published March 7, 2026) following the same pattern as [trustyai-service PR #97](https://github.com/trustyai-explainability/trustyai-service/pull/97).

## Test plan
- [x] Verify workflow syntax is valid
- [ ] Confirm Trivy scan completes successfully on PR

---

**Note:** This PR also includes the gzip filter implementation from the previous commits on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Support gzip-compressed data uploads and update security scanning in CI.

Enhancements:
- Add a JAX-RS request filter that transparently decompresses gzip-encoded request bodies for the /data/upload endpoint and returns a clear 400 response on decompression failures.

Build:
- Bump aquasecurity/trivy-action in the Trivy scan workflow from version 0.28.0 to 0.35.0.

Tests:
- Extend upload endpoint tests to cover successful handling of gzip-compressed payloads and validation of malformed gzip input returning a 400 error.